### PR TITLE
ifs: suppress modprobe's error if it can't find the module

### DIFF
--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -51,7 +51,7 @@ static int scan_init(struct test *test)
                 /* modprobe kernel driver, ignore errors entirely here */
                 pid_t pid = fork();
                 if (pid == 0) {
-                        execl("/sbin/modprobe", "/sbin/modprobe", "intel_ifs", NULL);
+                        execl("/sbin/modprobe", "/sbin/modprobe", "-q", "intel_ifs", NULL);
 
                         /* don't print an error if /sbin/modprobe wasn't found, but
                            log_debug() is fine (since the parent is waiting, we can


### PR DESCRIPTION
It is either telling us that the module doesn't exist or that we don't
have permissions to load it. Neither is a fatal issue so we shouldn't
let this be shown in logging verbosity 1.

According to kernel developers, the module should be auto-loaded on
machines that have IFS support, so the modprobe shouldn't even be
needed. However, on the machines we tested, that autoloading was somehow
broken, so we're choosing to leave it in.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>