### PR TITLE
Eigen: move HSW tests into the baseline

### DIFF
--- a/tests/eigen_sparse/eigen_sparse.cpp
+++ b/tests/eigen_sparse/eigen_sparse.cpp
@@ -118,7 +118,6 @@ DECLARE_TEST(eigen_sparse, "Eigen sparse linear algebra payload. Solve Ax=b usin
   .test_init = eigen_sparse_init,
   .test_run = eigen_sparse_run,
   .test_cleanup = eigen_sparse_cleanup,
-  .minimum_cpu = cpu_haswell,
   .desired_duration = -1,
   .quality_level = TEST_QUALITY_PROD,
 END_DECLARE_TEST

--- a/tests/eigen_svd/svd.cpp
+++ b/tests/eigen_svd/svd.cpp
@@ -40,7 +40,6 @@ DECLARE_TEST(eigen_svd, "Eigen SVD (Singular Value Decomposition) solving payloa
   .test_init = eigen_svd_test::init,
   .test_run = eigen_svd_test::run,
   .test_cleanup = eigen_svd_test::cleanup,
-  .minimum_cpu = cpu_haswell,
   .fracture_loop_count = 2,
   .quality_level = TEST_QUALITY_PROD,
 END_DECLARE_TEST

--- a/tests/eigen_svd/svd_double.cpp
+++ b/tests/eigen_svd/svd_double.cpp
@@ -40,7 +40,6 @@ DECLARE_TEST(eigen_svd_double, "Eigen SVD (Singular Value Decomposition) solving
   .test_init = eigen_svd_double_test::init,
   .test_run = eigen_svd_double_test::run,
   .test_cleanup = eigen_svd_double_test::cleanup,
-  .minimum_cpu = cpu_haswell,
   .fracture_loop_count = 5,
   .quality_level = TEST_QUALITY_PROD,
 END_DECLARE_TEST
@@ -53,7 +52,6 @@ DECLARE_TEST(eigen_svd_double2, "Eigen SVD (Singular Value Decomposition) solvin
   .test_init = eigen_svd_double2_test::init,
   .test_run = eigen_svd_double2_test::run,
   .test_cleanup = eigen_svd_double2_test::cleanup,
-  .minimum_cpu = cpu_haswell,
   .fracture_loop_count = 5,
   .quality_level = TEST_QUALITY_PROD,
 END_DECLARE_TEST

--- a/tests/eigen_svd/svd_fvectors.cpp
+++ b/tests/eigen_svd/svd_fvectors.cpp
@@ -58,7 +58,6 @@ DECLARE_TEST(eigen_svd_fvectors, "Eigen SVD (Singular Value Decomposition) solvi
   .test_init = eigen_svd_fvectors_init,
   .test_run = eigen_svd_fvectors_test::run,
   .test_cleanup = eigen_svd_fvectors_test::cleanup,
-  .minimum_cpu = cpu_haswell,
   .fracture_loop_count = 5,
   .quality_level = TEST_QUALITY_PROD,
 END_DECLARE_TEST

--- a/tests/eigen_svd_jacobi/svd.cpp
+++ b/tests/eigen_svd_jacobi/svd.cpp
@@ -39,6 +39,5 @@ DECLARE_TEST(eigen_svd_jacobi, "Eigen SVD (Singular Value Decomposition, Jacobi 
   .test_init = eigen_svd_jacobi_test::init,
   .test_run = eigen_svd_jacobi_test::run,
   .test_cleanup = eigen_svd_jacobi_test::cleanup,
-  .minimum_cpu = cpu_haswell,
   .quality_level = TEST_QUALITY_SKIP,
 END_DECLARE_TEST

--- a/tests/eigen_svd_jacobi/svd_cdouble.cpp
+++ b/tests/eigen_svd_jacobi/svd_cdouble.cpp
@@ -40,6 +40,5 @@ DECLARE_TEST(eigen_svd_jacobi_cdouble, "Eigen SVD (Singular Value Decomposition,
   .test_init = eigen_svd_jacobi_cdouble_test::init,
   .test_run = eigen_svd_jacobi_cdouble_test::run,
   .test_cleanup = eigen_svd_jacobi_cdouble_test::cleanup,
-  .minimum_cpu = cpu_haswell,
   .quality_level = TEST_QUALITY_SKIP,
 END_DECLARE_TEST

--- a/tests/eigen_svd_jacobi/svd_double.cpp
+++ b/tests/eigen_svd_jacobi/svd_double.cpp
@@ -39,6 +39,5 @@ DECLARE_TEST(eigen_svd_jacobi_double, "Eigen SVD (Singular Value Decomposition, 
   .test_init = eigen_svd_jacobi_double_test::init,
   .test_run = eigen_svd_jacobi_double_test::run,
   .test_cleanup = eigen_svd_jacobi_double_test::cleanup,
-  .minimum_cpu = cpu_haswell,
   .quality_level = TEST_QUALITY_SKIP,
 END_DECLARE_TEST

--- a/tests/eigen_svd_jacobi/svd_fvectors.cpp
+++ b/tests/eigen_svd_jacobi/svd_fvectors.cpp
@@ -58,6 +58,5 @@ DECLARE_TEST(eigen_svd_jacobi_fvectors, "Eigen SVD (Singular Value Decomposition
   .test_init = eigen_svd_jacobi_fvectors_init,
   .test_run = eigen_svd_jacobi_fvectors_test::run,
   .test_cleanup = eigen_svd_jacobi_fvectors_test::cleanup,
-  .minimum_cpu = cpu_haswell,
   .quality_level = TEST_QUALITY_SKIP,
 END_DECLARE_TEST

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -35,15 +35,9 @@ tests_base_set.add(
 		'eigen_gemm/gemm_cdouble_dynamic_square.cpp',
 		'eigen_gemm/gemm_double_dynamic_square.cpp',
 		'eigen_gemm/gemm_float_dynamic_square.cpp',
-		'eigen_svd/svd_cdouble_noavx512.cpp',
-	)
-)
-
-tests_hsw_set.add(
-	when : eigen3_dep,
-	if_true : files(
 		'eigen_sparse/eigen_sparse.cpp',
 		'eigen_svd/svd.cpp',
+		'eigen_svd/svd_cdouble_noavx512.cpp',
 		'eigen_svd/svd_double.cpp',
 		'eigen_svd/svd_fvectors.cpp',
 		'eigen_svd_jacobi/svd.cpp',


### PR DESCRIPTION
These tests do not contain any Haswell-specific code (read: AVX2 or
FMA), so they don't need to be in the tests_hsw library. That library
should be used only for tests that always require HSW.

This does not change the default OpenDCDiag binary contents, because we
default to `-march=haswell` anyway. However, it does make these tests
available for the other (`-march=westmere`) build.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>