### PR TITLE
Fix control thread pinning

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1789,7 +1789,7 @@ static TestResult run_child(/*nonconst*/ struct test *test, SharedMemorySynchron
                             const SandstoneApplication::ExecState *app_state = nullptr)
 {
     if (sApp->current_fork_mode() != SandstoneApplication::no_fork) {
-        pin_to_logical_processor(LogicalProcessor(cpu_info[0].cpu_number), "control");
+        pin_to_logical_processor(LogicalProcessor(-1), "control");
         setup_child_signals();
         debug_init_child();
         shmemsync.prepare_child();

--- a/framework/sysdeps/freebsd/cpu_affinity.cpp
+++ b/framework/sysdeps/freebsd/cpu_affinity.cpp
@@ -23,6 +23,8 @@ bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
 {
     if (thread_name)
         pthread_set_name_np(pthread_self(), thread_name);
+    if (n == LogicalProcessor(-1))
+        return true;            // don't change affinity
 
     cpuset_t cpu_set;
     CPU_ZERO(&cpu_set);

--- a/framework/sysdeps/linux/cpu_affinity.cpp
+++ b/framework/sysdeps/linux/cpu_affinity.cpp
@@ -23,6 +23,8 @@ bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
 {
     if (thread_name)
         prctl(PR_SET_NAME, thread_name);
+    if (n == LogicalProcessor(-1))
+        return true;            // don't change affinity
 
     cpu_set_t cpu_set;
     CPU_ZERO(&cpu_set);

--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -58,6 +58,9 @@ LogicalProcessorSet ambient_logical_processor_set()
 
 bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
 {
+    if (n == LogicalProcessor(-1))
+        return true;            // don't change affinity
+
     PROCESSOR_NUMBER processorNumber = {};
     GROUP_AFFINITY groupAffinity = {};
     processorNumber.Group = processor_group_for(n);


### PR DESCRIPTION
We used to do that before March 2021, but thought better of it.
Unfortunately, I accidentally brought it back when I wrote the
abstracted sysdeps/*/cpu_affinity.cpp when I moved the thread naming
functionality into pin_to_logical_processor().

As a consequence, on Unix systems, run_threads() starts each of the
worker threads with the same affinity, so they're all competing for CPU
time on the same processor. They'll eventually move themselves off to
another CPU, but not without a lot of context-switching. On systems with
100+ logical processors (such as dual-socket CLX and ICX), that's a lot
of contention.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
