### PR TITLE
forkfd: don't attempt to guess EWOULDBLOCK when WNOHANG is active

### DIFF
--- a/framework/forkfd/forkfd_linux.c
+++ b/framework/forkfd/forkfd_linux.c
@@ -149,6 +149,8 @@ int system_forkfd(int flags, pid_t *ppid, int *system)
     *system = 1;
     unsigned long cloneflags = CLONE_PIDFD | SIGCHLD;
     pid = sys_clone(cloneflags, &pidfd);
+    if (pid < 0)
+        return pid;
     if (ppid)
         *ppid = pid;
 


### PR DESCRIPTION
Reading the kernel sources, I was sure we'd get an ECHILD if the child
hadn't exited yet, but that's not the case. We only get ECHILD if the
current process has no child processes. But if we do have one and the
one we're waiting for hasn't exited, waitid() returns 0.

So let's not attempt to correct it with `forkfd_wait()` or `forkfd_wait4()`.
Those have "wait" in the name, so they should behave exactly the same
way. The man pages say:
```
 waitpid(): if WNOHANG was specified and one or more child(ren)
       specified by pid exist, but have not yet changed state, then 0 is
       returned.
 waitid(): returns 0 on success or if WNOHANG was specified and no
       child(ren) specified by id has yet changed state
```
OpenDCDiag does not use this code path (blocking mode forkfd only).
Matching Qt change:
https://codereview.qt-project.org/c/qt/qtbase/+/397906