### PR TITLE
Meson: fix make-gitid.pl with non-Git builds

### DIFF
--- a/framework/scripts/make-gitid.pl
+++ b/framework/scripts/make-gitid.pl
@@ -10,8 +10,8 @@ my $match = shift @ARGV;
 my $suffix = shift @ARGV or "";
 my $deps = "";
 
+open F, ">", $file or die("Could not open $file for writing: $!");
 open STDERR, ">", File::Spec->devnull(); # close stderr
-open F, ">", $file;
 open DEPFILE, ">", ($file =~ s,^(.*/)([^/]+),$1.$2.d,r); # ignore error
 
 chdir($ENV{MESON_SOURCE_ROOT}) if defined($ENV{MESON_SOURCE_ROOT});

--- a/framework/scripts/make-gitid.pl
+++ b/framework/scripts/make-gitid.pl
@@ -52,7 +52,7 @@ if ($? == 0) {
 
 # Check if the .hash file has useful information too
 if (open HASH, "<", ".hash") {
-    my $line = <F>;
+    my $line = <HASH>;
     chomp $line;
     close HASH;
     if ($line =~ m/^([0-9a-f]+) (.*)/) {

--- a/framework/scripts/make-gitid.pl
+++ b/framework/scripts/make-gitid.pl
@@ -27,6 +27,7 @@ my $description = `git describe --always --tags --match="$match*" --abbrev=12 --
 if ($? == 0) {
     # We are, so use the output of git describe (stripped of $match)
     chomp $description;
+    print F "// git describe: $description\n";
     $description =~ s/\Q$match\E//;
     $description .= $suffix;
 
@@ -55,6 +56,7 @@ if (open HASH, "<", ".hash") {
     my $line = <HASH>;
     chomp $line;
     close HASH;
+    print F "// .hash file: $line\n";
     if ($line =~ m/^([0-9a-f]+) (.*)/) {
         # Output from a git archive
         $deps .= " .hash";


### PR DESCRIPTION
Use the proper Perl stream name we've just opened.

Commit @ca4a226aef25527cdd76775a6154435cf9331f40 (PR #114) made the
script chdir() to the $MESON_SOURCE_ROOT dir so we could find the .hash
file properly. But that required opening the output file before the
chdir() (so we could deal with relative paths the right way), so I had
to change the name of the Perl stream from F to HASH. But I missed one
update.

Plus two minor updates to help debugging the script.