### PR TITLE
Re-add the "Copyright" line above the SPDX-License-Identifier.

### DIFF
--- a/docs/writing_tests.md
+++ b/docs/writing_tests.md
@@ -14,6 +14,7 @@ A [very simple test](../tests/examples/simple_add.c) is presented below
 ```c
 /**
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b simple_add
@@ -267,6 +268,7 @@ addition using SIMD instructions. Here's our [new test](../tests/examples/simple
 ```c
 /**
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b vector_add

--- a/framework/Floats.c
+++ b/framework/Floats.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/amx_common.h
+++ b/framework/amx_common.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/cpuid_internal.h
+++ b/framework/cpuid_internal.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/forkfd.h
+++ b/framework/forkfd.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/fp_vectors/Floats.h
+++ b/framework/fp_vectors/Floats.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/fp_vectors/static_vectors.h
+++ b/framework/fp_vectors/static_vectors.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/generated_vectors.c
+++ b/framework/generated_vectors.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/interrupt_monitor.hpp
+++ b/framework/interrupt_monitor.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -1,4 +1,5 @@
 # -*- indent-tabs-mode: t -*-
+# Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 sysdeps_dir = 'sysdeps/' + target_machine.system()

--- a/framework/mmap_region.c
+++ b/framework/mmap_region.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/random.cpp
+++ b/framework/random.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_asm.h
+++ b/framework/sandstone_asm.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_config.h
+++ b/framework/sandstone_config.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_context_dump.h
+++ b/framework/sandstone_context_dump.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_data.cpp
+++ b/framework/sandstone_data.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_data.h
+++ b/framework/sandstone_data.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_iovec.h
+++ b/framework/sandstone_iovec.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_kvm.h
+++ b/framework/sandstone_kvm.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_sections.S
+++ b/framework/sandstone_sections.S
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_span.h
+++ b/framework/sandstone_span.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_test_groups.cpp
+++ b/framework/sandstone_test_groups.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_test_groups.h
+++ b/framework/sandstone_test_groups.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_test_utils.h
+++ b/framework/sandstone_test_utils.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_utils.cpp
+++ b/framework/sandstone_utils.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sandstone_utils.h
+++ b/framework/sandstone_utils.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/scripts/make-gitid.pl
+++ b/framework/scripts/make-gitid.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/perl -l
 
+# Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 use strict;

--- a/framework/scripts/x86simd_generate.pl
+++ b/framework/scripts/x86simd_generate.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/env perl
 
+# Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 use strict;

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/static_vectors.c
+++ b/framework/static_vectors.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/darwin/cpu_affinity.cpp
+++ b/framework/sysdeps/darwin/cpu_affinity.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/darwin/malloc.cpp
+++ b/framework/sysdeps/darwin/malloc.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/darwin/pthread_barrier.cpp
+++ b/framework/sysdeps/darwin/pthread_barrier.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/darwin/pthread_barrier.h
+++ b/framework/sysdeps/darwin/pthread_barrier.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/freebsd/cpu_affinity.cpp
+++ b/framework/sysdeps/freebsd/cpu_affinity.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/freebsd/malloc.cpp
+++ b/framework/sysdeps/freebsd/malloc.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/generic/effective_cpu_freq.hpp
+++ b/framework/sysdeps/generic/effective_cpu_freq.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/generic/kvm.c
+++ b/framework/sysdeps/generic/kvm.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/generic/memfpt.c
+++ b/framework/sysdeps/generic/memfpt.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/generic/msr.c
+++ b/framework/sysdeps/generic/msr.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/generic/physicaladdress.c
+++ b/framework/sysdeps/generic/physicaladdress.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/generic/thermal_monitor.hpp
+++ b/framework/sysdeps/generic/thermal_monitor.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/linux/cpu_affinity.cpp
+++ b/framework/sysdeps/linux/cpu_affinity.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/linux/effective_cpu_freq.hpp
+++ b/framework/sysdeps/linux/effective_cpu_freq.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/linux/interrupt_monitor.cpp
+++ b/framework/sysdeps/linux/interrupt_monitor.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/linux/malloc.cpp
+++ b/framework/sysdeps/linux/malloc.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/linux/memfpt.cpp
+++ b/framework/sysdeps/linux/memfpt.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/linux/meson.build
+++ b/framework/sysdeps/linux/meson.build
@@ -1,3 +1,4 @@
+# Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 if (host_machine.cpu_family() == 'x86_64')

--- a/framework/sysdeps/linux/msr.c
+++ b/framework/sysdeps/linux/msr.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/linux/physicaladdress.cpp
+++ b/framework/sysdeps/linux/physicaladdress.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/linux/thermal_monitor.hpp
+++ b/framework/sysdeps/linux/thermal_monitor.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifdef __APPLE__

--- a/framework/sysdeps/unix/meson.build
+++ b/framework/sysdeps/unix/meson.build
@@ -1,4 +1,5 @@
 # -*- indent-tabs-mode: t -*-
+# Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 sysdeps_unix_files = files(

--- a/framework/sysdeps/unix/splitlock_detect.c
+++ b/framework/sysdeps/unix/splitlock_detect.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/unix/stacksize.cpp
+++ b/framework/sysdeps/unix/stacksize.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 #define _XOPEN_SOURCE 1

--- a/framework/sysdeps/unix/tmpfile.c
+++ b/framework/sysdeps/unix/tmpfile.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/aligned_alloc.c
+++ b/framework/sysdeps/windows/aligned_alloc.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/child_debug.cpp
+++ b/framework/sysdeps/windows/child_debug.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/fcntl.c
+++ b/framework/sysdeps/windows/fcntl.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/fcntl.h
+++ b/framework/sysdeps/windows/fcntl.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -1,3 +1,4 @@
+# Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 sysdeps_a = static_library(

--- a/framework/sysdeps/windows/mman.c
+++ b/framework/sysdeps/windows/mman.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/pthread.h
+++ b/framework/sysdeps/windows/pthread.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/sched.h
+++ b/framework/sysdeps/windows/sched.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/splitlock_detect.c
+++ b/framework/sysdeps/windows/splitlock_detect.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/sys/mman.h
+++ b/framework/sysdeps/windows/sys/mman.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/sys/uio.h
+++ b/framework/sysdeps/windows/sys/uio.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/sysexits.h
+++ b/framework/sysdeps/windows/sysexits.h
@@ -1,4 +1,5 @@
 /*-
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Copyright (c) 1987, 1993

--- a/framework/sysdeps/windows/tmpfile.c
+++ b/framework/sysdeps/windows/tmpfile.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/ucrt-mapping.c
+++ b/framework/sysdeps/windows/ucrt-mapping.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/unistd.c
+++ b/framework/sysdeps/windows/unistd.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/unistd.h
+++ b/framework/sysdeps/windows/unistd.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/sysdeps/windows/win32_stdlib.h
+++ b/framework/sysdeps/windows/win32_stdlib.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_knobs.cpp
+++ b/framework/test_knobs.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_knobs.h
+++ b/framework/test_knobs.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/AlphabeticalSelector.h
+++ b/framework/test_selectors/AlphabeticalSelector.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/ListFileSelector.h
+++ b/framework/test_selectors/ListFileSelector.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/OrderedSelector.h
+++ b/framework/test_selectors/OrderedSelector.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/PrioritizedSelector.h
+++ b/framework/test_selectors/PrioritizedSelector.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/SelectorFactory.cpp
+++ b/framework/test_selectors/SelectorFactory.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/SelectorFactory.h
+++ b/framework/test_selectors/SelectorFactory.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/TestrunSelectorBase.h
+++ b/framework/test_selectors/TestrunSelectorBase.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/WeightedNonRepeatingSelector.h
+++ b/framework/test_selectors/WeightedNonRepeatingSelector.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/WeightedRepeatingSelector.h
+++ b/framework/test_selectors/WeightedRepeatingSelector.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/WeightedSelectorBase.cpp
+++ b/framework/test_selectors/WeightedSelectorBase.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_selectors/WeightedSelectorBase.h
+++ b/framework/test_selectors/WeightedSelectorBase.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/test_weights.c
+++ b/framework/test_weights.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/unit-tests/WeightedTestSelector_tests.cpp
+++ b/framework/unit-tests/WeightedTestSelector_tests.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/unit-tests/sandstone_data_tests.cpp
+++ b/framework/unit-tests/sandstone_data_tests.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/unit-tests/sandstone_test_utils_tests.cpp
+++ b/framework/unit-tests/sandstone_test_utils_tests.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/unit-tests/sandstone_utils_tests.cpp
+++ b/framework/unit-tests/sandstone_utils_tests.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/unit-tests/test_knob_tests.cpp
+++ b/framework/unit-tests/test_knob_tests.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/framework/unit-tests/thermal_monitor_tests.cpp
+++ b/framework/unit-tests/thermal_monitor_tests.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
 # -*- indent-tabs-mode: t -*-
+# Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 project(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
+# Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 option('logging_format', type : 'combo', choices : ['yaml', 'tap', 'none'], value : 'yaml',

--- a/tests/eigen_gemm/double14.cpp
+++ b/tests/eigen_gemm/double14.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_gemm_double14

--- a/tests/eigen_gemm/gemm_cdouble_dynamic_square.cpp
+++ b/tests/eigen_gemm/gemm_cdouble_dynamic_square.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_gemm_cdouble_dynamic_square

--- a/tests/eigen_gemm/gemm_double_dynamic_square.cpp
+++ b/tests/eigen_gemm/gemm_double_dynamic_square.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_gemm_double_dynamic_square

--- a/tests/eigen_gemm/gemm_float_dynamic_square.cpp
+++ b/tests/eigen_gemm/gemm_float_dynamic_square.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_gemm_float_dynamic_square

--- a/tests/eigen_sparse/eigen_sparse.cpp
+++ b/tests/eigen_sparse/eigen_sparse.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_sparse

--- a/tests/eigen_svd/sandstone_eigen_common.h
+++ b/tests/eigen_svd/sandstone_eigen_common.h
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/tests/eigen_svd/svd.cpp
+++ b/tests/eigen_svd/svd.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_svd

--- a/tests/eigen_svd/svd_cdouble.cpp
+++ b/tests/eigen_svd/svd_cdouble.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_svd_cdouble

--- a/tests/eigen_svd/svd_cdouble_noavx512.cpp
+++ b/tests/eigen_svd/svd_cdouble_noavx512.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_svd_cdouble_noavx512

--- a/tests/eigen_svd/svd_double.cpp
+++ b/tests/eigen_svd/svd_double.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_svd_double

--- a/tests/eigen_svd/svd_fvectors.cpp
+++ b/tests/eigen_svd/svd_fvectors.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_svd_fvectors

--- a/tests/eigen_svd_jacobi/svd.cpp
+++ b/tests/eigen_svd_jacobi/svd.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_svd_jacobi

--- a/tests/eigen_svd_jacobi/svd_cdouble.cpp
+++ b/tests/eigen_svd_jacobi/svd_cdouble.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_svd_jacobi_cdouble

--- a/tests/eigen_svd_jacobi/svd_double.cpp
+++ b/tests/eigen_svd_jacobi/svd_double.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_svd_jacobi_double

--- a/tests/eigen_svd_jacobi/svd_fvectors.cpp
+++ b/tests/eigen_svd_jacobi/svd_fvectors.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b eigen_svd_jacobi_fvectors

--- a/tests/examples/simple_add.c
+++ b/tests/examples/simple_add.c
@@ -1,5 +1,6 @@
 /**
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b simple_add

--- a/tests/examples/vector_add.c
+++ b/tests/examples/vector_add.c
@@ -1,5 +1,6 @@
 /**
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b vector_add

--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/tests/mce_check/mce_check.cpp
+++ b/tests/mce_check/mce_check.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b mce_check

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,4 @@
+# Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 dep_static = get_option('dependency_link') == 'static'

--- a/tests/smi_count/smi_count.cpp
+++ b/tests/smi_count/smi_count.cpp
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b smi_count

--- a/tests/zlib/fuzz.c
+++ b/tests/zlib/fuzz.c
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b zfuzz

--- a/tests/zlib/test.c
+++ b/tests/zlib/test.c
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b zlib

--- a/tests/zstd/test.c
+++ b/tests/zstd/test.c
@@ -2,6 +2,7 @@
  * @file
  *
  * @copyright
+ * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * @test @b zstd


### PR DESCRIPTION
As required by SPDX[1] and Project REUSE[2].

[1] https://spdx.github.io/spdx-spec/file-information/#88-copyright-text-field

Says that it "Required: Yes"

[2] https://reuse.software/spec/
"The comment header MUST contain one or more SPDX-FileCopyrightText tags, and one or more SPDX-License-Identifier tags."
"A copyright notice MUST be prefixed by a tag, symbol or word denoting a copyright notice as described in this specification."

REUSE says "Copyright" suffices instead of the SPDX tag.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>