### PR TITLE
FW/CPUID: add support for Linux 5.16 state saving requests

### DIFF
--- a/framework/cpuid_internal.h
+++ b/framework/cpuid_internal.h
@@ -101,6 +101,13 @@ static uint64_t parse_register(enum X86CpuidLeaves leaf, uint32_t reg)
 #  define cpuid_errmsg(id, msg)         fputs(msg, stderr)
 #endif
 
+__attribute__((cold, noreturn))
+static void detect_cpu_not_supported(const char *msg)
+{
+    cpuid_errmsg(MSG_OS_Not_Supported, msg);
+    exit(EX_CONFIG);
+}
+
 __attribute__((noinline))
 static void detect_cpu(struct cpu_basic_info *basic_info)
 {
@@ -122,10 +129,8 @@ static void detect_cpu(struct cpu_basic_info *basic_info)
     if (ecx & (1<<26)) {
         // CPU supports XSAVE
         osxsave = true;
-        if ((ecx & (1<<27)) == 0) {     // OSXSAVE
-            cpuid_errmsg(MSG_OS_Not_Supported, "This OS did not enable XSAVE support. Cannot run.\n");
-            exit(EX_CONFIG);
-        }
+        if ((ecx & (1<<27)) == 0)           // OSXSAVE
+            detect_cpu_not_supported("This OS did not enable XSAVE support. Cannot run.\n");
     }
 
     if (max_level >= 7) {
@@ -165,11 +170,10 @@ static void detect_cpu(struct cpu_basic_info *basic_info)
             features &= ~XSaveReq_AmxState;
         }
 
-        if (xcr0_wanted && (xcr0 & xcr0_wanted) != xcr0_wanted) {
-            cpuid_errmsg(MSG_OS_Not_Supported,
-                         "This kernel did not enable necessary AVX or AMX state-saving. Cannot run.\n");
-            exit(EX_CONFIG);
-        }
+        if (xcr0_wanted && (xcr0 & xcr0_wanted) != xcr0_wanted)
+            detect_cpu_not_supported("This kernel did not enable necessary AVX or AMX state-saving."
+                                     " Cannot run.\n");
+
     }
 
     __cpuid(0x80000000, eax, ebx, ecx, edx);

--- a/framework/cpuid_internal.h
+++ b/framework/cpuid_internal.h
@@ -35,10 +35,10 @@ struct cpu_basic_info {
  * you prefer the framework to check for system or CPU criteria and exit() if
  * those criteria are not met.
  */
-void is_system_supported(const struct cpu_basic_info&);
+void is_system_supported(const struct cpu_basic_info *);
 
 __attribute__((weak))
-void is_system_supported(const struct cpu_basic_info& basic_info) { }
+void is_system_supported(const struct cpu_basic_info *basic_info) { }
 
 #ifdef __APPLE__
 /*

--- a/framework/cpuid_internal.h
+++ b/framework/cpuid_internal.h
@@ -114,7 +114,9 @@ static uint64_t adjusted_xcr0(uint64_t xcr0, uint64_t xcr0_wanted)
     // Either Linux < 5.16 or the kernel failed to enable what it told us it
     // supported (can happen if something else has installed a sigaltstack()
     // that is too small).
+#  ifndef LINUX_COMPAT_PRE_5_16_AMX_SUPPORT
     xcr0 &= KernelNonDynamicXSave;
+#  endif
     return xcr0;
 }
 #else

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
     if (minimum_cpu_features & ~cpu_features)
         fallback_exec(argv);
     check_missing_features(cpu_features, minimum_cpu_features);
-    is_system_supported(cpu_info);
+    is_system_supported(&cpu_info);
 
     return internal_main(argc, argv);
 }


### PR DESCRIPTION
With this implementation, we will only issue the new system call if
CPUID indicates AMX support, in which case we ignore XCR0. This is
designed for the likely scenario of AMX-capable kernels being used for
AMX-capable hardware. If, instead, we're running on a system that fails
to enable all CPU features, they won't begrudge us a few more CPU cycles
to find out.

We should also support the case in which the 5.16+ Linux kernel does
support AMX but refuses to offer it to us. For that case, we expect the
ARCH_GET_XCOMP_SUPP call to tell us "no AMX".
