### PR TITLE
FW: fix --test-file-list when --disable=mce_check was used

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3439,8 +3439,8 @@ int main(int argc, char **argv)
                            "# WARNING: both --test-list-file and --enable specified, using only "
                            "the test list file \"%s\".\n", test_list_file_path);
             test_list = {};
-            generate_test_list(test_list);
         }
+        generate_test_list(test_list);
         test_selector = create_list_file_test_selector(std::move(test_list), test_list_file_path,
                                                        starting_test_number, ending_test_number,
                                                        test_list_randomize);


### PR DESCRIPTION
Clearly I didn't test this very well, because generate_test_list() ended
up inside the branch printing the warning.
```
  $ $objdir/opendcdiag --test-list-file <(print zlib)
  ERROR: Attempt to specify non-existent test id [zlib] in list file
```
but if you enabled anything:
```
  $ $objdir/opendcdiag --quick -v -e zstd --test-list-file <(print zlib)
  # WARNING: both --test-list-file and --enable specified, using only the test list file "/proc/self/fd/11".
  command-line: 'opendcdiag --quick -v -e zstd --test-list-file /proc/self/fd/11'
  version: opendcdiag-f0c5461b7632
[...]
  tests:
  - test: zlib
    result: pass
    time-at-end:   { elapsed:    195.000, now: !!timestamp '2022-07-09T00:29:33Z' }
    test-runtime: 195.176
  - test: mce_check
    result: pass
    time-at-end:   { elapsed:    206.000, now: !!timestamp '2022-07-09T00:29:33Z' }
    test-runtime: 3.641
  exit: pass
```
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>