### PR TITLE
FW: implement stateful timestamps for the background scan

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -32,6 +32,7 @@
 
 #include <sandstone_config.h>
 #include <sandstone_chrono.h>
+#include <sandstone_span.h>
 #include <sandstone_utils.h>
 
 #include "effective_cpu_freq.hpp"
@@ -237,7 +238,7 @@ static constexpr Duration MaximumDelayBetweenTests = (DelayBetweenTestBatch / 2)
 
 struct SandstoneBackgroundScan
 {
-    std::array<MonotonicTimePoint, 24> timestamp;
+    span<MonotonicTimePoint> timestamp;
     float load_idle_threshold = 0.0;
 
     static constexpr float load_idle_threshold_init = 0.2;


### PR DESCRIPTION
This allows the tool to be restarted (for example, after an update) and
retain its average CPU consumption. There's no intention in this commit
to restart the scan wherever it was interrupted, though.

This will store the timestamp file in the runtime directory, which MUST
be specified via an environment variable. systemd does that for us if
you set the RuntimeDirectory= entry in the .service file[1]. I've chosen
the RuntimeDirectory because it's erased after boot (it's on tmpfs on
Linux).

This commit does NOT implement a race condition prevention, despite use
of atomics. If two instances of OpenDCDiag are launched with --service
and with the same runtime directory, they will step on each other's
toes. Preventing that is an exercise for the upper layer, like systemd.

This commit also does NOT implement stateful storage for Windows.

[1] https://www.freedesktop.org/software/systemd/man/systemd.exec.html#RuntimeDirectory=

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>