### PR TITLE
meson: fix set10 deprecation warning

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 framework_config = configuration_data()
-framework_config.set10('SANDSTONE_STATIC', 0) # sysdeps may override
+framework_config.set10('SANDSTONE_STATIC', false) # sysdeps may override
 
 sysdeps_dir = 'sysdeps/' + target_machine.system()
 

--- a/framework/sysdeps/unix/meson.build
+++ b/framework/sysdeps/unix/meson.build
@@ -10,5 +10,5 @@ sysdeps_unix_files = files(
 
 # same check as linux/meson.build
 if get_option('cpp_link_args').contains('-static')
-	framework_config.set10('SANDSTONE_STATIC', 1)
+	framework_config.set10('SANDSTONE_STATIC', true)
 endif


### PR DESCRIPTION
set10() needs to be called with a boolean, rather than an integer. Looks like
the integer argument was deprecated.

Signed-off-by: Joe Konno <joe.konno@intel.com>