### PR TITLE
fw: selftest: drop maxthreads1 from positive group

### DIFF
--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -776,7 +776,6 @@ static struct test selftests_array[] = {
 {
     .id = "selftest_timedpass_maxthreads1",
     .description = "Runs for the requested time, but on single thread",
-    .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_run = selftest_timedpass_run<(50000us).count()>,
     .max_threads = 1,
 },


### PR DESCRIPTION
It's a good self-test, but it's best for it to stand alone. Its
execution time can increase as core count increases. By dropping this
test from the @positive group, someone (like myself) wishing to run
@positive under strict constraints, especially timing, will no longer
have to account for a "long pole" self-test.

Signed-off-by: Joe Konno <joe.konno@intel.com>