### PR TITLE
FW: add a way to specify a version suffix

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -90,6 +90,8 @@ RtlGetVersion(
 #  include <gnu/libc-version.h>
 #endif
 
+#define PROGRAM_VERSION         EXECUTABLE_NAME "-" GIT_ID
+
 static int real_stdout_fd = STDOUT_FILENO;
 static int tty = -1;
 static int file_log_fd = -1;
@@ -894,18 +896,18 @@ static void print_reproduction_details()
 {
     switch (current_output_format()) {
     case SandstoneApplication::OutputFormat::key_value:
-        logging_printf(LOG_LEVEL_QUIET, "version = " EXECUTABLE_NAME "-" GIT_ID "\n");
+        logging_printf(LOG_LEVEL_QUIET, "version = " PROGRAM_VERSION "\n");
         logging_printf(LOG_LEVEL_QUIET, "current_time = %s\n", iso8601_time_now(Iso8601Format::WithMs));
         logging_printf(LOG_LEVEL_VERBOSE(1), "os = %s\n", os_info().c_str());
         return;
 
     case SandstoneApplication::OutputFormat::tap:
-        logging_printf(LOG_LEVEL_QUIET, "# Built from git commit: " GIT_ID "\n");
+        logging_printf(LOG_LEVEL_QUIET, "# Built from git commit: " PROGRAM_VERSION "\n");
         logging_printf(LOG_LEVEL_QUIET, "# Current time: %s\n", iso8601_time_now(Iso8601Format::WithMs));
         break;
 
     case SandstoneApplication::OutputFormat::yaml:
-        logging_printf(LOG_LEVEL_QUIET, "version: " EXECUTABLE_NAME "-" GIT_ID "\n");
+        logging_printf(LOG_LEVEL_QUIET, "version: " PROGRAM_VERSION "\n");
         // timestamp in the iteration start
         break;
 
@@ -914,6 +916,11 @@ static void print_reproduction_details()
         __builtin_unreachable();
         break;
     }
+}
+
+void logging_print_version()
+{
+    printf(PROGRAM_VERSION "\n");
 }
 
 void logging_print_header(int argc, char **argv, Duration test_duration, Duration test_timeout)
@@ -1917,7 +1924,7 @@ void TapFormatLogger::maybe_print_yaml_marker(int fd)
     std::string_view nothing;
     terminator = yamlseparator;
     writeln(fd, yamlseparator,
-            "\n  info: {version: " GIT_ID
+            "\n  info: {version: " PROGRAM_VERSION
             ", timestamp: ", iso8601_time_now(Iso8601Format::WithoutMs),
             cpu_has_feature(cpu_feature_hypervisor) ? ", virtualized: true" : nothing,
             "}");

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -90,7 +90,11 @@ RtlGetVersion(
 #  include <gnu/libc-version.h>
 #endif
 
-#define PROGRAM_VERSION         EXECUTABLE_NAME "-" GIT_ID
+#ifdef SANDSTONE_VERSION_SUFFIX
+#  define PROGRAM_VERSION         EXECUTABLE_NAME "-" GIT_ID "-" SANDSTONE_VERSION_SUFFIX
+#else
+#  define PROGRAM_VERSION         EXECUTABLE_NAME "-" GIT_ID
+#endif
 
 static int real_stdout_fd = STDOUT_FILENO;
 static int tty = -1;

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -69,6 +69,10 @@ framework_config.set10('SANDSTONE_RESTRICTED_CMDLINE', get_option('cmdline') == 
 framework_config.set10('SANDSTONE_DEBUG', get_option('b_ndebug') == 'false')
 
 framework_config.set10('SANDSTONE_CHILD_BACKTRACE', get_option('child_backtrace'))
+if get_option('version_suffix') != ''
+	framework_config.set_quoted('SANDSTONE_VERSION_SUFFIX', get_option('version_suffix'),
+		description: 'Suffix to show in the tool version')
+endif
 
 framework_config_h = configure_file(
 	input : 'sandstone_config.h.in',

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3109,7 +3109,7 @@ int main(int argc, char **argv)
             break;
 
         case version_option:
-            printf(EXECUTABLE_NAME "-" GIT_ID "\n");
+            logging_print_version();
             return EXIT_SUCCESS;
         case one_sec_option:
             sApp->test_list_randomize = true;

--- a/framework/sandstone_config.h.in
+++ b/framework/sandstone_config.h.in
@@ -14,8 +14,9 @@
 
 #mesondefine SANDSTONE_NO_LOGGING
 #mesondefine SANDSTONE_RESTRICTED_CMDLINE
-
 #mesondefine SANDSTONE_CHILD_BACKTRACE
+
+#mesondefine SANDSTONE_VERSION_SUFFIX
 
 #ifdef __cplusplus
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -499,6 +499,7 @@ void logging_print_header(int argc, char **argv, Duration test_duration, Duratio
 void logging_print_iteration_start();
 void logging_print_footer();
 void logging_print_triage_results(const std::vector<int> &sockets);
+void logging_print_version(void);
 void logging_flush(void);
 void logging_init(const struct test *test);
 void logging_init_child_prefork(SandstoneApplication::ExecState *state);

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,6 +19,8 @@ option('fallback_exec', type : 'string', value : '',
 	description : 'Executable to run if processor does not support required features (e.g. AVX2)')
 option('selftests', type : 'boolean', value : true,
 	description : 'Build in selftests (default true)')
+option('version_suffix', type : 'string', value: '',
+	description : 'Suffix to be added to the version number (e.g., build variant)')
 option('flavor', type : 'combo', choices : ['default', 'ga', 'ga-dev'], value : 'default',
 	description : 'Select one of the novel build flavors (ga, ga-dev) or the default')
 option('cmdline', type : 'combo', choices : ['full', 'restricted'], value : 'full',


### PR DESCRIPTION
We have multiple builds of our internal tool and we actually have a good CI process where everything gets build from the same source... but then we can't tell apart runs from different builds by just looking at the logs. So add a way for providing suffixes.
```
$ meson configure -Dversion_suffix=thiago
$ ninja
[48/48] Linking target opendcdiag
$ ./opendcdiag --version
opendcdiag-3a84c774ec3e-thiago
```
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
