### PR TITLE
FW: Add CPU Frequency Manager

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2024,6 +2024,19 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
         sApp->current_max_loop_count = test->fracture_loop_count;
     }
 
+    // Apply frequency changes if needed
+    if (sApp->fixed_frequency != -1 && test->variable_frequencies == 1) {
+        // Set fixed frequency
+    }
+    else if (sApp->alternate_frequency && test->variable_frequencies == 1) {
+        // Alternate frequency
+    }
+    else if (sApp->alternate_frequency || sApp->fixed_frequency != -1) {
+        if (test->variable_frequencies == 0) {
+            // Set max frequency back to normal
+        }
+    }
+
     assert(sApp->retest_count >= 0);
 
     /* First we go to do our -- possibly fractured -- normal run, we'll do retries after */

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -290,7 +290,7 @@ static void signal_handler(int signum)
     uint32_t expected = 0;
     if (signal_control.compare_exchange_strong(expected, W_EXITCODE(1, signum), std::memory_order_relaxed)) {
         // initial clean up
-        //FrequencyManager::restore_max_frequency();
+        sApp->frequency_manager.restore_max_frequency(sApp->enabled_cpus.count());
     } else {
         // just increment the counter
         signal_control.fetch_add(W_EXITCODE(1, 0), std::memory_order_relaxed);
@@ -2028,13 +2028,16 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
     // Apply frequency changes if needed
     if (sApp->fixed_frequency != -1 && test->variable_frequencies == 1) {
         // Set fixed frequency
+        sApp->frequency_manager.set_fixed_frequency(sApp->enabled_cpus.count(), sApp->fixed_frequency);
     }
     else if (sApp->alternate_frequency && test->variable_frequencies == 1) {
         // Alternate frequency
+        sApp->frequency_manager.alternate_frequency();
     }
     else if (sApp->alternate_frequency || sApp->fixed_frequency != -1) {
         if (test->variable_frequencies == 0) {
             // Set max frequency back to normal
+            sApp->frequency_manager.restore_max_frequency(sApp->enabled_cpus.count());
         }
     }
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2032,7 +2032,7 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
     }
     else if (sApp->alternate_frequency && test->variable_frequencies == 1) {
         // Alternate frequency
-        sApp->frequency_manager.alternate_frequency();
+        sApp->frequency_manager.alternate_frequency(sApp->enabled_cpus.count());
     }
     else if (sApp->alternate_frequency || sApp->fixed_frequency != -1) {
         if (test->variable_frequencies == 0) {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -290,6 +290,7 @@ static void signal_handler(int signum)
     uint32_t expected = 0;
     if (signal_control.compare_exchange_strong(expected, W_EXITCODE(1, signum), std::memory_order_relaxed)) {
         // initial clean up
+        //FrequencyManager::restore_max_frequency();
     } else {
         // just increment the counter
         signal_control.fetch_add(W_EXITCODE(1, 0), std::memory_order_relaxed);
@@ -3113,7 +3114,10 @@ int main(int argc, char **argv)
                 return EX_USAGE;
             }
             else
-                sApp->fixed_frequency=set_fixed_frequency; // Do ParseInt
+                sApp->fixed_frequency=ParseIntArgument<>{
+                        .min = sApp->frequency_manager.get_min_supported_freq(),
+                        .max = sApp->frequency_manager.get_max_supported_freq(),
+                }();
             break;
         case ignore_os_errors_option:
             sApp->ignore_os_errors = true;

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -387,6 +387,11 @@ struct test {
     /// free them in the test_cleanup function.
     void *data;
     struct test_data_per_thread *per_thread;
+
+    /// wheter frequency flags apply to this test or not.
+    /// 0       default (for now). Ignore frequency flags
+    /// 1       Honor frequency flags
+    int variable_frequencies;
 };
 
 /* internal function; see C macro and C++ templates at the end of this file */

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -295,7 +295,6 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
 
     bool fatal_skips = false;
     bool use_strict_runtime = false;
-
     ScheduleBy schedule_by = ScheduleBy::Thread;
     ForkMode fork_mode =
 #ifdef _WIN32
@@ -314,6 +313,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     bool force_test_time = false;
     bool ud_on_failure = false;
     bool service_background_scan = false;
+    bool alternate_frequency = false;
     static constexpr int MaxRetestCount = 64;
     int retest_count = 10;
     int total_retest_count = -2;
@@ -324,6 +324,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     int current_max_threads;
     int current_slice_count = 1;
     int current_iteration_count;        // iterations of the same test (positive for fracture; negative for retest)
+    int fixed_frequency = -1;
     MonotonicTimePoint starttime;
     MonotonicTimePoint endtime;
     MonotonicTimePoint current_test_starttime;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -35,6 +35,7 @@
 #include <sandstone_utils.h>
 
 #include "effective_cpu_freq.hpp"
+#include "frequency_manager.hpp"
 #include "topology.h"
 #include "interrupt_monitor.hpp"
 #include "thermal_monitor.hpp"
@@ -335,6 +336,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     Duration delay_between_tests = std::chrono::milliseconds(5);
 
     std::unique_ptr<RandomEngineWrapper, RandomEngineDeleter> random_engine;
+    FrequencyManager frequency_manager;
 
     LogicalProcessorSet enabled_cpus;
     int thread_count;

--- a/framework/sysdeps/darwin/frequency_manager.hpp
+++ b/framework/sysdeps/darwin/frequency_manager.hpp
@@ -1,0 +1,1 @@
+#include "../generic/frequency_manager.hpp"

--- a/framework/sysdeps/freebsd/frequency_manager.hpp
+++ b/framework/sysdeps/freebsd/frequency_manager.hpp
@@ -1,0 +1,1 @@
+#include "../generic/frequency_manager.hpp"

--- a/framework/sysdeps/generic/frequency_manager.hpp
+++ b/framework/sysdeps/generic/frequency_manager.hpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GENERIC_FREQUENCY_MANAGER_HPP
+#define GENERIC_FREQUENCY_MANAGER_HPP
+
+#include <limits>
+
+/*
+ * The "do nothing" placeholder version
+ */
+class FrequencyManager
+{
+public:
+    FrequencyManager() { }
+    void alternate_frequency() { }
+    void set_fixed_frequency() { }
+    void restore_max_frequency() { }
+    int get_min_supported_freq() { }
+    int get_max_supported_freq() { }
+};
+
+#endif //GENERIC_FREQUENCY_MANAGER_HPP

--- a/framework/sysdeps/generic/frequency_manager.hpp
+++ b/framework/sysdeps/generic/frequency_manager.hpp
@@ -16,8 +16,8 @@ class FrequencyManager
 public:
     FrequencyManager() { }
     void alternate_frequency() { }
-    void set_fixed_frequency() { }
-    void restore_max_frequency() { }
+    void set_fixed_frequency(int cpu_number, int max_freq_i) { }
+    void restore_max_frequency(int cpu_number) { }
     int get_min_supported_freq() { }
     int get_max_supported_freq() { }
 };

--- a/framework/sysdeps/linux/frequency_manager.hpp
+++ b/framework/sysdeps/linux/frequency_manager.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GENERIC_FREQUENCY_MANAGER_HPP
+#define GENERIC_FREQUENCY_MANAGER_HPP
+
+#ifndef __x86_64__
+#  include "../generic/frequency_manager.hpp"
+#else
+
+#include <limits>
+#include <fstream>
+
+#define DEFAULT_SYS_PATH "/sys/devices/system/cpu/"
+
+class FrequencyManager
+{
+public:
+    FrequencyManager()
+    {
+        /* Discover supported and current frequencies */
+    }
+
+    void alternate_frequency()
+    {
+        /* Based on max current frequency, set low value when current is high,
+         * or set high if current is low. */
+    }
+
+    void set_fixed_frequency()
+    {
+        /* Set given frequency as long as it is supported */
+    }
+
+    void restore_max_frequency()
+    {
+        /* Restore frequency to its original value */
+    }
+
+    int get_min_supported_freq()
+    {
+        return min_freq_supported;
+    }
+
+    int get_max_supported_freq()
+    {
+        return max_freq_supported;
+    }
+
+private:
+
+    int max_freq_supported;
+    int min_freq_supported;
+    int max_freq_initial;
+    int max_freq_current;
+};
+#endif
+#endif //GENERIC_FREQUENCY_MANAGER_HPP

--- a/framework/sysdeps/linux/frequency_manager.hpp
+++ b/framework/sysdeps/linux/frequency_manager.hpp
@@ -12,8 +12,13 @@
 
 #include <limits>
 #include <fstream>
+#include <filesystem>
 
-#define DEFAULT_SYS_PATH "/sys/devices/system/cpu/"
+#define DEFAULT_SYS_PATH        "/sys/devices/system/cpu/cpu"
+#define CPUINFO_MAX_FREQ_F      "cpuinfo_max_freq"
+#define CPUINFO_MIN_FREQ_F      "cpuinfo_min_freq"
+#define SCALING_MAX_FREQ_P      "/cpufreq/scaling_max_freq"
+#define KHZ                     100000
 
 class FrequencyManager
 {
@@ -21,22 +26,58 @@ public:
     FrequencyManager()
     {
         /* Discover supported and current frequencies */
+        std::filesystem::path cpuinfo_max_freq_p = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq";
+        max_freq_supported = get_frequency_from_file(cpuinfo_max_freq_p);
+
+        std::filesystem::path cpuinfo_min_freq_p = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq";
+        min_freq_supported = get_frequency_from_file(cpuinfo_min_freq_p);
+
+        std::filesystem::path scaling_max_freq_p = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq";
+        max_freq_initial = get_frequency_from_file(scaling_max_freq_p);
+        max_freq_current = max_freq_initial;
     }
 
     void alternate_frequency()
     {
         /* Based on max current frequency, set low value when current is high,
          * or set high if current is low. */
+        // If current is between max and max - 10
+        //  - return random(min, min+10)
+        // If current is between min and min + 10
+        //  - return random(max, max-10)
+        // Otherwise, could mean we are having a random one,
+        // we can either chose high or low
     }
 
-    void set_fixed_frequency()
+    void set_fixed_frequency(int cpu_number, int max_freq_i)
     {
         /* Set given frequency as long as it is supported */
+        std::filesystem::path scaling_max_freq_p;
+
+        // Assure required frequency is between min and max
+        if (max_freq_i > max_freq_supported || max_freq_i < min_freq_supported)
+            return;
+
+        // Convert to KHz and string
+        std::string max_freq_s = std::to_string(max_freq_i * KHZ);
+
+        for (int i=0; i< cpu_number; i++)
+        {
+            // Concatenate path
+            scaling_max_freq_p = DEFAULT_SYS_PATH;
+            scaling_max_freq_p += std::to_string(i);
+            scaling_max_freq_p += SCALING_MAX_FREQ_P;
+            
+            write_file(scaling_max_freq_p, max_freq_s);
+        }
+        // Update current freq
+        max_freq_current = max_freq_i;
     }
 
-    void restore_max_frequency()
+    void restore_max_frequency(int cpu_number)
     {
         /* Restore frequency to its original value */
+        set_fixed_frequency(cpu_number, max_freq_initial);
     }
 
     int get_min_supported_freq()
@@ -50,6 +91,40 @@ public:
     }
 
 private:
+
+    std::string read_file(std::filesystem::path f_path)
+    {
+        /* Read first line of given file */
+        std::string line;
+        std::ifstream in_file(f_path.c_str());
+
+        if (in_file.good())
+            getline(in_file, line);
+
+        in_file.close();
+        return line;
+    }
+
+    void write_file(std::filesystem::path f_path, std::string line)
+    {
+        /* Write first line of given file */
+        std::ofstream out_file(f_path, std::ofstream::out);
+        if (out_file.good())
+            out_file.write(line.c_str(), line.length());
+
+        out_file.close();
+    }
+
+    int get_frequency_from_file(std::filesystem::path f_path)
+    {
+        /* Read and convert value from file */
+        int value;
+        std::string line = read_file(f_path);
+
+        value = std::stod(line);
+        value = value/KHZ;
+        return value;
+    }
 
     int max_freq_supported;
     int min_freq_supported;

--- a/framework/sysdeps/linux/frequency_manager.hpp
+++ b/framework/sysdeps/linux/frequency_manager.hpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <fstream>
 #include <filesystem>
+#include <sandstone.h>
 
 #define DEFAULT_SYS_PATH        "/sys/devices/system/cpu/cpu"
 #define CPUINFO_MAX_FREQ_F      "cpuinfo_max_freq"
@@ -37,16 +38,19 @@ public:
         max_freq_current = max_freq_initial;
     }
 
