### PR TITLE
Enabling movdiri and movdiri64b instructions.

### DIFF
--- a/framework/simd.conf
+++ b/framework/simd.conf
@@ -62,8 +62,8 @@ avx512vpopcntdq 	Leaf07_00ECX	    14	avx512f	# AVX512 Population Count
 #la57			Leaf07_00ECX	    16		# 5-level page tables
 #rdpid			Leaf07_00ECX	    22		# RDPID instruction
 #cldemote		Leaf07_00ECX	    25		# Cache Line Demotion
-#movdiri		Leaf07_00ECX	    27		# Move Direct-store Integer
-#movdir64b		Leaf07_00ECX	    28		# Move Direct-store 64 bytes
+movdiri			Leaf07_00ECX	    27		# Move Direct-store Integer
+movdir64b		Leaf07_00ECX	    28		# Move Direct-store 64 bytes
 #enqcmd			Leaf07_00ECX	    29		# Enqueue Command
 #pks			Leaf07_00ECX	    31		# Protection Keys for Supervisor mode
 #avx5124nniw		Leaf07_00EDX	    2	avx512f	# AVX512 4-iteration Vector Neural Network Instructions


### PR DESCRIPTION
Enabling two instructions in simd.conf: movdiri and movdir64b.
Signed-off-by: Dawid Sabat <dawid.sabat@intel.com>