### PR TITLE
FW: clean up our uses of ud2 instruction

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -847,7 +847,7 @@ static void *thread_runner(void *arg)
 
             if (new_state == thread_failed) {
                 if (sApp->ud_on_failure)
-                    __asm__ volatile("ud2");
+                    ud2();
                 logging_mark_thread_failed(thread_number);
             }
             test_end(new_state);

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -337,7 +337,7 @@ static Duration calculate_runtime(MonotonicTimePoint start_time, MonotonicTimePo
 
 static inline __attribute__((always_inline, noreturn)) void ud2()
 {
-    __asm__ volatile("ud2");
+    __builtin_trap();
     __builtin_unreachable();
 }
 


### PR DESCRIPTION
Keep them in a single place (outside of the selftests, at least) and use the GCC built-in to generate it.