### PR TITLE
Background scan refactor (2/2)

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2800,7 +2800,7 @@ static void background_scan_wait()
 
     // move all timestaps except the oldest one
     auto array_data = sApp->background_scan.timestamp.data();
-    std::move(array_data + 1, sApp->background_scan.timestamp.end(), array_data);
+    std::move(array_data, sApp->background_scan.timestamp.end() - 1, array_data + 1);
 
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
     sApp->background_scan.timestamp.front() = now;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2773,7 +2773,7 @@ static void background_scan_init()
     // init timestamps to more than the batch testing time - this quickstarts
     // testing on first run
     MonotonicTimePoint now = MonotonicTimePoint::clock::now();
-    sApp->background_scan.timestamp.fill(now - MaximumDelayBetweenTests);
+    sApp->background_scan.timestamp.fill(now - DelayBetweenTestBatch);
 }
 
 static void background_scan_update_load_threshold(MonotonicTimePoint now)

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2794,19 +2794,20 @@ static void background_scan_wait()
 
     // Don't run too many tests in a short period of time
     Duration elapsed = now - sApp->background_scan.timestamp.back();
-    if (elapsed < DelayBetweenTestBatch) {
+    if (Duration expected_start = DelayBetweenTestBatch - elapsed; expected_start > 0s) {
+        expected_start += MinimumDelayBetweenTests;
         logging_printf(LOG_LEVEL_VERBOSE(2), "# Background scan: %zu tests completed in "
-                                             "%d s, waiting %d +/- 0.1%% s\n",
-                       sApp->background_scan.timestamp.size(),
-                       as_seconds(elapsed), as_seconds(DelayBetweenTestBatch));
-        do_wait(DelayBetweenTestBatch, DelayBetweenTestBatch / 1000);
+                                             "%d s, waiting %d +/- %d s\n",
+                       sApp->background_scan.timestamp.size(), as_seconds(elapsed),
+                       as_seconds(expected_start), as_seconds(MinimumDelayBetweenTests));
+        do_wait(expected_start, MinimumDelayBetweenTests);
         goto skip_wait;
     }
 
     logging_printf(LOG_LEVEL_VERBOSE(3), "# Background scan: waiting %d +/- 10%% s\n",
                    as_seconds(MinimumDelayBetweenTests));
     while (1) {
-        do_wait(MinimumDelayBetweenTests, MinimumDelayBetweenTests / 15);
+        do_wait(MinimumDelayBetweenTests, MinimumDelayBetweenTests / 10);
 
 skip_wait:
         now = MonotonicTimePoint::clock::now();


### PR DESCRIPTION
This PR continues the fixing and refactoring started in the previous refactor (#119)
 * fix std::move of the array, which we attempted to fix but didn't do the job properly
 * fix initialisation of the background scan timestamps
 * add some more logging info to the background scan
 * replace system_is_idle() with a function that returns the load
 * move wait_delay_between_tests_with_deviation() into a lambda
 * refactor the background scan's random time-waiting code
 * hoist the long wait out of the loop
 * don't wait too long between test starts
