### PR TITLE
FW/linux: fix build with GCC 10

### DIFF
--- a/framework/sysdeps/linux/effective_cpu_freq.hpp
+++ b/framework/sysdeps/linux/effective_cpu_freq.hpp
@@ -6,6 +6,7 @@
 #define LINUX_EFFECTIVE_FREQ_HPP
 
 #include <limits>
+#include <x86intrin.h>
 #include "sandstone_p.h"
 
 extern int get_monotonic_time_now(struct timespec *);


### PR DESCRIPTION
_rdtscp is in ia32intrin.h, which isn't included by immintrin.h with
GCC 10.