### PR TITLE
Meson: fix make-gitid.pl with some older Git versions

### DIFF
--- a/framework/scripts/make-gitid.pl
+++ b/framework/scripts/make-gitid.pl
@@ -1,16 +1,20 @@
 #!/usr/bin/perl -l
-
 # Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 use strict;
 use File::Spec;
-open STDERR, ">", File::Spec->devnull(); # close stderr
 
 my $file = shift @ARGV;
 my $match = shift @ARGV;
 my $suffix = shift @ARGV or "";
 my $deps = "";
+
+open STDERR, ">", File::Spec->devnull(); # close stderr
+open F, ">", $file;
+open DEPFILE, ">", ($file =~ s,^(.*/)([^/]+),$1.$2.d,r); # ignore error
+
+chdir($ENV{MESON_SOURCE_ROOT}) if defined($ENV{MESON_SOURCE_ROOT});
 
 if (scalar $match) {
     $match =~ s/\.exe$//;       # drop .exe extension, if happened
@@ -19,14 +23,14 @@ if (scalar $match) {
 $suffix = "-$suffix" if (scalar $suffix);
 
 # See if we're in a Git repository
-my $description = `git -C $ENV{MESON_SOURCE_ROOT} describe --always --tags --match="$match*" --abbrev=12 --dirty`;
+my $description = `git describe --always --tags --match="$match*" --abbrev=12 --dirty`;
 if ($? == 0) {
     # We are, so use the output of git describe (stripped of $match)
     chomp $description;
     $description =~ s/\Q$match\E//;
     $description .= $suffix;
 
-    my $gitdir = $ENV{MESON_SOURCE_ROOT} . "/" . ".git";
+    my $gitdir = ".git";
     if (-f $gitdir) {
         # .git is a "gitdir:" file
         open GITDIR, "<", $gitdir;
@@ -40,32 +44,33 @@ if ($? == 0) {
     do {
         $reffile = "$gitdir/packed-refs" unless (-f $reffile);
         $deps .= " $reffile";
-        $ref = `git -C $ENV{MESON_SOURCE_ROOT} symbolic-ref $ref`;
+        $ref = `git symbolic-ref $ref`;
         chomp $ref;
         $reffile = "$gitdir/$ref";
     } while ($? == 0);
 }
 
 # Check if the .hash file has useful information too
-open F, "<", $ENV{MESON_SOURCE_ROOT} . "/" . ".hash";
-my $line = <F>;
-chomp $line;
-close F;
-if ($line =~ m/^([0-9a-f]+) (.*)/) {
-    # Output from a git archive
-    $deps .= " .hash";
-    $description = "";
-    my $hash = $1;
-    my @refs = split /, /, $2;
-    for my $ref (@refs) {
-        next unless $ref =~ m/tag: \Q$match\E(.*)/;
-        # git archive of a matching tag
-        $description = sprintf("v%s%s (%s)", $1, $suffix, $hash);
-        last;
-    }
+if (open HASH, "<", ".hash") {
+    my $line = <F>;
+    chomp $line;
+    close HASH;
+    if ($line =~ m/^([0-9a-f]+) (.*)/) {
+        # Output from a git archive
+        $deps .= " .hash";
+        $description = "";
+        my $hash = $1;
+        my @refs = split /, /, $2;
+        for my $ref (@refs) {
+            next unless $ref =~ m/tag: \Q$match\E(.*)/;
+            # git archive of a matching tag
+            $description = sprintf("v%s%s (%s)", $1, $suffix, $hash);
+            last;
+        }
 
-    # didn't find a matching tag, so use the hash
-    $description = "$hash$suffix" unless scalar $description
+        # didn't find a matching tag, so use the hash
+        $description = "$hash$suffix" unless scalar $description
+    }
 }
 
 # Use RELEASE_NO environment variable if available
@@ -76,12 +81,9 @@ if ($ENV{'RELEASE_NO'}) {
 $description = "<unknown version>" unless scalar $description;
 
 # Save the description
-open F, ">", $file;
 printf F "#define GIT_ID \"%s\"\n", $description;
 close F;
 
 # And create a Makefile dependency for us to be called again
-my $depfile = ($file =~ s,^(.*/)([^/]+),$1.$2.d,r);
-open F, ">", $depfile;
-printf F "%s: %s\n", $file, $deps;
-close F;
+printf DEPFILE "%s: %s\n", $file, $deps;
+close DEPFILE;


### PR DESCRIPTION
They didn't understand the -C option, resulting in the script failing to
get a valid info from Git and thus producing
```c
 #define GIT_ID "<unknown version>"
```
Incidentally, this fixes running the script without $MESON_SOURCE_ROOT
set, which would have caused a run of `git -C describe --always`, which
also fails and also produces that unknown version.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>