### PR TITLE
FW: move the CPU-supported checking into sandstone_main()

### DIFF
--- a/framework/main.cpp
+++ b/framework/main.cpp
@@ -113,12 +113,9 @@ static void premain(int argc, char **argv, char **envp)
     (void) envp;
 
     // initialize CPU detection
-    cpu_basic_info cpu_info;
-    detect_cpu(&cpu_info);
-    cpu_features = cpu_info.features;
+    cpu_features = detect_cpu();
     if (minimum_cpu_features & ~cpu_features)
         fallback_exec(argv);
     check_missing_features(cpu_features, minimum_cpu_features);
-    is_system_supported(&cpu_info);
 }
 }

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -75,6 +75,14 @@ struct mmap_region
     size_t size;        /* actual size, not rounded up to page */
 };
 
+/*
+ * Called from sandstone_main(). The default weak implementations perform no
+ * checks, they just return. Feel free to implement a strong version elsewhere
+ * if you prefer the framework to check for system or CPU criteria.
+ */
+void cpu_specific_init(void);
+int cpu_specific_finish(int exit_code);
+
 /* child_debug.cpp */
 void debug_init_child(void);
 void debug_init_global(const char *on_hang_arg, const char *on_crash_arg);


### PR DESCRIPTION
Benefits:
* Can use the loaded CPU info from load_cpu_info()
* Runs after the command-line is processed, so --version and --help work
* Adds some code after the execution, to maybe modify it

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>