### PR TITLE
intel_ifs: cleanups and make product-quality

### DIFF
--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -44,8 +44,10 @@ static bool write_file(const char* filename, const char* value)
 
 static int scan_init(struct test *test)
 {
-        /* modprobe kernel driver, ignore errors entirely here */
-        IGNORE_RETVAL(system("/sbin/modprobe intel_ifs"));
+        if (access("/sys/devices/system/cpu/cpu0/ifs/status", R_OK) != 0) {
+                /* modprobe kernel driver, ignore errors entirely here */
+                IGNORE_RETVAL(system("/sbin/modprobe intel_ifs"));
+        }
 
         /* first check if there is basic kernel support with the API we support */
         if ((access("/sys/devices/system/cpu/ifs/run_test", W_OK) != 0) ||

--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -25,9 +25,6 @@
 
 static pthread_mutex_t scanmutex = PTHREAD_MUTEX_INITIALIZER;
 
-// static because we only every want to do this once per machine
-static bool initialized = false;
-
 #define BUFLEN 256 // kernel module prints at most a 64bit value
 
 static bool write_file(const char* filename, const char* value)
@@ -47,12 +44,6 @@ static bool write_file(const char* filename, const char* value)
 
 static int scan_init(struct test *test)
 {
-        // fracture may cause this function to be called several times.
-        if (initialized)
-                return 0;
-
-        initialized = true;
-
         /* modprobe kernel driver, ignore errors entirely here */
         IGNORE_RETVAL(system("/sbin/modprobe intel_ifs"));
 

--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -21,6 +21,8 @@
 
 #include <sandstone.h>
 
+#if defined(__x86_64__) && defined(__linux__)
+
 static pthread_mutex_t scanmutex = PTHREAD_MUTEX_INITIALIZER;
 
 // static because we only every want to do this once per machine
@@ -127,3 +129,5 @@ DECLARE_TEST(ifs, "IFS hardware selftest")
     .fracture_loop_count = -1,
     .max_threads = 1,
 END_DECLARE_TEST
+
+#endif // __x86_64__ && __linux__

--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -134,8 +134,8 @@ static int scan_run(struct test *test, int cpu)
         return 0;
 }
 
-DECLARE_TEST(ifs, "IFS hardware selftest")
-    .quality_level = TEST_QUALITY_BETA,
+DECLARE_TEST(ifs, "Intel In-Field Scan (IFS) hardware selftest")
+    .quality_level = TEST_QUALITY_PROD,
     .test_init = scan_init,
     .test_run = scan_run,
     .desired_duration = -1,


### PR DESCRIPTION
* Use `fork()` + `exec()` instead of `system()`
* Only build it on Linux/x86-64
* Don't produce errors if the /sys interface is already present
* Bump it to production quality