### PR TITLE
intel_ifs driver update

### DIFF
--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -88,6 +88,9 @@ static int scan_run(struct test *test, int cpu)
         char filename[PATH_MAX];
         char result[BUFLEN];
 
+        if (cpu_info[cpu].thread_id != 0)
+                return EXIT_SKIP;
+
         sprintf(filename, "/sys/devices/system/cpu/cpu%d/ifs/status", cpu_info[cpu].cpu_number);
 
         for (;;) {

--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -51,7 +51,7 @@ static int scan_init(struct test *test)
                 /* modprobe kernel driver, ignore errors entirely here */
                 pid_t pid = fork();
                 if (pid == 0) {
-                        execl("/sbin/modprobe", "/sbin/modprobe", "intel_ifs", NULL);
+                        execl("/sbin/modprobe", "/sbin/modprobe", "-q", "intel_ifs", NULL);
 
                         /* don't print an error if /sbin/modprobe wasn't found, but
                            log_debug() is fine (since the parent is waiting, we can


### PR DESCRIPTION
The sysfs API that was accepted into 5.19 differs slightly from the preliminary API that this code was written for.

This includes support for future "intel_ifs_#" tests and handles the timeout error codes.

Docs: https://docs.kernel.org/x86/ifs.html
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
