### PR TITLE
CI: Explicitily specify when the workflow should build.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: github.event_name == 'pull_request'
     steps:
     - name: Checkout target branch (${{ github.base_ref }})
       uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
 
   git-sanity:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: github.event_name == 'pull_request'
     steps:
     - name: Checkout the PR branch
       uses: actions/checkout@v2
@@ -37,7 +37,13 @@ jobs:
     - name: Run the git checks
       run: .github/scripts/check-git-history.sh origin/${{ github.base_ref }} ${{ github.head_ref }}
 
+
   build-linux:
+    if: |
+      github.event_name == 'push'
+      || ( github.event_name == 'pull_request'
+        && needs.lint.result == 'success'
+        && needs.git-sanity.result == 'success' )
     needs: [ lint, git-sanity ]
     runs-on: ubuntu-latest
     container: debian:sid
@@ -59,6 +65,11 @@ jobs:
           --gtest_filter=-LinuxThermalFixture.CurrentMachine_TestUsingSingletomTemperaturesOnCurrentMachine # this test doesn't execute properly in a github runner
 
   build-windows:
+    if: |
+      github.event_name == 'push'
+      || ( github.event_name == 'pull_request'
+        && needs.lint.result == 'success'
+        && needs.git-sanity.result == 'success' )
     needs: [ lint, git-sanity ]
     runs-on: ubuntu-latest
     container: fedora:34


### PR DESCRIPTION
Currently there's no easy way to allow a job running if dependency is
either success or skipped. See https://github.com/actions/runner/issues/491