### PR TITLE
Isolate x86-64 specific content

### DIFF
--- a/framework/interrupt_monitor.hpp
+++ b/framework/interrupt_monitor.hpp
@@ -43,14 +43,14 @@ public:
     }
 
     static constexpr bool InterruptMonitorWorks =
-#ifdef __linux__
+#if defined(__linux__) && defined(__x86_64__)
             true;
 #else
             false;
 #endif
 };
 
-#ifndef __linux__
+#if !defined(__linux__) || !defined(__x86_64__)
 inline std::vector<uint32_t> InterruptMonitor::get_interrupt_counts(InterruptType)
 {
     static_assert(!InterruptMonitorWorks);

--- a/framework/random.cpp
+++ b/framework/random.cpp
@@ -36,7 +36,9 @@ DECLSPEC_IMPORT BOOLEAN WINAPI SystemFunction036(PVOID RandomBuffer, ULONG Rando
 }
 #endif
 
-#include <immintrin.h>
+#ifdef __x86_64__
+#  include <immintrin.h>
+#endif
 
 #ifndef O_CLOEXEC
 #  define O_CLOEXEC 0

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -789,18 +789,22 @@ extern "C" {
 
 static void __attribute__((noinline)) test_start()
 {
+#ifdef __x86_64__
     __asm__("xchg   %%rbx, %%rbx\n"
             "xchg   %%rcx, %%rcx\n"
             "xchg   %%rdx, %%rdx"
             : : "D" (thread_running));
+#endif
 }
 
 static void __attribute__((noinline)) test_end(ThreadState state)
 {
+#ifdef __x86_64__
     __asm__("xchg   %%rdx, %%rdx\n"
             "xchg   %%rcx, %%rcx\n"
             "xchg   %%rbx, %%rbx\n"
             : : "D" (state));
+#endif
 }
 
 // This wrapper function is needed by emulation to be able to identify

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -186,7 +186,7 @@ thread_local int thread_num = 0;
 
 static span<struct test> test_set = regular_tests;
 
-#ifdef __linux__
+#if defined(__linux__) && defined(__x86_64__)
 extern struct test mce_test;
 #else
 // no MCE test outside Linux

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -6,12 +6,15 @@
 #define __INCLUDE_GUARD_SANDSTONE_H_
 
 #include <errno.h>
-#include <immintrin.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+#ifdef __x86_64__
+#include <immintrin.h>
+#endif
 
 #include "cpu_features.h"
 #include "sandstone_config.h"

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -5,6 +5,7 @@
 #include "sandstone_context_dump.h"
 #include "sandstone.h"
 
+#ifdef __x86_64__
 #include "amx_common.h"
 #include "cpu_features.h"
 #include "fp_vectors/Floats.h"
@@ -475,3 +476,5 @@ void dump_xsave(FILE *f, const void *xsave_area, size_t xsave_size, int xsave_du
     if (mask & XSave_AmxState)
         print_amx_state(f, state, mask);
 }
+
+#endif // x86-64

--- a/framework/sandstone_data.h
+++ b/framework/sandstone_data.h
@@ -5,12 +5,15 @@
 #ifndef SANDSTONE_DATA_H
 #define SANDSTONE_DATA_H
 
-#include <immintrin.h>
 #include <float.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+
+#ifdef __F16C__
+#  include <immintrin.h>
+#endif
 
 #ifndef __FLT16_DECIMAL_DIG__
 #  define __FLT16_DECIMAL_DIG__ 5

--- a/framework/sysdeps/linux/effective_cpu_freq.hpp
+++ b/framework/sysdeps/linux/effective_cpu_freq.hpp
@@ -5,6 +5,10 @@
 #ifndef LINUX_EFFECTIVE_FREQ_HPP
 #define LINUX_EFFECTIVE_FREQ_HPP
 
+#ifndef __x86_64__
+#  include "../generic/effective_cpu_freq.hpp"
+#else
+
 #include <limits>
 #include <x86intrin.h>
 #include "sandstone_p.h"
@@ -54,5 +58,7 @@ private:
     uint32_t tsc_aux;
     uint64_t aperf, mperf;
 };
+
+#endif // __x86_64__
 
 #endif // LINUX_EFFECTIVE_FREQ_HPP

--- a/framework/sysdeps/linux/meson.build
+++ b/framework/sysdeps/linux/meson.build
@@ -1,16 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
+if (host_machine.cpu_family() == 'x86_64')
+        sysdeps_arch_files = files(
+                'kvm.c',
+                'msr.c',
+        )
+else
+        sysdeps_arch_files = files(
+                '../generic/kvm.c',
+                '../generic/msr.c',
+        )
+endif
+
 _sysdeps_a = static_library(
 	'sysdeps_linux',
         sysdeps_unix_files,
+	sysdeps_arch_files,
 	files(
 		'cpu_affinity.cpp',
 		'interrupt_monitor.cpp',
-		'kvm.c',
 		'malloc.cpp',
 		'memfpt.cpp',
-		'msr.c',
-		'physicaladdress.cpp',
+	        'physicaladdress.cpp',
 	),
 	build_by_default: false,
 	include_directories : [

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -6,7 +6,6 @@
 #  define _XOPEN_SOURCE 1
 #endif
 
-#include "sandstone.h"
 #include "sandstone_p.h"
 #include "sandstone_context_dump.h"
 #include "sandstone_iovec.h"
@@ -17,7 +16,6 @@
 #include <type_traits>
 
 #include <sys/types.h>
-#include <cpuid.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <paths.h>
@@ -30,6 +28,10 @@
 #include <sys/wait.h>
 #include <ucontext.h>
 #include <unistd.h>
+
+#ifdef __x86_64__
+#  include <cpuid.h>
+#endif
 
 #ifdef __FreeBSD__
 #  include <sys/thr.h>

--- a/framework/sysdeps/unix/splitlock_detect.c
+++ b/framework/sysdeps/unix/splitlock_detect.c
@@ -11,6 +11,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#ifdef __x86_64__
 static void splitlock_signal_handler(int signum)
 {
     _exit(signum);
@@ -51,3 +52,9 @@ bool splitlock_enforcement_enabled()
     cached_result = enforced ? 1 : -1;
     return enforced;
 }
+#else
+bool splitlock_enforcement_enabled()
+{
+    return false;
+}
+#endif

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -327,6 +327,7 @@ static int fill_topo_sysfs(struct cpu_info *info)
 
 }
 
+#ifdef __x86_64__
 static int fill_family_cpuid(struct cpu_info *info)
 {
     /*
@@ -430,6 +431,11 @@ static int fill_ucode_msr(struct cpu_info *info)
 
     return 0;
 }
+#else
+constexpr auto fill_family_cpuid = nullptr;
+constexpr auto fill_ucode_msr = nullptr;
+constexpr auto fill_topo_cpuid = nullptr;
+#endif // x86-64
 
 static int fill_ucode_sysfs(struct cpu_info *info)
 {
@@ -500,6 +506,7 @@ static int fill_ucode_sysfs(struct cpu_info *info)
 #endif /* __linux__ */
 }
 
+#ifdef __x86_64__
 static int fill_ppin_msr(struct cpu_info *info)
 {
     info->ppin = 0;
@@ -554,11 +561,15 @@ static int fill_cache_info_cpuid(struct cpu_info *info) {
 
     return 0;
 }
+#else
+constexpr auto fill_ppin_msr = nullptr;
+constexpr auto fill_cache_info_cpuid = nullptr;
+#endif // __x86_64__
 
 static int fill_ppin_sysfs(struct cpu_info *info)
 {
     int ret = 1;
-#if defined(__linux__)
+#if defined(__linux__) && defined(__x86_64__)
     auto_fd cpufd = open_sysfs_cpu_dir(info->cpu_number);
     if (cpufd < 0)
         return 1;

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -10,13 +10,15 @@
 #include <vector>
 
 #include <assert.h>
-#include <cpuid.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
+#ifdef __x86_64__
+#  include <cpuid.h>
+#endif
 #if defined(_WIN32)
 #   include <windows.h>
 #endif

--- a/meson.build
+++ b/meson.build
@@ -29,22 +29,29 @@ if cpp.get_linker_id() != 'ld.bfd' or cc.get_linker_id() != 'ld.bfd'
 	warning('We recommend linking OpenDCDiag with the binutils linker (ld). Your build may fail or your executable may not behave as expected.')
 endif
 
+march_generic_flags = []
+march_flags = []
 march_base = get_option('march_base')
-if march_base == ''
-	march_base='haswell'
+if march_base != ''
+	march_flags += '-march=' + march_base
 endif
-march_generic_flags = [
-	'-march=core2',
-	'-mno-sse3',
-]
-march_flags = [
-	'-march=' + march_base,
-	'-mtune=skylake',
-	'-maes',
-	'-mpclmul',
-	'-mno-rdrnd',
-	'-falign-loops=32',
-]
+if host_machine.cpu_family() == 'x86_64'
+	if march_base == ''
+		march_base='haswell'
+	endif
+	march_generic_flags = [
+		'-march=core2',
+		'-mno-sse3',
+	]
+	march_flags = [
+		'-march=' + march_base,
+		'-mtune=skylake',
+		'-maes',
+		'-mpclmul',
+		'-mno-rdrnd',
+		'-falign-loops=32',
+	]
+endif
 
 debug_nasm_flags = ''
 if get_option('buildtype') == 'debug'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,8 +2,8 @@
 
 option('logging_format', type : 'combo', choices : ['yaml', 'tap', 'none'], value : 'yaml',
 	description : 'Set build-time default logging format to "none", "yaml" (default), or "tap".')
-option('march_base', type : 'combo', choices : ['', 'haswell', 'westmere'], value : '',
-	description : 'Build framework with this base optimization -march= value (valid are "haswell" (default) and "westmere").')
+option('march_base', type : 'string', value : '',
+	description : 'Build framework with this base optimization -march= value (default: "haswell").')
 option('tests_options', type : 'array', value : [],
 	description : 'Pass strings to flag test content build options.')
 option('dependency_link', type : 'combo', choices : ['dynamic', 'static'], value : 'dynamic',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -27,6 +27,12 @@ tests_common_incdirs = [
 	framework_incdir,
 ]
 
+if target_machine.cpu_family() != 'x86_64'
+	# non-x86 Eigen does not get as much attention so this annoying
+	# warning was left behind
+	tests_common_cpp_args += '-Wno-deprecated-copy'
+endif
+
 eigen3_dep = dependency('eigen3', static : dep_static)
 tests_base_set.add(
 	when : eigen3_dep,
@@ -89,52 +95,57 @@ tests_base_a = static_library(
 	],
 )
 
-tests_hsw_config = tests_hsw_set.apply(tests_config_data)
-
-tests_hsw_a = static_library(
-	'tests_hsw',
-	sources : tests_hsw_config.sources(),
-	dependencies : tests_hsw_config.dependencies(),
-	build_by_default: false,
-	include_directories : [
-		tests_common_incdirs,
-	],
-	c_args : [
-		'-march=haswell',
-		'-mrtm',
-		tests_common_c_args,
-	],
-	cpp_args : [
-		'-march=haswell',
-		'-mrtm',
-		'-DEigen=EigenAVX2',
-		tests_common_cpp_args,
-	],
-)
-
-tests_skx_config = tests_skx_set.apply(tests_config_data)
-
-tests_skx_a = static_library(
-	'tests_skx',
-	sources : tests_skx_config.sources(),
-	dependencies : tests_skx_config.dependencies(),
-	build_by_default: false,
-	include_directories : [
-		tests_common_incdirs,
-	],
-	c_args : [
-		'-march=skylake-avx512',
-		tests_common_c_args,
-	],
-	cpp_args : [
-		'-march=skylake-avx512',
-		'-DEigen=EigenAVX512',
-		tests_common_cpp_args,
-	],
-)
-
 sandstone_tests += [
 	tests_base_a,
-	tests_hsw_a,
-	tests_skx_a,
 ]
+
+if host_machine.cpu_family() == 'x86_64'
+	tests_hsw_config = tests_hsw_set.apply(tests_config_data)
+
+	tests_hsw_a = static_library(
+		'tests_hsw',
+		sources : tests_hsw_config.sources(),
+		dependencies : tests_hsw_config.dependencies(),
+		build_by_default: false,
+		include_directories : [
+			tests_common_incdirs,
+		],
+		c_args : [
+			tests_common_c_args,
+			'-march=haswell',
+			'-mrtm',
+		],
+		cpp_args : [
+			tests_common_cpp_args,
+			'-march=haswell',
+			'-mrtm',
+			'-DEigen=EigenAVX2',
+		],
+	)
+
+	tests_skx_config = tests_skx_set.apply(tests_config_data)
+
+	tests_skx_a = static_library(
+		'tests_skx',
+		sources : tests_skx_config.sources(),
+		dependencies : tests_skx_config.dependencies(),
+		build_by_default: false,
+		include_directories : [
+			tests_common_incdirs,
+		],
+		c_args : [
+			tests_common_c_args,
+			'-march=skylake-avx512',
+		],
+		cpp_args : [
+			tests_common_cpp_args,
+			'-march=skylake-avx512',
+			'-DEigen=EigenAVX512',
+		],
+	)
+
+	sandstone_tests += [
+		tests_hsw_a,
+		tests_skx_a,
+	]
+endif


### PR DESCRIPTION
This allows building OpenDCDiag for a non-x86-64 platform. No guarantees this passes the selftests or does anything useful, but it at least compiles.