### PR TITLE
FW/Data: fix again the detection of FP16 and FP128

### DIFF
--- a/framework/sandstone_data.h
+++ b/framework/sandstone_data.h
@@ -216,7 +216,7 @@ private:
 #endif
 };
 
-#ifdef __FLT128_MAX__
+#ifdef __SIZEOF_FLOAT128__
 struct Float128
 {
     __float128 payload;
@@ -388,12 +388,12 @@ template<> struct TypeToDataType<float> : TypeToDataType_helper<Float32Data> {};
 template<> struct TypeToDataType<double> : TypeToDataType_helper<Float64Data> {};
 template<> struct TypeToDataType<long double> :
         TypeToDataType_helper<sizeof(long double) == sizeof(double) ? Float64Data : Float80Data> {};
-#ifdef __FLT128_MAX__
+#ifdef __SIZEOF_FLOAT128__
 template<> struct TypeToDataType<Float128> : TypeToDataType_helper<Float128Data> {};
 template<> struct TypeToDataType<__float128> : TypeToDataType_helper<Float128Data> {};
 #endif
 #ifndef SANDSTONE_FLOAT16_EMULATED
-template<> struct TypeToDataType<_Float16> : TypeToDataType_helper<Float16Data> {};
+template<> struct TypeToDataType<__fp16> : TypeToDataType_helper<Float16Data> {};
 #endif
 
 static constexpr size_t type_real_size(DataType type)

--- a/framework/sandstone_utils.cpp
+++ b/framework/sandstone_utils.cpp
@@ -90,9 +90,9 @@ template void check_type_assumptions<long double>();
 template void check_type_assumptions<Float16>();
 template void check_type_assumptions<BFloat16>();
 #ifndef SANDSTONE_FLOAT16_EMULATED
-template void check_type_assumptions<_Float16>();
+template void check_type_assumptions<__fp16>();
 #endif
-#ifdef __FLT128_MAX__
+#ifdef __SIZEOF_FLOAT128__
 template void check_type_assumptions<__float128>();
 template void check_type_assumptions<Float128>();
 #endif


### PR DESCRIPTION
The constants and types we were using were not reliable.