### PR TITLE
Fix Windows builds & add toolchain file

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -3,6 +3,9 @@
  */
 
 #define _GNU_SOURCE 1
+#ifdef _WIN32
+#  define _POSIX_C_SOURCE 200112L
+#endif
 #include "sandstone.h"
 #include "sandstone_p.h"
 #include "sandstone_iovec.h"

--- a/meson-cross-win32.ini
+++ b/meson-cross-win32.ini
@@ -1,0 +1,23 @@
+[constants]
+common_args = ['-pipe']
+
+[binaries]
+c = '/usr/bin/x86_64-w64-mingw32-gcc'
+cpp = '/usr/bin/x86_64-w64-mingw32-g++'
+objc = '/usr/bin/x86_64-w64-mingw32-gcc'
+ar = '/usr/bin/x86_64-w64-mingw32-ar'
+strip = '/usr/bin/x86_64-w64-mingw32-strip'
+windres = '/usr/bin/x86_64-w64-mingw32-windres'
+cmake = '/usr/bin/cmake'
+pkgconfig = '/usr/bin/x86_64-w64-mingw32-pkg-config'
+exe_wrapper = 'wine'
+
+[built-in options]
+c_args = common_args
+cpp_args = common_args
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ add_project_arguments([
 	'-D__USE_MINGW_ANSI_STDIO',
 	'-D_POSIX',
 	'-D_WIN32_WINNT=0x0A00',
+	'-gstabs+',
 	'-Wa,-mbig-obj',
 	'-include',
 	meson.current_source_dir() + '/framework/sysdeps/windows/win32_stdlib.h',


### PR DESCRIPTION
This needs to be added to the CI. The build was failing because we are using `gmtime_r`, which MinGW implements as an inline function in time.h but only if the `_POSIX_C_SOURCE` macro is defined.