### PR TITLE
meson: correct DEBUG, NDEBUG handling

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -66,8 +66,6 @@ framework_config.set10('SANDSTONE_GA_DEV', get_option('flavor') == 'ga-dev')
 framework_config.set10('SANDSTONE_NO_LOGGING', get_option('flavor') == 'ga')
 framework_config.set10('SANDSTONE_RESTRICTED_CMDLINE', get_option('cmdline') == 'restricted')
 
-framework_config.set10('SANDSTONE_DEBUG', get_option('b_ndebug') == 'false')
-
 framework_config.set10('SANDSTONE_CHILD_BACKTRACE', get_option('child_backtrace'))
 
 framework_config_h = configure_file(

--- a/framework/sandstone_config.h.in
+++ b/framework/sandstone_config.h.in
@@ -6,7 +6,17 @@
 #ifndef SANDSTONE_CONFIG_H
 #define SANDSTONE_CONFIG_H
 
-#mesondefine SANDSTONE_DEBUG
+#if !defined(DEBUG) && !defined(NDEBUG)
+#  define DEBUG 1
+#endif
+
+#if defined(DEBUG) && defined(NDEBUG)
+#  pragma message "DEBUG and NDEBUG macros were both defined. Defining DEBUG macro only."
+#  undef NDEBUG
+#elif defined(NDEBUG)
+#  define DEBUG 0
+#endif
+
 #mesondefine SANDSTONE_STATIC
 
 #mesondefine SANDSTONE_GA
@@ -20,7 +30,7 @@
 #ifdef __cplusplus
 
 namespace SandstoneConfig {
-static constexpr bool Debug = SANDSTONE_DEBUG;
+static constexpr bool Debug = DEBUG;
 static constexpr bool StaticLink = SANDSTONE_STATIC;
 
 static constexpr bool GeneralAvailability = SANDSTONE_GA;


### PR DESCRIPTION
First time around, I wasn't setting SANDSTONE_DEBUG correctly. Silly me.

Then, it was realized that SANDSTONE_DEBUG wasn't necessary. So, brought back DEBUG and preprocessor handling for the DEBUG, NDEBUG macros in sandstone_config.h.

Signed-off-by: Joe Konno <joe.konno@intel.com>