### PR TITLE
FreeBSD port

### DIFF
--- a/framework/forkfd/forkfd_freebsd.c
+++ b/framework/forkfd/forkfd_freebsd.c
@@ -56,7 +56,7 @@ int system_forkfd(int flags, pid_t *ppid, int *system)
     if (state < 0)
         return -1;
 
-    pid = pdfork(&ret, PD_DAEMON);
+    pid = pdfork(&ret, PD_DAEMON | PD_CLOEXEC);
 #  if __FreeBSD__ == 9
     if (state == 0 && pid != 0) {
         /* Parent process: remember whether PROCDESC was compiled into the kernel */
@@ -76,8 +76,8 @@ int system_forkfd(int flags, pid_t *ppid, int *system)
     }
 
     /* parent process */
-    if (flags & FFD_CLOEXEC)
-        fcntl(ret, F_SETFD, FD_CLOEXEC);
+    if ((flags & FFD_CLOEXEC) == 0)
+        fcntl(ret, F_SETFD, 0);
     if (flags & FFD_NONBLOCK)
         fcntl(ret, F_SETFL, fcntl(ret, F_GETFL) | O_NONBLOCK);
     if (ppid)

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -3,7 +3,6 @@
  */
 
 #define _GNU_SOURCE 1
-#define _POSIX_C_SOURCE 200112L
 #include "sandstone.h"
 #include "sandstone_p.h"
 #include "sandstone_iovec.h"

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -27,7 +27,7 @@ int internal_main(int argc, char **argv);
 
 #if defined(AT_EXECPATH) && !defined(AT_EXECFN)
 // FreeBSD uses AT_EXECPATH instead of AT_EXECFN
-#  define AT_EXECFN AT_EXECPATH
+//#  define AT_EXECFN AT_EXECPATH
 #endif
 #if defined(AT_EXECFN)
 #  if !defined(__GLIBC_PREREQ) || !__GLIBC_PREREQ(2, 16)

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1300,7 +1300,9 @@ static ChildExitStatus wait_for_child(int ffd, intptr_t child, int *tc, const st
             // on forkfd_wait() until it finally does exit
         } else {
             /* child has exited */
+#ifndef __FreeBSD__
             assert(pfd[0].revents & POLLIN);
+#endif
         }
 
         EINTR_LOOP(ret, forkfd_wait(pfd[0].fd, &info, nullptr));

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #ifdef __unix__
 #  include <poll.h>
 #endif

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -279,11 +279,11 @@ static void signal_handler(int signum)
 {
     // communicate which signal we've received
     uint32_t expected = 0;
-    if (signal_control.compare_exchange_strong(expected, __W_EXITCODE(1, signum), std::memory_order_relaxed)) {
+    if (signal_control.compare_exchange_strong(expected, W_EXITCODE(1, signum), std::memory_order_relaxed)) {
         // initial clean up
     } else {
         // just increment the counter
-        signal_control.fetch_add(__W_EXITCODE(1, 0), std::memory_order_relaxed);
+        signal_control.fetch_add(W_EXITCODE(1, 0), std::memory_order_relaxed);
     }
 }
 

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -233,24 +233,24 @@ void dump_gprs(FILE *f, const mcontext_t *mc)
     using register_t = decltype(mc->mc_rax);
     static constexpr struct {
         char name[4];
-        register_t mcontext:: *ptr;
+        register_t mcontext_t:: *ptr;
     } registers[] = {
-        { "rax", &mcontext::mc_rax },
-        { "rbx", &mcontext::mc_rbx },
-        { "rcx", &mcontext::mc_rcx },
-        { "rdx", &mcontext::mc_rdx },
-        { "rsi", &mcontext::mc_rsi },
-        { "rdi", &mcontext::mc_rdi },
-        { "rbp", &mcontext::mc_rbp },
-        { "rsp", &mcontext::mc_rsp },
-        { "r8", &mcontext::mc_r8 },
-        { "r9", &mcontext::mc_r9 },
-        { "r10", &mcontext::mc_r10 },
-        { "r11", &mcontext::mc_r11 },
-        { "r12", &mcontext::mc_r12 },
-        { "r13", &mcontext::mc_r13 },
-        { "r14", &mcontext::mc_r14 },
-        { "r15", &mcontext::mc_r15 },
+        { "rax", &mcontext_t::mc_rax },
+        { "rbx", &mcontext_t::mc_rbx },
+        { "rcx", &mcontext_t::mc_rcx },
+        { "rdx", &mcontext_t::mc_rdx },
+        { "rsi", &mcontext_t::mc_rsi },
+        { "rdi", &mcontext_t::mc_rdi },
+        { "rbp", &mcontext_t::mc_rbp },
+        { "rsp", &mcontext_t::mc_rsp },
+        { "r8", &mcontext_t::mc_r8 },
+        { "r9", &mcontext_t::mc_r9 },
+        { "r10", &mcontext_t::mc_r10 },
+        { "r11", &mcontext_t::mc_r11 },
+        { "r12", &mcontext_t::mc_r12 },
+        { "r13", &mcontext_t::mc_r13 },
+        { "r14", &mcontext_t::mc_r14 },
+        { "r15", &mcontext_t::mc_r15 },
     };
     for (auto reg : registers)
         print_gpr(f, reg.name, mc->*(reg.ptr));

--- a/framework/sandstone_iovec.h
+++ b/framework/sandstone_iovec.h
@@ -38,7 +38,7 @@ template <typename... Args>
     return writev(fd, vec, std::size(vec));
 }
 
