### PR TITLE
CI: build unittests as part of PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,4 +21,6 @@ jobs:
       run: meson setup builddir
     - name: ninja build
       run: ninja -C builddir
+    - name: ninja build unittests
+      run: ninja -C builddir unittests
 


### PR DESCRIPTION
Integrate building and running OpenDCDiag's unittests into the PR workflow.