-    void alternate_frequency()
+    void alternate_frequency(int cpu_number)
     {
         /* Based on max current frequency, set low value when current is high,
          * or set high if current is low. */
-        // If current is between max and max - 10
-        //  - return random(min, min+10)
-        // If current is between min and min + 10
-        //  - return random(max, max-10)
-        // Otherwise, could mean we are having a random one,
-        // we can either chose high or low
+        int middle_freq = max_freq_supported;
+        int deviation = random32() % 10;
+        int alternating_freq;
+        if (max_freq_current >= middle_freq)
+            alternating_freq = max_freq_supported - deviation;
+        else
+            alternating_freq = min_freq_supported + deviation;
+
+        set_fixed_frequency(cpu_number, alternating_freq);
     }
 
     void set_fixed_frequency(int cpu_number, int max_freq_i)

--- a/framework/sysdeps/unix/frequency_manager.hpp
+++ b/framework/sysdeps/unix/frequency_manager.hpp
@@ -1,0 +1,1 @@
+#include "../generic/frequency_manager.hpp"

--- a/framework/sysdeps/windows/frequency_manager.hpp
+++ b/framework/sysdeps/windows/frequency_manager.hpp
@@ -1,0 +1,1 @@
+#include "../generic/frequency_manager.hpp"


### PR DESCRIPTION
The end goal of this is adding an option that allows OpenDcdiag tool to change randomly CPU frequency during runtime.

NOTE: This is a WIP PR, so some things still don't work and some others are simply hard-coded.

Signed-off-by: Athenas Jimenez <athenas.jimenez.gonzalez@intel.com>