### PR TITLE
meson: add 'meson test' functionality

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -232,7 +232,7 @@ executable(
 	],
 )
 
-executable(
+unittests = executable(
 	'unittests',
 	files(
 		'framework/sysdeps/linux/malloc.cpp',
@@ -253,6 +253,8 @@ executable(
 	build_by_default : false,
 	native : true,
 )
+
+test('Unit Tests', unittests)
 
 summary({
 		'Logging format': get_option('logging_format'),


### PR DESCRIPTION
Nothing fancy. Just enables the "meson test" wrapper in case folks want to use it.

Side effect: unittests target is always built. If that's undesirable, we can do without this.