### PR TITLE
FW: child_debug: add missing FreeBSD include

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -31,6 +31,10 @@
 #include <ucontext.h>
 #include <unistd.h>
 
+#ifdef __FreeBSD__
+#  include <sys/thr.h>
+#endif
+
 #ifndef MSG_NOSIGNAL
 #  define MSG_NOSIGNAL  0
 #endif


### PR DESCRIPTION
The thr_self() function is defined in sys/thr.h, so we'll include it.
Without it, OpenDCDiag may not build on FreeBSD.

Bumped into this compiler error when I attempted to compile on FreeBSD
13.0 with GCC-11.

Signed-off-by: Joe Konno <joe.konno@intel.com>