### PR TITLE
FW: fix the memmove in background_scan_update_timestamps()

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2830,13 +2830,11 @@ static void background_scan_update_timestamps(void)
 {
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
 
-    //move all timestaps execpt the oldest one
-    memmove(
-            &(sApp->background_scan.timestamp[sApp->background_scan.timestamp_newest]), 
-            &(sApp->background_scan.timestamp[sApp->background_scan.timestamp_second]),
-            (sApp->background_scan.number_of_timestamps - 1));
+    // move all timestaps except the oldest one
+    auto array_data = sApp->background_scan.timestamp.data();
+    std::move(array_data + 1, sApp->background_scan.timestamp.end(), array_data);
     
-    sApp->background_scan.timestamp[sApp->background_scan.timestamp_newest] = now;
+    sApp->background_scan.timestamp.front() = now;
 }
 
 extern constexpr const uint64_t minimum_cpu_features = _compilerCpuFeatures;


### PR DESCRIPTION
This forgot to multiply by the size of the object, so the compiler produced a warning that we left a byte unchanged. And it inverted source and destination, as evidenced by the fact that overwrote the first timestamp after the `memmove()`.

So use `std::move()` to be clearer. The compiler emits `memmove()` anyway after optimisations kick in, because `std::chrono::duration` has a trivial destructor and copy/move constructor.

```
framework/sandstone.cpp: In function ‘void background_scan_update_timestamps()’:
framework/sandstone.cpp:2979:12: warning: ‘void* memmove(void*, const void*, size_t)’ writing to an object of a non-trivial type ‘std::array<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >, 24>::value_type’ {aka ‘struct std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >’}
        leaves 1 byte unchanged [-Wclass-memaccess]
```
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>