### PR TITLE
Background scan refactor 1

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2773,7 +2773,8 @@ static void background_scan_init()
 static void background_scan_update_load_threshold(MonotonicTimePoint now)
 {
     hours time_from_last_test = 
-        duration_cast<hours>(now - sApp->background_scan.timestamp[sApp->background_scan.timestamp_newest]);
+        duration_cast<hours>(now - sApp->background_scan.timestamp.front());
+
     // scale our idle threshold value from 0.2 base, to 0.8 after 12h
     // every hour adds 0.05 to the threshold value
     sApp->background_scan.load_idle_threshold = 
@@ -2809,7 +2810,7 @@ static void background_scan_wait()
 
         // If all the last N tests ran within the last batch time set, don't
         // run anything at all.
-        if (now < (sApp->background_scan.timestamp[sApp->background_scan.timestamp_oldest] + sApp->background_scan.time_to_run_next_batch_of_tests)) {
+        if (now < (sApp->background_scan.timestamp.back() + sApp->background_scan.time_to_run_next_batch_of_tests)) {
             sApp->delay_between_tests = sApp->background_scan.time_to_run_next_batch_of_tests;
 
             double wait_deviation_percent = 0.1;
@@ -2828,7 +2829,7 @@ static void background_scan_wait()
         // if we haven't run *any* tests in the last x hours, run a test
         // because of day/night cycles, 12 hours should help typical data center
         // duty cycles.
-        if (now > (sApp->background_scan.timestamp[sApp->background_scan.timestamp_newest] + sApp->background_scan.time_to_force_next_test_running))
+        if (now > (sApp->background_scan.timestamp.front() + sApp->background_scan.time_to_force_next_test_running))
             break;
     }
 }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2759,7 +2759,7 @@ static bool system_is_idle(float idle_threshold)
     return false;
 }
 
-static void background_scan_init(void)
+static void background_scan_init()
 {
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
 
@@ -2769,7 +2769,7 @@ static void background_scan_init(void)
     }
 }
 
-static void background_scan_update_load_threshold(void)
+static void background_scan_update_load_threshold()
 {
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
 
@@ -2786,7 +2786,7 @@ static void background_scan_update_load_threshold(void)
         sApp->background_scan.load_idle_threshold = sApp->background_scan.load_idle_threshold_max;
 }
 
-static void background_scan_wait(void) 
+static void background_scan_wait()
 {
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
     // Don't run tests unless load is low or it's time to run a test anyway
@@ -2827,7 +2827,7 @@ static void background_scan_wait(void)
     }
 }
 
