### PR TITLE
modified docs/writing_tests.md to correct build errors

### DIFF
--- a/docs/writing_tests.md
+++ b/docs/writing_tests.md
@@ -364,7 +364,7 @@ it. This can be done by adding the following lines to the
 [meson.build](../tests/meson.build) file in the tests directory and rebuilding.
 
 ```
-tests_base_skx_set.add(
+tests_skx_set.add(
         'examples/vector_add.c'
 )
 ```


### PR DESCRIPTION
Was playing around opendcdiag. Encountered "Failed build" issue when adding the following test case.

```
tests_base_skx_set.add(
        'examples/vector_add.c'
)
```
Pasting the error message.

```Checking for type "_Float16" : YES (cached)
Checking for type "_Float16" : YES (cached)
Checking for type "__fp16" : NO (cached)

**../tests/meson.build:42:19: ERROR: Unknown variable "tests_base_skx_set".**

A full log can be found at /home/xxxx/DilipMain/OpenDCDiag/DilipDCDiag/builddir/meson-logs/meson-log.txt
FAILED: build.ninja
/usr/bin/meson --internal regenerate /home/xxxx/DilipMain/OpenDCDiag/DilipDCDiag
```

Resolved by removing `base` in `test_base_skx_set.add`.

