### PR TITLE
Fixing off by one in gdb backtrace

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -513,7 +513,7 @@ static void communicate_gdb_backtrace(int log, int in, int out, uintptr_t handle
             if (ret <= 0)
                 return;
 
-            ret = read(in, buf, sizeof(buf));
+            ret = read(in, buf, sizeof(buf) - 1);
             if (ret <= 0)
                 return;
             buf[ret] = '\0';


### PR DESCRIPTION
Following outcome of static code analysis, fixing an off by one error, where string null termination character was written outside of string's buffer.