### PR TITLE
FW/Unix: add signal debugging for SIGTRAP too

### DIFF
--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -435,6 +435,11 @@ static void cause_sigsegv_instruction()
     asm volatile ("jmp *%0" : : "r" (ptr));
 }
 
+static void cause_sigtrap_int3()
+{
+    asm volatile("int3");
+}
+
 #ifdef _WIN32
 static void raise_fastfail()
 {
@@ -888,6 +893,13 @@ FOREACH_DATATYPE(DATACOMPARE_TEST)
     .description = "Crashes with SIGSEGV (instruction)",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
     .test_run = selftest_crash_run<cause_sigsegv_instruction>,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_sigtrap_int3",
+    .description = "Crashes with SIGTRAP (int3 instruction)",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_run = selftest_crash_run<cause_sigtrap_int3>,
     .desired_duration = -1,
 },
 #ifdef _WIN32

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -685,6 +685,23 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
         return generic_code_string(code);
     };
 
+    auto sigtrap_code_string = [](int code) {
+        switch (code) {
+        case TRAP_BRKPT: return "TRAP_BRKPT";
+        case TRAP_TRACE: return "TRAP_TRACE";
+#ifdef TRAP_BRANCH      // added on 2.6.28
+        case TRAP_BRANCH: return "TRAP_BRANCH";
+#endif
+#ifdef TRAP_HWBKPT
+        case TRAP_HWBKPT: return "TRAP_HWBKPT";
+#endif
+#ifdef TRAP_UNK
+        case TRAP_UNK: return "TRAP_UNK";
+#endif
+        }
+        return generic_code_string(code);
+    };
+
     const char *(*code_string_fn)(int) = nullptr;
     (void)code_string_fn;
 
@@ -709,6 +726,10 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
 
     case SIGBUS:
         code_string_fn = sigbus_code_string;
+        break;
+
+    case SIGTRAP:
+        code_string_fn = sigtrap_code_string;
         break;
 
     default:
@@ -887,6 +908,8 @@ void debug_init_child()
         for (int signum : { SIGILL, SIGABRT, SIGFPE, SIGBUS, SIGSEGV }) {
             sigaction(signum, &action, nullptr);
         }
+        if (sApp->current_fork_mode() != SandstoneApplication::exec_each_test)
+            sigaction(SIGTRAP, &action, nullptr);
     }
 }
 


### PR DESCRIPTION
```yaml
    messages:
    - { level: error, text: 'E> Received signal 5 (Trace/breakpoint trap) code=128 (SI_KERNEL), RIP = 0x44e29f, CR2 = (nil)' }
    - level: warning
      text: |1
       W> #4  cause_sigtrap_int3 () at ../../../src/arkose/arkose-one/opendcdiag/framework/selftest.cpp:423
       423	}
       => 0x44e29f <cause_sigtrap_int3()+5>:	nop
```
The disassembly points to the next instruction, but oh well.