### PR TITLE
Make better use of sandstone_config.h and the meson -D options

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2305,7 +2305,7 @@ void YamlLogger::print(int, ChildExitStatus status)
 void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, Duration test_timeout)
 {
     logging_printf(LOG_LEVEL_QUIET, "command-line: '%s'\n", cmdline.data());
-    logging_printf(LOG_LEVEL_QUIET, "version: " EXECUTABLE_NAME "-" GIT_ID "\n");
+    logging_printf(LOG_LEVEL_QUIET, "version: " PROGRAM_VERSION "\n");
     logging_printf(LOG_LEVEL_VERBOSE(1), "os: %s\n", os_info().c_str());
     logging_printf(LOG_LEVEL_VERBOSE(1), "timing: { duration: %s, timeout: %s }\n",
                    format_duration(test_duration, FormatDurationOptions::WithoutUnit).c_str(),

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -62,8 +62,8 @@ framework_config.set10('SANDSTONE_GA_DEV', get_option('flavor') == 'ga-dev')
 framework_config.set10('SANDSTONE_NO_LOGGING', get_option('logging_format') == 'none')
 framework_config.set('SANDSTONE_DEFAULT_LOGGING', 'SandstoneApplication::OutputFormat::' + get_option('logging_format'))
 
-framework_config.set10('SANDSTONE_RESTRICTED_CMDLINE', get_option('cmdline') == 'restricted')
-framework_config.set10('SANDSTONE_CHILD_BACKTRACE', get_option('child_backtrace'))
+framework_config.set10('SANDSTONE_RESTRICTED_CMDLINE', get_option('framework_options').contains('restricted-cmdline'))
+framework_config.set10('SANDSTONE_CHILD_BACKTRACE', get_option('framework_options').contains('no-child-backtrace'))
 
 framework_config_h = configure_file(
 	input : 'sandstone_config.h.in',

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 project(
-	'dcdiag',
+	'OpenDCDiag',
 	['c', 'cpp'],
 	default_options : [
 		'b_ndebug=if-release',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,8 +5,9 @@ option('logging_format', type : 'combo', choices : ['yaml', 'tap', 'none'], valu
 	description : 'Set build-time default logging format to "none", "yaml" (default), or "tap".')
 option('march_base', type : 'string', value : '',
 	description : 'Build framework with this base optimization -march= value (default: "haswell").')
-option('tests_options', type : 'array', value : [],
-	description : 'Pass strings to flag test content build options.')
+option('framework_options', type : 'array', value : [],
+	description : 'Configuration options for the framework. ' +
+	'Possible options: restricted-cmdline, no-child-backtrace')
 option('dependency_link', type : 'combo', choices : ['dynamic', 'static'], value : 'dynamic',
 	description : 'Link preference for dependencies: dynamic (default) or static')
 option('docdir', type : 'string', value : 'doc/dcdiag',
@@ -23,7 +24,3 @@ option('version_suffix', type : 'string', value: '',
 	description : 'Suffix to be added to the version number (e.g., build variant)')
 option('flavor', type : 'combo', choices : ['default', 'ga', 'ga-dev'], value : 'default',
 	description : 'Select one of the novel build flavors (ga, ga-dev) or the default')
-option('cmdline', type : 'combo', choices : ['full', 'restricted'], value : 'full',
-	description : 'Build in full command line options (default) or a restricted set')
-option('child_backtrace', type : 'boolean', value : true,
-	description : 'Print child backtraces on test failure or error (default true)')


### PR DESCRIPTION
* Moved `SANDSTONE_EXECUTABLE_NAME` and `SANDSTONE_FALLBACK_EXEC` into sandstone_config.h
* Moved two very uncommon settings to `framework_config` array (arrays are actually hard to set...)
* Opportunistically fixed one missing use of `PROGRAM_VERSION`