### PR TITLE
FW: Change the memory randomisation from malloc() to mmap()

### DIFF
--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -155,6 +155,26 @@ static int selftest_logs_options_init(struct test *test)
     return EXIT_SUCCESS;
 }
 
+static int log_stack_and_heap_address()
+{
+    alignas(4096) char i;
+    void *ptr = aligned_alloc(4096, 4096);
+    log_info("stack: %p heap: %p", &i, ptr);
+    usleep(5000);   // 5 ms
+    free(ptr);
+    return EXIT_SUCCESS;
+}
+
+static int selftest_logs_stackandheap_init(struct test *test)
+{
+    return log_stack_and_heap_address();
+}
+
+static int selftest_logs_stackandheap_run(struct test *test, int cpu)
+{
+    return log_stack_and_heap_address();
+}
+
 static int selftest_skip_init(struct test *test)
 {
     log_info("Requesting skip (this message should be visible)");
@@ -716,6 +736,13 @@ static struct test selftests_array[] = {
     .test_init = selftest_logs_options_init,
     .test_run = selftest_pass_run,
     .desired_duration = -1,
+},
+{
+    .id = "selftest_logs_stackandheap",
+    .description = "Logs the thread's stack and heap pointers",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_init = selftest_logs_stackandheap_init,
+    .test_run = selftest_logs_stackandheap_run,
 },
 {
     .id = "selftest_skip",


### PR DESCRIPTION
The malloc() call wasn't helping much. It was indeed moving the heap
allocation pointer for the main thread, but that had never affected the
worker threads. Moreover, since commit 4248649b550477eb299efcdbfd35be85b
(PR #82), the init() function isn't run in the main thread either, so
not even memory allocated in the tests' init functions would be
randomised.

Instead, if we use mmap(), we shift the entire address space, causing
the stacks and malloc() arenas to shift.

Implementation detail: because we use pthread_create() in
load_cpu_info(), libpthread has created at least one mmap for a thread's
stack. As of version 2.35, it caches that, so the stack will be used for
the thread for init() and for thread_num == 0. Moreover, the threaded
code in load_cpu_info() allocates memory, so a large (128 MB) arena is
created for it too.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>