### PR TITLE
meson: add dependency_link option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,8 @@ option('march_base', type : 'combo', choices : ['haswell', 'westmere'], value : 
 	description : 'Build framework with this base optimization -march= value (valid are "haswell" (default) and "westmere").')
 option('tests_options', type : 'array', value : [],
 	description : 'Pass strings to flag test content build options.')
+option('dependency_link', type : 'combo', choices : ['dynamic', 'static'], value : 'dynamic',
+	description : 'Link preference for dependencies: dynamic (default) or static')
 option('docdir', type : 'string', value : 'doc/dcdiag',
 	description : 'Directory name of where documentation will be installed.')
 option('static_libstdcpp', type : 'boolean', value : false,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-static_link = get_option('cpp_link_args').contains('-static')
+dep_static = get_option('dependency_link') == 'static'
 
 setmod = import('sourceset')
 
@@ -25,7 +25,7 @@ tests_common_incdirs = [
 	framework_incdir,
 ]
 
-eigen3_dep = dependency('eigen3', static : static_link)
+eigen3_dep = dependency('eigen3', static : dep_static)
 tests_base_set.add(
 	when : eigen3_dep,
 	if_true : files(
@@ -58,7 +58,7 @@ tests_skx_set.add(
 	)
 )
 
-zstd_dep = dependency('libzstd', static : static_link)
+zstd_dep = dependency('libzstd', static : dep_static)
 tests_base_set.add(
 	when : zstd_dep,
 	if_true : files(
@@ -66,7 +66,7 @@ tests_base_set.add(
 	)
 )
 
-zlib_dep = dependency('zlib', static : static_link)
+zlib_dep = dependency('zlib', static : dep_static)
 tests_base_set.add(
 	when : zlib_dep,
 	if_true : files(


### PR DESCRIPTION
Cleans up how folks configure library dependency links. Pass
'-Ddependency_link=static' if that is your preference.

Only influences dependency() static_link behavior. A riff on meson's
default_library core option.

Signed-off-by: Joe Konno <joe.konno@intel.com>