### PR TITLE
forkfd: implement vfork(2) support

### DIFF
--- a/framework/forkfd/forkfd.h
+++ b/framework/forkfd/forkfd.h
@@ -53,6 +53,7 @@ struct forkfd_info {
 };
 
 int forkfd(int flags, pid_t *ppid);
+int vforkfd(int flags, pid_t *ppid, int (*childFn)(void *), void *token);
 int forkfd_wait4(int ffd, struct forkfd_info *info, int options, struct rusage *rusage);
 static inline int forkfd_wait(int ffd, struct forkfd_info *info, struct rusage *rusage)
 {

--- a/framework/forkfd/forkfd_freebsd.c
+++ b/framework/forkfd/forkfd_freebsd.c
@@ -29,6 +29,8 @@
 
 #include "forkfd_atomic.h"
 
+#undef SYSTEM_FORKFD_CAN_VFORK
+
 // in forkfd.c
 static int convertForkfdWaitFlagsToWaitFlags(int ffdoptions);
 static void convertStatusToForkfdInfo(int status, struct forkfd_info *info);
@@ -56,7 +58,7 @@ int system_forkfd(int flags, pid_t *ppid, int *system)
     if (state < 0)
         return -1;
 
-    pid = pdfork(&ret, PD_DAEMON | PD_CLOEXEC);
+    pid = pdfork(&ret, PD_DAEMON);
 #  if __FreeBSD__ == 9
     if (state == 0 && pid != 0) {
         /* Parent process: remember whether PROCDESC was compiled into the kernel */
@@ -76,8 +78,8 @@ int system_forkfd(int flags, pid_t *ppid, int *system)
     }
 
     /* parent process */
-    if ((flags & FFD_CLOEXEC) == 0)
-        fcntl(ret, F_SETFD, 0);
+    if (flags & FFD_CLOEXEC)
+        fcntl(ret, F_SETFD, FD_CLOEXEC);
     if (flags & FFD_NONBLOCK)
         fcntl(ret, F_SETFL, fcntl(ret, F_GETFL) | O_NONBLOCK);
     if (ppid)


### PR DESCRIPTION
fork() works by implementing Copy-On-Write for all pages that either the
parent or the child process write to. So if the parent process continues
running while the child is between fork(2) and execve(2), then it will
keep causing page faults and requiring the OS to duplicate those pages,
with the accompanying page table update and a TLB flush. This problem
is aggravated if the parent process is multithreaded, as the simple act
of running in the parent will cause those threads' stacks to cause page
faults.

The BSD solution for that was vfork(), which has two differences in
behavior: it blocks the parent from running and it shares memory with
it. But it's always been tricky, so POSIX.1-2001 deprecated it and 2008
removed its definition completely. Because it is still sharing the same
pages, we can't return from the forkfd() function, so to implement this
functionality vforkfd() adds a callback of the same signature as glibc's
clone(2) wrapper (something that hadn't occurred to me when we attempted
to use CLONE_VFORK last time).

On FreeBSD, we ignore the request for vfork() and simply call
pdfork(). It's a compliant implementation for fork() and vfork() to be
identical, so we make it so for forkfd() and vforkfd().

On other OSes, use of vfork() is not possible, because forkfd() requires
the parent to run before the child execve()s, in order to save the child
PID in the list of children we're going to handle SIGCHLD for in a
non-racy way.

Fixes https://bugreports.qt.io/browse/QTBUG-104493. Matching Qt review:
https://codereview.qt-project.org/c/qt/qtbase/+/417829

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>