-#if _POSIX_VERSION < 200809L && !defined(__GLIBC__)
+#ifdef _WIN32
 [[maybe_unused]] int dprintf(int fd, const char *fmt, ...)
 {
     std::string msg = va_start_and_stdprintf(fmt);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -450,6 +450,7 @@ struct Pipe
         int ret = pipe2(fds, O_CLOEXEC | O_NOSIGPIPE);
         if (ret < 0)
             return ret;
+#  ifdef F_SETPIPE_SZ
         if (reserved > PIPE_BUF) {
             int ret = fcntl(out(), F_GETPIPE_SZ);
             if (ret >= 0 && ret < reserved) {
@@ -457,6 +458,7 @@ struct Pipe
                 fcntl(out(), F_SETPIPE_SZ, reserved);
             }
         }
+#  endif
         return 0;
 #endif
     }

--- a/framework/sysdeps/freebsd/cpu_affinity.cpp
+++ b/framework/sysdeps/freebsd/cpu_affinity.cpp
@@ -1,8 +1,14 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
+ * (C) 2019-2021 Intel Corporation
+ *
+ * This source code is Intel Confidential and not for distribution outside of Intel without
+ * explicit permission from the authors
+ *
+ * sandstone test framework and tests
+ *
  */
 
-#include <cpu_affinity.h>
+#include <topology.h>
 
 #include <pthread_np.h>
 #include <sys/cpuset.h>
@@ -12,8 +18,8 @@ static_assert(sizeof(cpuset_t) >= sizeof(LogicalProcessorSet));
 LogicalProcessorSet ambient_logical_processor_set()
 {
     LogicalProcessorSet result;
-    if (cpuset_getaffinity(CPU_LEVEL_ROOT, CPU_WHICH_PID, -1, sizeof(result.array),
-                           reinterpret_cast<cpu_set_t *>(result.array)) != 0)
+    if (cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_PID, -1, sizeof(result.array),
+                           reinterpret_cast<cpuset_t *>(result.array)) != 0)
         result.clear();
     return result;
 }
@@ -25,9 +31,9 @@ bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
 
     cpuset_t cpu_set;
     CPU_ZERO(&cpu_set);
-    CPU_SET(n, &cpu_set);
+    CPU_SET(int(n), &cpu_set);
 
-    if (cpuset_setaffinity(CPU_LEVEL_ROOT, CPU_WHICH_PID, -1, sizeof(cpu_set), &cpu_set)) {
+    if (cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(cpu_set), &cpu_set)) {
         perror("cpuset_setaffinity");
         return false;
     }

