### PR TITLE
macOS port

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -90,6 +90,11 @@ framework_files += [
 	'forkfd/forkfd.c',
 ]
 endif
+if target_machine.system() == 'darwin'
+framework_files += [
+	'sandstone_sections.S',
+]
+endif
 
 # Default logging options
 logging_c_flags = []

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -99,7 +99,7 @@ using AutoClosingHandle = std::unique_ptr<void, HandleCloser>;
 #  define O_CLOEXEC     0
 #endif
 
-#ifndef __GLIBC__
+#if !defined(__GLIBC__) && !defined(fileno_unlocked)
 #  define fileno_unlocked   fileno
 #endif
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -265,8 +265,9 @@ static constexpr std::initializer_list<int> termination_signals = {
     SIGHUP, SIGINT, SIGTERM, SIGPIPE
 };
 
-#  if defined(__WAIT_INT) && defined(__linux__)
+#  if (defined(__WAIT_INT) && defined(__linux__)) || defined(__APPLE__)
 // glibc prior to 2.24 defined WTERMSIG with compatibility with BSD union wait
+// Apple libc does the same
 static constexpr uint32_t SignalMask = 0x7f;
 #  else
 static constexpr uint32_t SignalMask = WTERMSIG(~0);

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -40,6 +40,12 @@ extern "C" {
 #endif
 #define MAX_HWTHREADS_PER_CORE  4
 
+#ifdef __APPLE__
+#  define SANDSTONE_SECTION_PREFIX              "__DATA,"
+#else
+#  define SANDSTONE_SECTION_PREFIX
+#endif
+
 // Requested thread stack size for our test threads:
 // We have some tests that do deep recursion, so we need a stable value
 #define THREAD_STACK_SIZE   (8192*1024)
@@ -121,7 +127,7 @@ extern "C" {
 #define EXIT_SKIP               -255
 
 #define DECLARE_TEST_INNER2(test_id, test_description) \
-    __attribute__((aligned(alignof(void*)), used, section("tests"))) struct test _test_ ## test_id = { \
+    __attribute__((aligned(alignof(void*)), used, section(SANDSTONE_SECTION_PREFIX "tests"))) struct test _test_ ## test_id = { \
         .id = SANDSTONE_STRINGIFY(test_id), .description = test_description,
 #define DECLARE_TEST_INNER(test_id, test_description)   DECLARE_TEST_INNER2(test_id, test_description)
 

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -169,7 +169,7 @@ static void print_gpr(FILE *f, const char *name, int64_t value)
 
 static void print_rip(FILE *f, uintptr_t rip)
 {
-    fprintf(f, " %-5s = 0x%016" PRIx64, "rip", rip);
+    fprintf(f, " %-5s = 0x%016tx", "rip", rip);
 #ifdef __unix__
     uint8_t *ptr = reinterpret_cast<uint8_t *>(rip);
     Dl_info dli;
@@ -260,38 +260,38 @@ void dump_gprs(FILE *f, const mcontext_t *mc)
     print_segment(f, "gs", mc->mc_gs);
 }
 #elif defined(__APPLE__) || defined(__MACH__)
-void dump_gprs(FILE *f, const mcontext_t *mc)
+void dump_gprs(FILE *f, const mcontext_t mc)
 {
-    auto *state = &mc->ss;
-    using ThreadState = decltype(*state);
+    auto *state = &mc->__ss;
+    using ThreadState = std::decay_t<decltype(*state)>;
     using register_t = decltype(state->__rax);
     static constexpr struct {
         char name[4];
         register_t ThreadState:: *ptr;
     } registers[] = {
-        { "rax", &ThreadState::rax },
-        { "rbx", &ThreadState::rbx },
-        { "rcx", &ThreadState::rcx },
-        { "rdx", &ThreadState::rdx },
-        { "rsi", &ThreadState::rsi },
-        { "rdi", &ThreadState::rdi },
-        { "rbp", &ThreadState::rbp },
-        { "rsp", &ThreadState::rsp },
-        { "r8", &ThreadState::r8 },
-        { "r9", &ThreadState::r9 },
-        { "r10", &ThreadState::r10 },
-        { "r11", &ThreadState::r11 },
-        { "r12", &ThreadState::r12 },
-        { "r13", &ThreadState::r13 },
-        { "r14", &ThreadState::r14 },
-        { "r15", &ThreadState::r15 },
+        { "rax", &ThreadState::__rax },
+        { "rbx", &ThreadState::__rbx },
+        { "rcx", &ThreadState::__rcx },
+        { "rdx", &ThreadState::__rdx },
+        { "rsi", &ThreadState::__rsi },
+        { "rdi", &ThreadState::__rdi },
+        { "rbp", &ThreadState::__rbp },
+        { "rsp", &ThreadState::__rsp },
+        { "r8", &ThreadState::__r8 },
+        { "r9", &ThreadState::__r9 },
+        { "r10", &ThreadState::__r10 },
+        { "r11", &ThreadState::__r11 },
+        { "r12", &ThreadState::__r12 },
+        { "r13", &ThreadState::__r13 },
+        { "r14", &ThreadState::__r14 },
+        { "r15", &ThreadState::__r15 },
     };
     for (auto reg : registers)
         print_gpr(f, reg.name, state->*(reg.ptr));
-    print_rip(f, state->rip);
-    print_eflags(f, state->rflags);
-    print_segment(f, "fs", state->fs);
-    print_segment(f, "gs", state->gs);
+    print_rip(f, state->__rip);
+    print_eflags(f, state->__rflags);
+    print_segment(f, "fs", state->__fs);
+    print_segment(f, "gs", state->__gs);
 }
 #endif
 

--- a/framework/sandstone_context_dump.h
+++ b/framework/sandstone_context_dump.h
@@ -8,7 +8,8 @@
 
 #include <stdio.h>
 
-#ifdef __unix__
+// macOS doesn't consider itself to be Unix?
+#if defined(__unix__) || defined(__APPLE__)
 #  include <sys/ucontext.h>
 #else
 // do we want to define something for Windows?
@@ -21,7 +22,11 @@ typedef struct {} mcontext_t;
 extern "C" {
 #endif
 
+#ifdef __APPLE__
+extern void dump_gprs(FILE *, const mcontext_t);
+#else
 extern void dump_gprs(FILE *, const mcontext_t *);
+#endif
 extern void dump_xsave(FILE *, const void *xsave_area, size_t xsave_size, int xsave_dump_mask);
 
 #ifdef __cplusplus

--- a/framework/sandstone_data.h
+++ b/framework/sandstone_data.h
@@ -65,46 +65,6 @@
 #  define __FLT128_DENORM_MIN__ 6.47517511943802511092443895822764655e-4966F128
 #endif
 
-#ifndef __FLT128_DIG__
-#  define __FLT128_DIG__ 33
-#endif
-#ifndef __FLT128_EPSILON__
-#  define __FLT128_EPSILON__ 1.92592994438723585305597794258492732e-34F128
-#endif
-#ifndef __FLT128_HAS_DENORM__
-#  define __FLT128_HAS_DENORM__ 1
-#endif
-#ifndef __FLT128_HAS_INFINITY__
-#  define __FLT128_HAS_INFINITY__ 1
-#endif
-#ifndef __FLT128_HAS_QUIET_NAN__
-#  define __FLT128_HAS_QUIET_NAN__ 1
-#endif
-#ifndef __FLT128_MANT_DIG__
-#  define __FLT128_MANT_DIG__ 113
-#endif
-#ifndef __FLT128_MAX_10_EXP__
-#  define __FLT128_MAX_10_EXP__ 4932
-#endif
-#ifndef __FLT128_MAX__
-#  define __FLT128_MAX__ 1.18973149535723176508575932662800702e+4932F128
-#endif
-#ifndef __FLT128_MAX_EXP__
-#  define __FLT128_MAX_EXP__ 16384
-#endif
-#ifndef __FLT128_MIN_10_EXP__
-#  define __FLT128_MIN_10_EXP__ (-4931)
-#endif
-#ifndef __FLT128_MIN__
-#  define __FLT128_MIN__ 3.36210314311209350626267781732175260e-4932F128
-#endif
-#ifndef __FLT128_MIN_EXP__
-#  define __FLT128_MIN_EXP__ (-16381)
-#endif
-#ifndef __FLT128_NORM_MAX__
-#  define __FLT128_NORM_MAX__ 1.18973149535723176508575932662800702e+4932F128
-#endif
-
 #define BFLT16_DECIMAL_DIG      3
 #define BFLT16_DENORM_MIN       (0x1p-133)
 #define BFLT16_DIG              2
@@ -256,6 +216,7 @@ private:
 #endif
 };
 
+#ifdef __FLT128_MAX__
 struct Float128
 {
     __float128 payload;
@@ -314,6 +275,7 @@ struct Float128
     { return __builtin_nansf128(""); }
 #endif
 };
+#endif // __FLT128_MAX__
 
 extern Float16 tofp16_emulated(float f);
 extern float fromfp16_emulated(Float16 f);
@@ -420,7 +382,6 @@ template<> struct TypeToDataType<int32_t> : TypeToDataType_helper<Int32Data> {};
 template<> struct TypeToDataType<int64_t> : TypeToDataType_helper<Int64Data> {};
 template<> struct TypeToDataType<__int128_t> : TypeToDataType_helper<Int128Data> {};
 
-template<> struct TypeToDataType<Float128> : TypeToDataType_helper<Float128Data> {};
 template<> struct TypeToDataType<Float16> : TypeToDataType_helper<Float16Data> {};
 template<> struct TypeToDataType<BFloat16> : TypeToDataType_helper<BFloat16Data> {};
 template<> struct TypeToDataType<float> : TypeToDataType_helper<Float32Data> {};
@@ -428,6 +389,7 @@ template<> struct TypeToDataType<double> : TypeToDataType_helper<Float64Data> {}
 template<> struct TypeToDataType<long double> :
         TypeToDataType_helper<sizeof(long double) == sizeof(double) ? Float64Data : Float80Data> {};
 #ifdef __FLT128_MAX__
+template<> struct TypeToDataType<Float128> : TypeToDataType_helper<Float128Data> {};
 template<> struct TypeToDataType<__float128> : TypeToDataType_helper<Float128Data> {};
 #endif
 #ifndef SANDSTONE_FLOAT16_EMULATED

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -10,6 +10,8 @@
 #ifndef INC_SANDSTONE_P_H
 #define INC_SANDSTONE_P_H
 
+#define _DARWIN_C_SOURCE 1
+
 #include <assert.h>
 #include <fcntl.h>
 #include <getopt.h>
@@ -445,6 +447,12 @@ struct Pipe
 #ifdef _WIN32
         // Windows won't signal any way
         return _pipe(fds, reserved, _O_BINARY | _O_NOINHERIT);
+#elif defined(__APPLE__)
+        int ret = pipe(fds);
+        if (ret < 0)
+            return ret;
+        fcntl(out(), F_SETNOSIGPIPE, 1);
+        return 0;
 #else
         // pipe2 is a Linux invention but all modern Unix (not macOS) have it too
         int ret = pipe2(fds, O_CLOEXEC | O_NOSIGPIPE);

--- a/framework/sandstone_sections.S
+++ b/framework/sandstone_sections.S
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+        .file "sandstone-sections.S"
+
+#ifdef __MACH__
+.macro add_section_symbols name
+        .section        __DATA, \name\().a
+        .global         ___start_\name
+        .align 8
+___start_\name\():
+        .section        __DATA, \name
+dummy_\name\():
+        .section        __DATA, \name\().z
+        .global         ___stop_\name
+___stop_\name\():
+.endm
+
+        add_section_symbols tests
+        add_section_symbols test_group
+#endif // __MACH__
+
+#ifdef __ELF__
+        .section        .note.GNU-stack,"",@progbits
+#endif // __ELF__

--- a/framework/sandstone_test_groups.cpp
+++ b/framework/sandstone_test_groups.cpp
@@ -9,14 +9,16 @@
 #else
 #  define TEST_GROUP(name, descr)   .id = name, .description = descr
 #endif
+#define TEST_GROUP_ATTRIBUTES                                           \
+    __attribute__((section(SANDSTONE_SECTION_PREFIX "test_group"), aligned(8)))
 
-__attribute__((section("test_group"), aligned(8)))
+TEST_GROUP_ATTRIBUTES
 extern constexpr struct test_group group_compression = {
     TEST_GROUP("compression",
                "Tests that drive compression routines in various libraries"),
 };
 
-__attribute__((section("test_group"), aligned(8)))
+TEST_GROUP_ATTRIBUTES
 extern constexpr struct test_group group_math = {
     TEST_GROUP("math",
                "Tests that perform math using, e.g., Eigen"),

--- a/framework/sandstone_utils.cpp
+++ b/framework/sandstone_utils.cpp
@@ -238,12 +238,14 @@ std::string stdprintf(const char *fmt, ...)
 
 coarse_steady_clock::time_point coarse_steady_clock::now() noexcept
 {
+#ifdef CLOCK_MONOTONIC_COARSE
     using namespace std::chrono;
     struct timespec ts;
     clock_t clk = CLOCK_MONOTONIC;
-#ifdef CLOCK_MONOTONIC_COARSE
     clk = CLOCK_MONOTONIC_COARSE;
-#endif
     clock_gettime(clk, &ts);
     return time_point(seconds(ts.tv_sec) + nanoseconds(ts.tv_nsec));
+#else
+    return time_point(std::chrono::steady_clock::now().time_since_epoch());
+#endif
 }

--- a/framework/sandstone_utils.cpp
+++ b/framework/sandstone_utils.cpp
@@ -94,8 +94,8 @@ template void check_type_assumptions<_Float16>();
 #endif
 #ifdef __FLT128_MAX__
 template void check_type_assumptions<__float128>();
-#endif
 template void check_type_assumptions<Float128>();
+#endif
 
 string format_single_type(DataType type, int typeSize, const uint8_t *data, bool detailed)
 {

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -360,7 +360,7 @@ static void cause_sigill()
     // make sure there are no function calls between the instruction above and the one below
 
     asm volatile(
-#ifdef __clang__
+#if defined(__clang__) || defined(__APPLE__)
                 "ud2" : :           // clang's integrated assembler doesn't support ud1
 #else
                 "ud1 %0, %1" : :

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -474,7 +474,7 @@ static int selftest_libc_fatal_run(struct test *, int)
 }
 #endif
 
-#ifndef _WIN32
+#ifdef __linux__
 BEGIN_ASM_FUNCTION(payload_long_64bit)
     asm("movabs $0x1234deadbeaf5678, %rax\n"
         "mov    $0x12345, %ebx\n"
@@ -557,7 +557,7 @@ static const kvm_config_t *selftest_kvm_config_real_16bit_fail()
 {
     return &kvm_config_real_16bit_fail;
 }
-#endif // _WIN32
+#endif // __linux__
 
 const static test_group group_positive = {
     .id = "positive",
@@ -687,7 +687,7 @@ static struct test selftests_array[] = {
     .desired_duration = -1,
 },
 
-#ifndef _WIN32
+#ifdef __linux__
 {
     .id = "kvm_long_64bit",
     .description = "Runs simple 64-bit KVM workload successfully",
@@ -702,7 +702,7 @@ static struct test selftests_array[] = {
     .test_kvm_config = selftest_kvm_config_real_16bit,
     .flags = test_type_kvm,
 },
-#endif // _WIN32
+#endif // __linux__
 
     /* Randomly failing tests */
 
@@ -941,7 +941,7 @@ FOREACH_DATATYPE(DATACOMPARE_TEST)
     .desired_duration = -1,
 },
 
-#ifndef _WIN32
+#ifdef __linux__
 {
     .id = "kvm_prot_64bit_fail",
     .description = "Runs simple 64-bit KVM workload that fails",
@@ -958,7 +958,7 @@ FOREACH_DATATYPE(DATACOMPARE_TEST)
     .desired_duration = -1,
     .flags = test_type_kvm,
 },
-#endif // _WIN32
+#endif // __linux__
 };
 
 const span<struct test> selftests = { std::begin(selftests_array), std::end(selftests_array) };

--- a/framework/sysdeps/darwin/cpu_affinity.cpp
+++ b/framework/sysdeps/darwin/cpu_affinity.cpp
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "topology.h"
+
+#include <stdio.h>
+#include <unistd.h>
+
+LogicalProcessorSet ambient_logical_processor_set()
+{
+    static bool warning_printed = []() {
+        fprintf(stderr, "# WARNING: this OS does not support thread affinity. Results may be unreliable.\n");
+        return true;
+    }();
+    (void) warning_printed;
+
+    // assume all CPUs
+    LogicalProcessorSet result = {};
+    long n = sysconf(_SC_NPROCESSORS_ONLN);
+    for (long i = 0; i < n; ++i)
+        result.set(LogicalProcessor(i));
+    return result;
+}
+
+bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
+{
+    // simulate success
+    (void) n;
+    (void) thread_name;
+    return true;
+}
+

--- a/framework/sysdeps/darwin/malloc.cpp
+++ b/framework/sysdeps/darwin/malloc.cpp
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sandstone_p.h>
+
+#include <errno.h>
+#include <malloc/malloc.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef __SANITIZE_ADDRESS__
+static void *bzero_block(void *ptr, size_t len)
+{
+    return memset(ptr, 0, len);
+}
+
+static __attribute__((noinline, noreturn)) void null_pointer_consumption(void *ptr, size_t size)
+{
+    static const char msg[] = "Out of memory condition\n";
+    (void) ptr;
+    IGNORE_RETVAL(write(STDERR_FILENO, msg, sizeof(msg) - 1));
+
+    // if the size is non-silly, simulate the Linux OOM killer
+    if (size < 256 * 1024 * 1024)
+        raise(SIGKILL);
+    abort();
+}
+
+static inline void *check_null_pointer(void *ptr, size_t size, size_t count = 1)
+{
+    if (__builtin_expect(!ptr, 0))
+        null_pointer_consumption(ptr, size * count);
+    return ptr;
+}
+
+static inline void *checked_allocation(size_t size, void *block)
+{
+    check_null_pointer(block, size);
+    size = malloc_size(block);
+    return bzero_block(block, size);
+}
+
+// different from all the rest
+int posix_memalign(void **newptr, size_t alignment, size_t size)
+{
+    *newptr = aligned_alloc(alignment, size);
+    return *newptr ? 0 : errno;
+}
+
+// pvalloc is valloc rounding up to the actual page size
+void *pvalloc(size_t bytes)
+{
+    bytes = ROUND_UP_TO_PAGE(bytes);
+    return valloc(bytes);
+}
+
+void *aligned_alloc(size_t alignment, size_t size)
+{
+    return checked_allocation(size, malloc_zone_memalign(malloc_default_zone(), alignment, size));
+}
+
+void *memalign(size_t alignment, size_t size)
+{
+    return checked_allocation(size, malloc_zone_memalign(malloc_default_zone(), alignment, size));
+}
+
+void *valloc(size_t size)
+{
+    return checked_allocation(size, malloc_zone_valloc(malloc_default_zone(), size));
+}
+
+void *malloc(size_t size)
+{
+    return checked_allocation(size, malloc_zone_malloc(malloc_default_zone(), size));
+}
+
+void *calloc(size_t n, size_t size)
+{
+    // calloc always zeroes memory, so we don't need to do it ourselves
+    return check_null_pointer(malloc_zone_calloc(malloc_default_zone(), n, size), n, size);
+}
+
+void *realloc(void *ptr, size_t size)
+{
+    size_t oldsize = malloc_size(ptr);
+    void *newptr = check_null_pointer(malloc_zone_realloc(malloc_default_zone(), ptr, size), size);
+    size = malloc_size(newptr);
+
+    ptrdiff_t bytestoclear = size - oldsize;
+    if (bytestoclear > 0)
+        bzero_block(reinterpret_cast<uint8_t *>(newptr) + oldsize, bytestoclear);
+    return newptr;
+}
+#endif // __SANITIZE_ADDRESS__

--- a/framework/sysdeps/darwin/meson.build
+++ b/framework/sysdeps/darwin/meson.build
@@ -4,6 +4,7 @@ sysdeps_a = static_library(
         sysdeps_unix_files,
 	files(
 		'cpu_affinity.cpp',
+		'malloc.cpp',
 		'../generic/kvm.c',
 		'../generic/memfpt.c',
 		'../generic/msr.c',

--- a/framework/sysdeps/darwin/meson.build
+++ b/framework/sysdeps/darwin/meson.build
@@ -5,6 +5,7 @@ sysdeps_a = static_library(
 	files(
 		'cpu_affinity.cpp',
 		'malloc.cpp',
+		'pthread_barrier.cpp',
 		'../generic/kvm.c',
 		'../generic/memfpt.c',
 		'../generic/msr.c',

--- a/framework/sysdeps/darwin/meson.build
+++ b/framework/sysdeps/darwin/meson.build
@@ -1,0 +1,24 @@
+# -*- indent-tabs-mode: t -*-
+sysdeps_a = static_library(
+	'sysdeps_darwin',
+        sysdeps_unix_files,
+	files(
+		'cpu_affinity.cpp',
+		'../generic/kvm.c',
+		'../generic/memfpt.c',
+		'../generic/msr.c',
+		'../generic/physicaladdress.c',
+	),
+	build_by_default: false,
+	include_directories : [
+		framework_incdir,
+	],
+	c_args : [
+		default_c_warn,
+		debug_c_flags,
+	],
+	cpp_args : [
+		default_cpp_warn,
+		debug_c_flags,
+	],
+)

--- a/framework/sysdeps/darwin/pthread_barrier.cpp
+++ b/framework/sysdeps/darwin/pthread_barrier.cpp
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "pthread_barrier.h"
+
+int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+    pthread_mutex_destroy(&barrier->mutex);
+    pthread_cond_destroy(&barrier->cond);
+    return 0;
+}
+
+int pthread_barrier_init(pthread_barrier_t *barrier,
+                         const pthread_barrierattr_t *attr, unsigned count)
+{
+    pthread_mutex_init(&barrier->mutex, nullptr);
+    pthread_cond_init(&barrier->cond, nullptr);
+    barrier->count = count;
+    return 0;
+}
+
+int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+    pthread_mutex_lock(&barrier->mutex);
+    if (--barrier->count)
+        pthread_cond_wait(&barrier->cond, &barrier->mutex);
+    else
+        pthread_cond_broadcast(&barrier->cond);
+    pthread_mutex_unlock(&barrier->mutex);
+
+    // Note: we don't return PTHREAD_BARRIER_SERIAL_THREAD
+    return 0;
+}

--- a/framework/sysdeps/darwin/pthread_barrier.h
+++ b/framework/sysdeps/darwin/pthread_barrier.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DARWIN_PTHREAD_BARRIER_H
+#define DARWIN_PTHREAD_BARRIER_H
+
+#include <pthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct pthread_barrier {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    unsigned count;
+} pthread_barrier_t;
+typedef struct pthread_barrierattr pthread_barrierattr_t;
+
+int pthread_barrier_destroy(pthread_barrier_t *barrier);
+int pthread_barrier_init(pthread_barrier_t *barrier,
+                         const pthread_barrierattr_t *attr, unsigned count);
+int pthread_barrier_wait(pthread_barrier_t *barrier);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DARWIN_PTHREAD_BARRIER_H

--- a/framework/sysdeps/darwin/thermal_monitor.hpp
+++ b/framework/sysdeps/darwin/thermal_monitor.hpp
@@ -1,0 +1,1 @@
+#include "../generic/thermal_monitor.hpp"

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -31,6 +31,10 @@
 #include <ucontext.h>
 #include <unistd.h>
 
+#ifndef MSG_NOSIGNAL
+#  define MSG_NOSIGNAL  0
+#endif
+
 #ifdef __linux__
 #  include <sys/prctl.h>
 #  include <sys/syscall.h>
@@ -381,6 +385,10 @@ static void create_crash_pipe(int xsave_size)
     int ret = fcntl(crashpipe[CrashPipeParent], F_GETFL);
     if (ret >= 0)
         fcntl(crashpipe[CrashPipeParent], F_SETFL, ret | O_NONBLOCK);
+
+#ifdef F_SETNOSIGPIPE
+    fcntl(crashpipe[CrashPipeChild], F_SETNOSIGPIPE, 1);
+#endif
 }
 #endif
 

--- a/framework/sysdeps/unix/stacksize.cpp
+++ b/framework/sysdeps/unix/stacksize.cpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  */
-
+#define _XOPEN_SOURCE 1
 #include <stdio.h>
 #include <sys/time.h>
 #include <sys/resource.h>

--- a/meson-darwin.ini
+++ b/meson-darwin.ini
@@ -1,0 +1,11 @@
+[constants]
+common_args = ['-I/usr/local/include', '-pipe']
+
+[binaries]
+c = 'gcc-10'
+cpp = 'g++-10'
+
+[built-in options]
+c_args = common_args
+cpp_args = common_args
+#cpp_link_args = ['-Wl,-rpath=/usr/local/lib/gcc10']

--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,18 @@ nasm_system_flags = [
 	'-Xgnu',
 	'-DWIN_ABI',
 ]
+elif target_machine.system() == 'darwin'
+add_project_arguments([
+	'-D__unix__',		# Why doesn't Apple think their OS is Unix?
+	'-D_DARWIN_C_SOURCE',
+], language: [ 'c', 'cpp' ])
+nasm_system_flags = [
+	'-fmacho64',
+	'-Xgnu',
+	'-DAPPLE',
+	'-D__APPLE__',
+        '--prefix=_'
+]
 else
 if get_option('buildtype') == 'debug'
 	debug_nasm_flags = '-gdwarf'


### PR DESCRIPTION
Complementing now the FreeBSD port, this is the macOS port. This PR allows OpenDCDiag to run on a macOS system, but due to the lack of an affinity-setting API, the **macOS port is not reliable**.

But it does run:
```
$ ./opendcdiag -o- | awk '(NR > 1 && NR < 6) || /exit:/'
command-line: 'opendcdiag -o-'
version: opendcdiag-e6b8da7dc018
os: Darwin 19.6.0
timing: { duration: 1000.000, timeout: 300000.000 }
exit: pass
```