### PR TITLE
Add context to exit handler

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -306,6 +306,8 @@ struct test_data_per_thread
     void *data;
 };
 
+struct kvm_ctx;
+typedef struct kvm_ctx kvm_ctx_t;
 struct kvm_config;
 typedef struct kvm_config kvm_config_t;
 typedef const kvm_config_t *(*kvmconfigfunc)(void);

--- a/framework/sandstone_kvm.h
+++ b/framework/sandstone_kvm.h
@@ -38,6 +38,18 @@ struct kvm_config {
     kvmexitfunc exit_handler;
 };
 
+/* kvm context for 1 thread - 1 vm - 1 cpu topology which each sandstone thread
+ * carries around for the duration of the test. */
+struct kvm_ctx {
+    int vm_fd;
+    int cpu_fd;
+    const kvm_config_t *config;
+    uint8_t *ram;
+    struct kvm_run *runs;
+    uint32_t ram_sz;
+    int run_sz;
+};
+
 int kvm_generic_init(struct test *);
 int kvm_generic_run(struct test *, int cpu);
 int kvm_generic_cleanup(struct test *);

--- a/framework/sandstone_kvm.h
+++ b/framework/sandstone_kvm.h
@@ -28,7 +28,7 @@ typedef enum {
     KVM_EXIT_FAILURE,
 } kvm_exit_code_t;
 
-typedef kvm_exit_code_t(*kvmexitfunc)(int vcpu_fd, void *kvm_ctx);
+typedef kvm_exit_code_t(*kvmexitfunc)(kvm_ctx_t *ctx, struct test *test, int cpu);
 
 struct kvm_config {
     kvm_addr_mode_t addr_mode;

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -524,7 +524,7 @@ int kvm_generic_run(struct test *test, int cpu)
             }
 
             if (ctx.config->exit_handler != NULL) {
-                switch (ctx.config->exit_handler(ctx.cpu_fd, ctx.runs)) {
+                switch (ctx.config->exit_handler(&ctx, test, cpu)) {
                 case KVM_EXIT_FAILURE:
                     result = EXIT_FAILURE;
                     log_error("KVM exit handler for VM-Exit %d failed", ctx.runs->exit_reason);

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -89,18 +89,6 @@ int kvm_fd = -1;
     (((base)  & UINT64_C(0x00ffffff)) << 16) |      \
     (((limit) & UINT64_C(0x0000ffff))))
 
-/* kvm context for 1 thread - 1 vm - 1 cpu topology which each sandstone thread
- * carries around for the duration of the test. */
-typedef struct kvm_ctx {
-    int vm_fd;
-    int cpu_fd;
-    const kvm_config_t *config;
-    uint8_t *ram;
-    struct kvm_run *runs;
-    uint32_t ram_sz;
-    int run_sz;
-} kvm_ctx_t;
-
 
 static int kvm_generic_create_vm(int kvm_fd)
 {


### PR DESCRIPTION
In order to write richer KVM content, we'll need (imho) more context provided to the exit handler. This series has the generic_run function pass `struct kvm_ctx`, `struct test`, and `cpu` info/state to the handler.

I'm fine with squashing these-- broke them up to help with review.