### PR TITLE
framework: Consider slices count when calculating test timeout.

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -623,7 +623,11 @@ static Duration test_timeout(Duration regular_duration)
 
     Duration result = regular_duration * 5 + 30s;
     if (result < 300s)
-        return 300s;
+        result = 300s;
+
+    // Multiply by the number of slices needed to run on all cpus.
+    result = result * sApp->current_slice_count;
+
     return result;
 }
 

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -714,6 +714,13 @@ static struct test selftests_array[] = {
     .test_run = selftest_uses_too_much_mem_run,
     .desired_duration = -1,
 },
+{
+    .id = "selftest_timedpass_maxthreads1",
+    .description = "Runs for the requested time, but on single thread",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_run = selftest_timedpass_run<(50000us).count()>,
+    .max_threads = 1,
+},
 
 #if defined(__linux__) && defined(__x86_64__)
 {


### PR DESCRIPTION
When a test is split into several slices due a limit imposed by
"max_threads" flag, we need to consider this extra runtime when
calculating timeout.

Signed-off-by: Athenas Jimenez <athenas.jimenez.gonzalez@intel.com>