-static void background_scan_update_timestamps(void)
+static void background_scan_update_timestamps()
 {
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2761,18 +2761,21 @@ static bool system_is_idle(float idle_threshold)
 
 static void background_scan_init()
 {
+    using namespace SandstoneBackgroundScanConstants;
     if (!sApp->service_background_scan)
         return;
 
     // init timestamps to more than the batch testing time - this quickstarts
     // testing on first run
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
-    sApp->background_scan.timestamp.fill(now - sApp->background_scan.time_to_run_next_batch_of_tests);
+    sApp->background_scan.timestamp.fill(now - time_to_run_next_batch_of_tests);
 }
 
 static void background_scan_update_load_threshold(MonotonicTimePoint now)
 {
-    hours time_from_last_test = 
+    using namespace SandstoneBackgroundScanConstants;
+
+    hours time_from_last_test =
         duration_cast<hours>(now - sApp->background_scan.timestamp.front());
 
     // scale our idle threshold value from 0.2 base, to 0.8 after 12h
@@ -2788,6 +2791,8 @@ static void background_scan_update_load_threshold(MonotonicTimePoint now)
 
 static void background_scan_wait()
 {
+    using namespace SandstoneBackgroundScanConstants;
+
     // move all timestaps except the oldest one
     auto array_data = sApp->background_scan.timestamp.data();
     std::move(array_data + 1, sApp->background_scan.timestamp.end(), array_data);
@@ -2798,7 +2803,7 @@ static void background_scan_wait()
     // Don't run tests unless load is low or it's time to run a test anyway
     while(1) {
         // wait ~5 mins no matter what
-        sApp->delay_between_tests = sApp->background_scan.minimum_delay_between_tests;
+        sApp->delay_between_tests = minimum_delay_between_tests;
 
         double wait_deviation_percent = 10.0;
 
@@ -2810,8 +2815,8 @@ static void background_scan_wait()
 
         // If all the last N tests ran within the last batch time set, don't
         // run anything at all.
-        if (now < (sApp->background_scan.timestamp.back() + sApp->background_scan.time_to_run_next_batch_of_tests)) {
-            sApp->delay_between_tests = sApp->background_scan.time_to_run_next_batch_of_tests;
+        if (now < (sApp->background_scan.timestamp.back() + time_to_run_next_batch_of_tests)) {
+            sApp->delay_between_tests = time_to_run_next_batch_of_tests;
 
             double wait_deviation_percent = 0.1;
             wait_delay_between_tests_with_deviation(
@@ -2829,7 +2834,7 @@ static void background_scan_wait()
         // if we haven't run *any* tests in the last x hours, run a test
         // because of day/night cycles, 12 hours should help typical data center
         // duty cycles.
-        if (now > (sApp->background_scan.timestamp.front() + sApp->background_scan.time_to_force_next_test_running))
+        if (now > (sApp->background_scan.timestamp.front() + time_to_force_next_test_running))
             break;
     }
 }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2769,10 +2769,8 @@ static void background_scan_init()
     }
 }
 
-static void background_scan_update_load_threshold()
+static void background_scan_update_load_threshold(MonotonicTimePoint now)
 {
-    MonotonicTimePoint now = MonotonicTimePoint::clock::now();
-
     hours time_from_last_test = 
         duration_cast<hours>(now - sApp->background_scan.timestamp[sApp->background_scan.timestamp_newest]);
     // scale our idle threshold value from 0.2 base, to 0.8 after 12h
@@ -2811,9 +2809,10 @@ static void background_scan_wait()
             wait_delay_between_tests_with_deviation(
                     wait_deviation_percent,
                     false);
+            now = MonotonicTimePoint::clock::now();
         }
 
-        background_scan_update_load_threshold();
+        background_scan_update_load_threshold(now);
 
         // if the system is idle, run a test
         if (system_is_idle(sApp->background_scan.load_idle_threshold))

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2768,7 +2768,7 @@ static void background_scan_init()
     // init timestamps to more than the batch testing time - this quickstarts
     // testing on first run
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
-    sApp->background_scan.timestamp.fill(now - time_to_run_next_batch_of_tests);
+    sApp->background_scan.timestamp.fill(now - MaximumDelayBetweenTests);
 }
 
 static void background_scan_update_load_threshold(MonotonicTimePoint now)
@@ -2803,7 +2803,7 @@ static void background_scan_wait()
     // Don't run tests unless load is low or it's time to run a test anyway
     while(1) {
         // wait ~5 mins no matter what
-        sApp->delay_between_tests = minimum_delay_between_tests;
+        sApp->delay_between_tests = MinimumDelayBetweenTests;
 
         double wait_deviation_percent = 10.0;
 
@@ -2815,8 +2815,8 @@ static void background_scan_wait()
 
         // If all the last N tests ran within the last batch time set, don't
         // run anything at all.
-        if (now < (sApp->background_scan.timestamp.back() + time_to_run_next_batch_of_tests)) {
-            sApp->delay_between_tests = time_to_run_next_batch_of_tests;
+        if (now < (sApp->background_scan.timestamp.back() + DelayBetweenTestBatch)) {
+            sApp->delay_between_tests = DelayBetweenTestBatch;
 
             double wait_deviation_percent = 0.1;
             wait_delay_between_tests_with_deviation(
@@ -2834,7 +2834,7 @@ static void background_scan_wait()
         // if we haven't run *any* tests in the last x hours, run a test
         // because of day/night cycles, 12 hours should help typical data center
         // duty cycles.
-        if (now > (sApp->background_scan.timestamp.front() + time_to_force_next_test_running))
+        if (now > (sApp->background_scan.timestamp.front() + MaximumDelayBetweenTests))
             break;
     }
 }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2786,7 +2786,13 @@ static void background_scan_update_load_threshold(MonotonicTimePoint now)
 
 static void background_scan_wait()
 {
+    // move all timestaps except the oldest one
+    auto array_data = sApp->background_scan.timestamp.data();
+    std::move(array_data + 1, sApp->background_scan.timestamp.end(), array_data);
+
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
+    sApp->background_scan.timestamp.front() = now;
+
     // Don't run tests unless load is low or it's time to run a test anyway
     while(1) {
         // wait ~5 mins no matter what
@@ -2824,17 +2830,6 @@ static void background_scan_wait()
         if (now > (sApp->background_scan.timestamp[sApp->background_scan.timestamp_newest] + sApp->background_scan.time_to_force_next_test_running))
             break;
     }
-}
-
-static void background_scan_update_timestamps()
-{
-    MonotonicTimePoint now = MonotonicTimePoint::clock::now();
-
-    // move all timestaps except the oldest one
-    auto array_data = sApp->background_scan.timestamp.data();
-    std::move(array_data + 1, sApp->background_scan.timestamp.end(), array_data);
-    
-    sApp->background_scan.timestamp.front() = now;
 }
 
 extern constexpr const uint64_t minimum_cpu_features = _compilerCpuFeatures;
@@ -3472,9 +3467,6 @@ int main(int argc, char **argv)
         }
 
         lastTestResult = run_one_test(&tc, test, per_cpu_failures);
-
-        if(sApp->service_background_scan == true)
-            background_scan_update_timestamps();
 
         // keep the record of failures to triage later
         total_tests_run++;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2761,12 +2761,13 @@ static bool system_is_idle(float idle_threshold)
 
 static void background_scan_init()
 {
-    MonotonicTimePoint now = MonotonicTimePoint::clock::now();
+    if (!sApp->service_background_scan)
+        return;
 
-    // init timestamps to 1day old - this quickstarts testing on first run
-    if ((sApp->background_scan.init_timestamp == true) && (sApp->service_background_scan == true)) {
-        sApp->background_scan.timestamp.fill(now - sApp->background_scan.time_to_run_next_batch_of_tests);
-    }
+    // init timestamps to more than the batch testing time - this quickstarts
+    // testing on first run
+    MonotonicTimePoint now = MonotonicTimePoint::clock::now();
+    sApp->background_scan.timestamp.fill(now - sApp->background_scan.time_to_run_next_batch_of_tests);
 }
 
 static void background_scan_update_load_threshold(MonotonicTimePoint now)
@@ -3382,6 +3383,7 @@ int main(int argc, char **argv)
     logging_init_global();
     cpu_specific_init();
     random_global_init(seed);
+    background_scan_init();
 
     if (InterruptMonitor::InterruptMonitorWorks) {
         sApp->last_thermal_event_count = sApp->count_thermal_events();
@@ -3438,9 +3440,6 @@ int main(int argc, char **argv)
     bool restarting = true;
     int total_tests_run = 0;
     TestResult lastTestResult = TestSkipped;
-
-    if(sApp->service_background_scan == true)
-        background_scan_init();
 
     for (struct test *test = get_next_test(tc); test; test = get_next_test(tc)) {
         if (restarting){

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -228,13 +228,7 @@ struct SandstoneBackgroundScan
     static constexpr Duration time_to_run_next_batch_of_tests = std::chrono::hours(24);
     static constexpr Duration time_to_force_next_test_running = (time_to_run_next_batch_of_tests / 2);
 
-    static constexpr uint32_t number_of_timestamps = 24;
-
-    static constexpr uint32_t timestamp_newest = 0;
-    static constexpr uint32_t timestamp_second = 1;
-    static constexpr uint32_t timestamp_oldest = (number_of_timestamps - 1);
-
-    std::array<MonotonicTimePoint, number_of_timestamps> timestamp;
+    std::array<MonotonicTimePoint, 24> timestamp;
 
     static constexpr float load_idle_threshold_init = 0.2;
     static constexpr float load_idle_threshold_inc_val = 0.05;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -222,19 +222,20 @@ template <> struct test_the_test_data<true>
     void test_tests_finish(const struct test *);
 };
 
-struct SandstoneBackgroundScan
-{
+namespace SandstoneBackgroundScanConstants {
     static constexpr Duration minimum_delay_between_tests = std::chrono::minutes(5);
     static constexpr Duration time_to_run_next_batch_of_tests = std::chrono::hours(24);
     static constexpr Duration time_to_force_next_test_running = (time_to_run_next_batch_of_tests / 2);
+}
 
+struct SandstoneBackgroundScan
+{
     std::array<MonotonicTimePoint, 24> timestamp;
+    float load_idle_threshold = 0.0;
 
     static constexpr float load_idle_threshold_init = 0.2;
     static constexpr float load_idle_threshold_inc_val = 0.05;
     static constexpr float load_idle_threshold_max = 0.8;
-
-    float load_idle_threshold = 0.0;
 };
 
 struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -228,7 +228,6 @@ struct SandstoneBackgroundScan
     static constexpr Duration time_to_run_next_batch_of_tests = std::chrono::hours(24);
     static constexpr Duration time_to_force_next_test_running = (time_to_run_next_batch_of_tests / 2);
 
-    static constexpr bool init_timestamp = true;
     static constexpr uint32_t number_of_timestamps = 24;
 
     static constexpr uint32_t timestamp_newest = 0;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -223,9 +223,9 @@ template <> struct test_the_test_data<true>
 };
 
 namespace SandstoneBackgroundScanConstants {
-    static constexpr Duration minimum_delay_between_tests = std::chrono::minutes(5);
-    static constexpr Duration time_to_run_next_batch_of_tests = std::chrono::hours(24);
-    static constexpr Duration time_to_force_next_test_running = (time_to_run_next_batch_of_tests / 2);
+static constexpr Duration MinimumDelayBetweenTests = std::chrono::minutes(5);
+static constexpr Duration DelayBetweenTestBatch = std::chrono::hours(24);
+static constexpr Duration MaximumDelayBetweenTests = (DelayBetweenTestBatch / 2);
 }
 
 struct SandstoneBackgroundScan


### PR DESCRIPTION
This is a set of simple no-op changes, just to improve the code a little
 * removed (void) parameters
 * passing "now" as a variable to background_scan_update_load_threshold()
 * merged background_scan_update() into background_scan_wait()
 * removed unnecessary init_timestamp constant variable
 * removed the SandstoneBackgroundScan::timestamp_* constants
 * moved the background scan's time constants to a namespace
 * renamed and capitalised said constants names
