### PR TITLE
Meson cleanups

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -24,16 +24,17 @@ if target_machine.system() != 'windows' and target_machine.system() != 'cygwin'
 endif
 subdir(sysdeps_dir)
 
+# Must be a configure_file, not custom_target, so it's created at
+# meson time and thus before everything
 generated_cpu_features_h = configure_file(
 	output : 'cpu_features.h',
 	encoding : 'ascii',
-	input : [
-		'scripts/x86simd_generate.pl',
+	input : files(
 		'simd.conf',
-	],
+	),
 	capture : true,
 	command : [
-		perl, '@INPUT0@', '@INPUT1@', '@OUTPUT@',
+		perl, files('scripts/x86simd_generate.pl'), '@INPUT@', '@OUTPUT@',
 	],
 )
 

--- a/framework/sysdeps/linux/meson.build
+++ b/framework/sysdeps/linux/meson.build
@@ -47,7 +47,9 @@ if get_option('cpp_link_args').contains('-static')
 
 	# Need to extract malloc.o from libc.a and transform it
 	# Step 1: extract it:
-	libc_a = run_command(cc.cmd_array(), '-print-file-name=libc.a')
+	libc_a = run_command(cc.cmd_array(), '-print-file-name=libc.a',
+	       check: true
+	)
 
 	orig_glibc_malloc_o = custom_target(
 		'extract-malloc.o',

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 project(
-	'dcdiag',
+	'OpenDCDiag',
 	['c', 'cpp'],
 	default_options : [
 		'b_ndebug=if-release',


### PR DESCRIPTION
* fix the warning of a missing kwarg to `run_command¹
* stop abusing the input file array for `configure_file¹
* add a comment explaining why we use `configure_file`
* fix the project name