### PR TITLE
Clang fixes

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -75,7 +75,9 @@ extern "C" {
 /// This macro is provided in case tests need more fine grained control.
 #define cpu_has_feature(f)      ((_compilerCpuFeatures & (f)) == (f) || (cpu_features & (f)) == (f))
 
-#if defined(__GNUC__) && !SANDSTONE_NO_LOGGING
+#if defined(__clang__) && !SANDSTONE_NO_LOGGING
+#  define ATTRIBUTE_PRINTF(x, y)    __attribute__((__format__(printf, x, y)))
+#elif defined(__GNUC__) && !SANDSTONE_NO_LOGGING
 #  define ATTRIBUTE_PRINTF(x, y)    __attribute__((__format__(gnu_printf, x, y)))
 #else
 #  define ATTRIBUTE_PRINTF(x, y)

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -344,6 +344,7 @@ static void cause_sigill()
                             -std::numeric_limits<double>::infinity());
 
     __m128i one = _mm_set1_epi32(-1);
+#ifndef __clang__
     if (cpu_has_feature(cpu_feature_avx)) {
         // init the AVX state (using inline assembly to avoid vzeroupper)
         if (cpu_has_feature(cpu_feature_avx512f)) {
@@ -354,6 +355,7 @@ static void cause_sigill()
             asm ("vpcmpeqb %t0, %t0, %t0" : "=x" (one));
         }
     }
+#endif
 
     // make sure there are no function calls between the instruction above and the one below
 
@@ -382,7 +384,7 @@ static void cause_sigill()
 static void cause_sigfpe()
 {
     int r = 0;
-    asm volatile ("idiv%z0 %0, %0" : "+a" (r));
+    asm volatile ("idivl %0, %0" : "+a" (r));
 }
 
 static void cause_sigbus()
@@ -395,7 +397,7 @@ static void cause_sigbus()
     IGNORE_RETVAL(ftruncate(fd, 0));
 
     int result;
-    asm volatile ("mov%z0 (%1), %0" : "=r" (result) : "r" (ptr));
+    asm volatile ("movl (%1), %0" : "=r" (result) : "r" (ptr));
 
     munmap(ptr, 4096);
     close(fd);
@@ -406,7 +408,7 @@ static void cause_sigsegv()
     uintptr_t ptr = ~uintptr_t(0) - 64 * 1024 * 1024;
     ptr += rand() & 0xfff;
     int result;
-    asm volatile ("mov%z0 (%1), %0" : "=r" (result) : "r" (ptr));
+    asm volatile ("movl (%1), %0" : "=r" (result) : "r" (ptr));
 }
 
 static void cause_sigsegv_instruction()

--- a/framework/test_selectors/WeightedSelectorBase.h
+++ b/framework/test_selectors/WeightedSelectorBase.h
@@ -26,7 +26,7 @@ protected:
 public:
 
 
-    struct test * get_next_test(){
+    struct test * get_next_test() override{
         auto weighted_info = this->select_test();
         test * next_test = testinfo[weighted_info->test_index];
         if (next_test != nullptr)

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -16,7 +16,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-struct LogicalProcessorSet;
+class LogicalProcessorSet;
 
 class Topology
 {


### PR DESCRIPTION
This is not complete and Clang is not officially supported. These are just a couple of changes I'd done anyway, so I might as well upstream.

Clang didn't like some of the inline assembly we had for GCC. This is the only build error. Everything else was just annoyance (warnings).