### PR TITLE
FW: cpuid_internal: include sandstone_p

### DIFF
--- a/framework/cpuid_internal.h
+++ b/framework/cpuid_internal.h
@@ -12,6 +12,7 @@
 #include <sysexits.h>
 #include <unistd.h>
 #include "cpu_features.h"
+#include "sandstone_p.h"
 
 #ifndef signature_INTEL_ebx     /* cpuid.h lacks include guards */
 #  include <cpuid.h>


### PR DESCRIPTION
Depending on build flags, LOG_LEVEL_QUIET may be used. That define is in
sandstone_p.h, so let's include it.

Signed-off-by: Joe Konno <joe.konno@intel.com>