--- a/framework/sysdeps/freebsd/malloc.cpp
+++ b/framework/sysdeps/freebsd/malloc.cpp
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sandstone_p.h>
+
+#include <errno.h>
+#include <malloc_np.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>            // for MALLOC_ALLIGN's use of ffsl()
+#include <unistd.h>
+
+#ifndef __SANITIZE_ADDRESS__
+static __attribute__((noinline, noreturn)) void null_pointer_consumption(void *ptr, size_t size)
+{
+    static const char msg[] = "Out of memory condition\n";
+    (void) ptr;
+    IGNORE_RETVAL(write(STDERR_FILENO, msg, sizeof(msg) - 1));
+
+    // if the size is non-silly, simulate the Linux OOM killer
+    if (size < 256 * 1024 * 1024)
+        raise(SIGKILL);
+    abort();
+}
+
+static inline void *check_null_pointer(void *ptr, size_t size)
+{
+    if (__builtin_expect(!ptr, 0))
+        null_pointer_consumption(ptr, size);
+    return ptr;
+}
+
+static inline void *checked_allocation(size_t size, void *block)
+{
+    return check_null_pointer(block, size);
+}
+
+// different from all the rest
+int posix_memalign(void **newptr, size_t alignment, size_t size)
+{
+    *newptr = aligned_alloc(alignment, size);
+    return *newptr ? 0 : errno;
+}
+
+// pvalloc is valloc rounding up to the actual page size
+void *pvalloc(size_t bytes)
+{
+    bytes = ROUND_UP_TO_PAGE(bytes);
+    return valloc(bytes);
+}
+
+void *aligned_alloc(size_t alignment, size_t size)
+{
+    return checked_allocation(size, mallocx(size, MALLOCX_ZERO | MALLOCX_ALIGN(alignment)));
+}
+
+void *memalign(size_t alignment, size_t size)
+{
+    return aligned_alloc(alignment, size);
+}
+
+void *valloc(size_t size)
+{
+    return checked_allocation(size, mallocx(size, MALLOCX_ZERO | MALLOCX_ALIGN(4096)));
+}
+
+void *malloc(size_t size)
+{
+    return checked_allocation(size, mallocx(size, MALLOCX_ZERO));
+}
+
+void *calloc(size_t n, size_t size)
+{
+    // calloc always zeroes memory, so we don't need to do it ourselves
+    return check_null_pointer(mallocx(size * n, MALLOCX_ZERO), size);
+}
+
+void *realloc(void *ptr, size_t size)
+{
+    return check_null_pointer(rallocx(ptr, size, MALLOCX_ZERO), size);
+}
+#endif // __SANITIZE_ADDRESS__

--- a/framework/sysdeps/freebsd/meson.build
+++ b/framework/sysdeps/freebsd/meson.build
@@ -4,6 +4,7 @@ sysdeps_a = static_library(
         sysdeps_unix_files,
 	files(
 		'cpu_affinity.cpp',
+		'malloc.cpp',
 		'../generic/kvm.c',
 		'../generic/memfpt.c',
 		'../generic/msr.c',

--- a/framework/sysdeps/freebsd/meson.build
+++ b/framework/sysdeps/freebsd/meson.build
@@ -1,0 +1,24 @@
+# -*- indent-tabs-mode: t -*-
+sysdeps_a = static_library(
+	'sysdeps_freebsd',
+        sysdeps_unix_files,
+	files(
+		'cpu_affinity.cpp',
+		'../generic/kvm.c',
+		'../generic/memfpt.c',
+		'../generic/msr.c',
+		'../generic/physicaladdress.c',
+	),
+	build_by_default: false,
+	include_directories : [
+		framework_incdir,
+	],
+	c_args : [
+		default_c_warn,
+		debug_c_flags,
+	],
+	cpp_args : [
+		default_cpp_warn,
+		debug_c_flags,
+	],
+)

--- a/framework/sysdeps/freebsd/thermal_monitor.hpp
+++ b/framework/sysdeps/freebsd/thermal_monitor.hpp
@@ -1,0 +1,1 @@
+#include "../generic/thermal_monitor.hpp"

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -631,8 +631,12 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
         case FPE_FLTRES: return "FPE_FLTRES";        // Floating point inexact result.
         case FPE_FLTINV: return "FPE_FLTINV";        // Floating point invalid operation.
         case FPE_FLTSUB: return "FPE_FLTSUB";        // Subscript out of range.
+#ifdef FPE_FLTUNK
         case FPE_FLTUNK: return "FPE_FLTUNK";        // Undiagnosed floating-point exception.
+#endif
+#ifdef FPE_CONDTRAP
         case FPE_CONDTRAP: return "FPE_CONDTRAP";    // Trap on condition.
+#endif
         }
         return generic_code_string(code);
     };
@@ -647,7 +651,9 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
         case ILL_PRVREG: return "ILL_PRVREG";        // Privileged register.
         case ILL_COPROC: return "ILL_COPROC";        // Coprocessor error.
         case ILL_BADSTK: return "ILL_BADSTK";        // Internal stack error.
