### PR TITLE
fw: kvm: Add setup and check handlers

### DIFF
--- a/framework/sandstone_kvm.h
+++ b/framework/sandstone_kvm.h
@@ -30,12 +30,28 @@ typedef enum {
 
 typedef kvm_exit_code_t(*kvmexitfunc)(kvm_ctx_t *ctx, struct test *test, int cpu);
 
+/* Called just before the framework executes the kvm payload.  This
+ * callback is optional.  Test writers can use it to initialise the VM
+ * state, e.g., set up segment registers, populate memory, before the
+ * payload is run.
+ */
+typedef int (*kvmvcpusetup)(kvm_ctx_t *ctx, struct test *test, int cpu);
+
+/* Called just after the kvm payload finishes executing.  This callback
+ * is optional.  Test writers can use it to verify the state of the executed
+ * VM is correct.  An error can be signalled by returning a value other than
+ * EXIT_SUCCESS.
+ */
+typedef int (*kvmvcpucheck)(kvm_ctx_t *ctx, struct test *test, int cpu);
+
 struct kvm_config {
     kvm_addr_mode_t addr_mode;
     size_t ram_size;
     const void *payload;
     const void *payload_end;
     kvmexitfunc exit_handler;
+    kvmvcpusetup setup_handler;
+    kvmvcpucheck check_handler;
 };
 
 /* kvm context for 1 thread - 1 vm - 1 cpu topology which each sandstone thread

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -517,6 +517,12 @@ int kvm_generic_run(struct test *test, int cpu)
             goto epilogue;
         }
 
+        if (ctx.config->setup_handler != NULL) {
+                result = ctx.config->setup_handler(&ctx, test, cpu);
+                if (result != EXIT_SUCCESS)
+                        goto epilogue;
+        }
+
         do {
             if (ioctl(ctx.cpu_fd, KVM_RUN, 0) == -1) {
                 result = EXIT_FAILURE;
@@ -563,6 +569,9 @@ int kvm_generic_run(struct test *test, int cpu)
             }
 
         } while (!stop);
+
+        if ((result == EXIT_SUCCESS) && (ctx.config->check_handler != NULL))
+                result = ctx.config->check_handler(&ctx, test, cpu);
 
         count++;
 


### PR DESCRIPTION
This commit adds two new optional kvm handlers that can be used to
initialise a VM before the payload is run and to access the state
of the VM after the payload has finished executing.

A new selftest is also added to test the new handlers.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>