### PR TITLE
Meson: fix the version suffix when the commit is tagged

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -90,11 +90,7 @@ RtlGetVersion(
 #  include <gnu/libc-version.h>
 #endif
 
-#ifdef SANDSTONE_VERSION_SUFFIX
-#  define PROGRAM_VERSION         EXECUTABLE_NAME "-" GIT_ID "-" SANDSTONE_VERSION_SUFFIX
-#else
-#  define PROGRAM_VERSION         EXECUTABLE_NAME "-" GIT_ID
-#endif
+#define PROGRAM_VERSION         EXECUTABLE_NAME "-" GIT_ID
 
 static int real_stdout_fd = STDOUT_FILENO;
 static int tty = -1;

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -64,10 +64,6 @@ framework_config.set('SANDSTONE_DEFAULT_LOGGING', 'SandstoneApplication::OutputF
 
 framework_config.set10('SANDSTONE_RESTRICTED_CMDLINE', get_option('cmdline') == 'restricted')
 framework_config.set10('SANDSTONE_CHILD_BACKTRACE', get_option('child_backtrace'))
-if get_option('version_suffix') != ''
-	framework_config.set_quoted('SANDSTONE_VERSION_SUFFIX', get_option('version_suffix'),
-		description: 'Suffix to show in the tool version')
-endif
 
 framework_config_h = configure_file(
 	input : 'sandstone_config.h.in',

--- a/framework/sandstone_config.h.in
+++ b/framework/sandstone_config.h.in
@@ -29,8 +29,6 @@
 #mesondefine SANDSTONE_RESTRICTED_CMDLINE
 #mesondefine SANDSTONE_CHILD_BACKTRACE
 
-#mesondefine SANDSTONE_VERSION_SUFFIX
-
 #ifdef __cplusplus
 
 namespace SandstoneConfig {

--- a/framework/scripts/make-gitid.pl
+++ b/framework/scripts/make-gitid.pl
@@ -9,12 +9,14 @@ open STDERR, ">", File::Spec->devnull(); # close stderr
 
 my $file = shift @ARGV;
 my $match = shift @ARGV;
+my $suffix = shift @ARGV or "";
 my $deps = "";
 
 if (scalar $match) {
     $match =~ s/\.exe$//;       # drop .exe extension, if happened
     $match .= '-';              # add dash
 }
+$suffix = "-$suffix" if (scalar $suffix);
 
 # See if we're in a Git repository
 my $description = `git -C $ENV{MESON_SOURCE_ROOT} describe --always --tags --match="$match*" --abbrev=12 --dirty`;
@@ -22,6 +24,7 @@ if ($? == 0) {
     # We are, so use the output of git describe (stripped of $match)
     chomp $description;
     $description =~ s/\Q$match\E//;
+    $description .= $suffix;
 
     my $gitdir = $ENV{MESON_SOURCE_ROOT} . "/" . ".git";
     if (-f $gitdir) {
@@ -57,17 +60,17 @@ if ($line =~ m/^([0-9a-f]+) (.*)/) {
     for my $ref (@refs) {
         next unless $ref =~ m/tag: \Q$match\E(.*)/;
         # git archive of a matching tag
-        $description = sprintf("v%s (%s)", $1, $hash);
+        $description = sprintf("v%s%s (%s)", $1, $suffix, $hash);
         last;
     }
 
     # didn't find a matching tag, so use the hash
-    $description = $hash unless scalar $description
+    $description = "$hash$suffix" unless scalar $description
 }
 
 # Use RELEASE_NO environment variable if available
 if ($ENV{'RELEASE_NO'}) {
-    $description = $ENV{'RELEASE_NO'};
+    $description = $ENV{'RELEASE_NO'} . $suffix;
 }
 
 $description = "<unknown version>" unless scalar $description;

--- a/meson.build
+++ b/meson.build
@@ -219,7 +219,7 @@ generated_gitid_h = configure_file(
 	output : 'gitid.h',
 	encoding : 'ascii',
 	command : [
-		perl, '@INPUT0@', '@OUTPUT@', 'opendcdiag',
+		perl, '@INPUT0@', '@OUTPUT@', 'opendcdiag', get_option('version_suffix')
 	],
 )
 top_incdir = include_directories('.')


### PR DESCRIPTION
Partially reverts commit 6e7b7a44a5c7bd53565b35a0a53d9df4da0ab96f (PR #101),
which added the concept of version suffix, but it was inserted in the
incorrect place for tagged releases.

For example:
```
$ git tag opendcdiag-2459761.5
$ git archive @ : | tar -x .hash
$ cat .hash
ea83aacaa2302d36f6fc5c3572d71f85963d166d HEAD -> main, tag: opendcdiag-2459761.5
```
That used to produce:
```c
#define GIT_ID "v2459761.5 (ea83aacaa2302d36f6fc5c3572d71f85963d166d)"
```

Which would result in OpenDCDiag printing:

```yaml
version: v2459761.5 (ea83aacaa2302d36f6fc5c3572d71f85963d166d)-foobar
```

This commit moves it to the right place:

```c
#define GIT_ID "v2459761.5-foobar (ea83aacaa2302d36f6fc5c3572d71f85963d166d)"
```

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>