+#ifdef ILL_BADIADDR
         case ILL_BADIADDR: return "ILL_BADIADDR";    // Unimplemented instruction address.
+#endif
         }
         return generic_code_string(code);
     };
@@ -657,8 +663,12 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
         // Linux seems to generate only MAPERR, BNDERR and PKUERR
         case SEGV_MAPERR: return "SEGV_MAPERR";        // Address not mapped to object.
         case SEGV_ACCERR: return "SEGV_ACCERR";        // Invalid permissions for mapped object.
+#ifdef SEGV_BNDERR
         case SEGV_BNDERR: return "SEGV_BNDERR";        // Bounds checking failure.
+#endif
+#ifdef SEGV_PKUERR
         case SEGV_PKUERR: return "SEGV_PKUERR";        // Protection key checking failure.
+#endif
 #if 0               // seem to be Sparc-specific
         case SEGV_ACCADI: return "SEGV_ACCADI";        // ADI not enabled for mapped object.
         case SEGV_ADIDERR: return "SEGV_ADIDERR";      // Disrupting MCD error.
@@ -677,8 +687,12 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
         case BUS_ADRALN: return "BUS_ADRALN";        // Invalid address alignment.
         case BUS_ADRERR: return "BUS_ADRERR";        // Non-existant physical address.
         case BUS_OBJERR: return "BUS_OBJERR";        // Object specific hardware error.
+#ifdef BUS_MCEERR_AR
         case BUS_MCEERR_AR: return "BUS_MCEERR_AR";  // Hardware memory error: action required.
+#endif
+#ifdef BUS_MCEERR_AO
         case BUS_MCEERR_AO: return "BUS_MCEERR_AO";  // Hardware memory error: action optional.
+#endif
         }
         return generic_code_string(code);
     };

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -533,7 +533,7 @@ static void communicate_gdb_backtrace(int log, int in, int out, uintptr_t handle
         ret = read(in, buf, sizeof(buf));
         if (ret > 0)
             IGNORE_RETVAL(write(log, buf, ret));
-#else
+#elif defined(__linux__)
         ret = splice(in, nullptr, log, nullptr, std::numeric_limits<int>::max(), SPLICE_F_NONBLOCK);
 #endif
         if (ret == -1 && (errno == EINTR || errno == EWOULDBLOCK))

--- a/framework/sysdeps/unix/tmpfile.c
+++ b/framework/sysdeps/unix/tmpfile.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>           /* memfd_create is here on FreeBSD */
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -18,7 +19,9 @@
 #include <inttypes.h>
 
 #if !defined(__linux__)
-#  define memfd_create(name, flags)     -1
+#  ifndef MFD_CLOEXEC
+#    define memfd_create(name, flags)   -1
+#  endif
 #  define gettid()                      getpid()
 #else
 #  define gettid()                      syscall(SYS_gettid)

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -58,7 +58,11 @@ enum class LogicalProcessor : int {};
 class LogicalProcessorSet
 {
 public:
+#if defined(__linux__) || defined(_WIN32)
     static constexpr int Size = 1024;
+#else
+    static constexpr int Size = 256;
+#endif
 
     using Word = unsigned long long;
     Word array[Size / (CHAR_BIT * sizeof(Word))];

--- a/meson-freebsd.ini
+++ b/meson-freebsd.ini
@@ -1,0 +1,11 @@
+[constants]
+common_args = ['-I/usr/local/include', '-pipe']
+
+[binaries]
+c = 'gcc10'
+cpp = 'g++10'
+
+[built-in options]
+c_args = common_args
+cpp_args = common_args
+cpp_link_args = ['-Wl,-rpath=/usr/local/lib/gcc10']

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,4 @@
+# -*- indent-tabs-mode: t -*-
 # SPDX-License-Identifier: Apache-2.0
 
 project(


### PR DESCRIPTION
This PR adds a series of commits that, as far as I can tell, make OpenDCDiag compile and run properly on FreeBSD. I've only tested with GCC 10 (installed from the ports tree), which is the compiler that we support for Linux and Windows too.

The majority of commits are build fixes, correcting improper assumptions of Linux behaviour in the Unix code, such as using `splice(2)` (a Linux-specific system call) or Linux-specific constants elsewhere. There are also fixes to existing FreeBSD functionality that wasn't correct or was incomplete, because it had never been compiled or run. Finally, it turns out that FreeBSD does have memfds, so that is enabled for it.