### PR TITLE
[RFC] fw: remove --max-test-count

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -127,7 +127,6 @@ enum {
     test_knob_option,
     longer_runtime_option,
     max_concurrent_threads_option,
-    max_test_count_option,
     max_test_loop_count_option,
     max_messages_option,
     max_logdata_option,
@@ -2850,7 +2849,6 @@ int main(int argc, char **argv)
         { "list-groups", no_argument, nullptr, raw_list_groups },
         { "longer-runtime", required_argument, nullptr, longer_runtime_option },
         { "max-concurrent-threads", required_argument, nullptr, max_concurrent_threads_option },
-        { "max-test-count", required_argument, nullptr, max_test_count_option },
         { "max-test-loop-count", required_argument, nullptr, max_test_loop_count_option },
         { "mce-check-every", required_argument, nullptr, mce_check_period_option },
         { "max-logdata", required_argument, nullptr, max_logdata_option },
@@ -3268,10 +3266,6 @@ int main(int argc, char **argv)
             sApp->endtime = calculate_wallclock_deadline(5min, &sApp->starttime);
             break;
 
-        case max_test_count_option:
-            sApp->max_test_count = ParseIntArgument<>{"--max-test-count"}();
-            break;
-
         case max_test_loop_count_option:
             sApp->max_test_loop_count = ParseIntArgument<>{"--max-test-loop-count"}();
             if (sApp->max_test_loop_count == 0)
@@ -3439,9 +3433,6 @@ int main(int argc, char **argv)
             // ### use per_cpu_fails??
             triage_tests.push_back(test);
         }
-
-        if (total_tests_run >= sApp->max_test_count)
-            break;
 
         //don't wait when the test failed or it was skipped.
         if(sApp->service_background_scan == true && (r != TestFailed || r != TestSkipped))

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -320,7 +320,6 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     static constexpr int MaxRetestCount = 64;
     int retest_count = 10;
     int total_retest_count = -2;
-    int max_test_count = INT_MAX;
     int max_test_loop_count = 0;
     int max_concurrent_thread_count = 0;
     int current_max_loop_count;


### PR DESCRIPTION
The semantics of this option can get tricky, especially with fracturing
enabled. I don't believe this option gets much play, so removing it.

Signed-off-by: Joe Konno <joe.konno@intel.com>