### PR TITLE
Make Test Selector base destructor virtual

### DIFF
--- a/framework/test_selectors/TestrunSelectorBase.h
+++ b/framework/test_selectors/TestrunSelectorBase.h
@@ -17,6 +17,7 @@ protected:
     std::unordered_map<std::string, struct test *> test_by_id;
 
 public:
+    virtual ~TestrunSelector() = default;
     virtual void set_test_list(std::vector<struct test *> _tests){
         testinfo = std::move(_tests);
 


### PR DESCRIPTION
Avoids compiler warnings for nonvirtual destructors, and potential
memory leaks

Signed-off-by: Kevin Boyd<kevinboyd@google.com>