### PR TITLE
FW: fix triage runs

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3509,15 +3509,11 @@ int main(int argc, char **argv)
 
         lastTestResult = run_one_test(&tc, test, per_cpu_failures);
 
-        // keep the record of failures to triage later
         total_tests_run++;
-        if (total_failures > triage_tests.size()) {
-            // ### use per_cpu_fails??
-            triage_tests.push_back(test);
-        }
-
         if (lastTestResult == TestFailed) {
             ++total_failures;
+            // keep the record of failures to triage later
+            triage_tests.push_back(test);
             if (fatal_errors)
                 break;
         } else if (lastTestResult == TestPassed) {


### PR DESCRIPTION
The clean up in commit @c01b34b399e3d57cedf8d85479a174b4206b7bc1 (PR
#113) moved the update of total_failures below the use of the variable.

I really need to add some unit tests to the framework. I'll do that
right after this PR.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>