### PR TITLE
fw: kvm: don't use report_fail_msg

### DIFF
--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -549,7 +549,7 @@ int kvm_generic_run(struct test *test, int cpu)
                                 break;
                             default:
                                 kvm_log_registers(SANDSTONE_LOG_INFO, &cregs);
-                                report_fail_msg("KVM test reported exit code %lld", cregs.rax);
+                                log_error("KVM test reported exit code %lld", cregs.rax);
                                 result = EXIT_FAILURE;
                                 break;
                         }


### PR DESCRIPTION
It's better to signal an error in a KVM test by letting the functions
unwind naturally rather than cancelling the thread.  This allows the
framework to cleanup the VMs it's created and crucially to report
the error more quickly.  It takes the framework 3.5 seconds to report
the failure of a simple test on my test machine when the failure is signalled via
report_fail_msg.  After this patch, the failure is reported in 400ms.
The problem can be reproduced using the selftests, e.g.,

opendcdiag --selftests -e kvm_prot_64bit_fail

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>