### PR TITLE
fw: vmx: remove debug log

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2245,8 +2245,6 @@ static void add_test(/*nonconst*/ struct test *test)
                 test->test_init = kvm_generic_init;
                 test->test_run = kvm_generic_run;
                 test->test_cleanup = kvm_generic_cleanup;
-            } else {
-                log_debug("KVM test '%s' provides its own init function.", test->description);
             }
         }
     }


### PR DESCRIPTION
The debug message logged by the framework when a kvm tests uses a
custom init method crashes, as it is called before logging has been
initialised.  In addition, it's of limited informational value, so
it's better to simply remove it.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>