### PR TITLE
unit-tests: #include <algorithm> in test_knob_tests

### DIFF
--- a/framework/unit-tests/test_knob_tests.cpp
+++ b/framework/unit-tests/test_knob_tests.cpp
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <algorithm>
 #include <vector>
 #include "gtest/gtest.h"
 #include "test_knobs.h"


### PR DESCRIPTION
I recently got nipped by this when using an older version of gcc. This
should fix errors about find_if not being part of std::.

Signed-off-by: Joe Konno <joe.konno@intel.com>