### PR TITLE
Adding support for native building on Windows using MSYS.

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -1,18 +1,25 @@
 # -*- indent-tabs-mode: t -*-
 # SPDX-License-Identifier: Apache-2.0
 
+sysdeps_dir = 'sysdeps/' + target_machine.system()
+
+if target_machine.system() == 'cygwin'
+  sysdeps_dir = 'sysdeps/windows'
+endif
+
 framework_incdir = [
 	top_incdir,
 	include_directories([
 		'.',
 		'test_selectors',
-		'sysdeps/' + target_machine.system(),
+		sysdeps_dir,
 	])
 ]
-if target_machine.system() != 'windows'
+
+if target_machine.system() != 'windows' and target_machine.system() != 'cygwin'
 	subdir('sysdeps/unix')
 endif
-subdir('sysdeps/' + target_machine.system())
+subdir(sysdeps_dir)
 
 generated_cpu_features_h = configure_file(
 	output : 'cpu_features.h',
@@ -83,7 +90,7 @@ else
 	default_cpp_flags += [ '-DNO_SELF_TESTS', ]
 endif
 
-if target_machine.system() != 'windows'
+if target_machine.system() != 'windows' and target_machine.system() != 'cygwin'
 framework_files += [
 	'forkfd/forkfd.c',
 ]


### PR DESCRIPTION
* Use of "cygwin" build target in meson
If user uses meson package provided with python from MSYS repo (not
MINGW64) for configuration Python's sys.platform is set to "cygwin".
Meson declares to support Cygwin as a target and makes project
configuration frictionless under MSYS environment. This unfortunetly
means we have to check for "cygwin" target during meson configuration
when we check for "windows" targets, but makes configuration much
easier.