### PR TITLE
Meson: add -Werror=discarded-qualifiers to the C flags

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -157,6 +157,7 @@ endif
 default_c_warn = [
 	'-Wall',
 	'-Wextra',
+        '-Werror=discarded-qualifiers',
 	'-Werror=incompatible-pointer-types',
 	'-Werror=implicit-function-declaration',
 	'-Werror=int-conversion',


### PR DESCRIPTION
Because C allows this:
```c
  void f(int *x);
  void g(const int *x)
  { f(x); }
```