### PR TITLE
[Eigen 3.4] Backward compatibility with Eigen tests

### DIFF
--- a/framework/sandstone_eigen_configurator.h
+++ b/framework/sandstone_eigen_configurator.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * NOTE: This is a private include file of the sandstone framework to configure Eigen library
+ * and should be included only by the test using Eigen. Must be very first included file
+ * (with prior definition of SANDSTONE_EIGEN_VECTORIZATION)
+ */
+
+#ifndef SANDSTONE_EIGEN_CONFIGURATOR_H
+#define SANDSTONE_EIGEN_CONFIGURATOR_H
+
+#define SANDSTONE_EIGEN_DEFAULT      0
+#define SANDSTONE_EIGEN_AVX          1
+#define SANDSTONE_EIGEN_AVX2         2
+#define SANDSTONE_EIGEN_AVX512       3
+#define SANDSTONE_EIGEN_AVX512_DQ_ER 4
+#define SANDSTONE_EIGEN_FP16         5
+
+
+#ifdef SANDSTONE_EIGEN_VECTORIZATION
+    // disable eigen's configurator
+    #define EIGEN_DONT_VECTORIZE
+
+    // common vector operations
+    #define EIGEN_VECTORIZE
+    #define EIGEN_VECTORIZE_SSE
+    #define EIGEN_VECTORIZE_SSE2
+
+    #ifdef __SSE3__
+    #define EIGEN_VECTORIZE_SSE3
+    #endif
+    #ifdef __SSSE3__
+    #define EIGEN_VECTORIZE_SSSE3
+    #endif
+    #ifdef __SSE4_1__
+    #define EIGEN_VECTORIZE_SSE4_1
+    #endif
+    #ifdef __SSE4_2__
+    #define EIGEN_VECTORIZE_SSE4_2
+    #endif
+
+    #if (SANDSTONE_EIGEN_VECTORIZATION == SANDSTONE_EIGEN_DEFAULT)
+        #warning Default compiler handling is used
+
+    #elif (SANDSTONE_EIGEN_VECTORIZATION == SANDSTONE_EIGEN_AVX)
+        #if !defined(__AVX__)
+            #error AVX feature is not available
+        #elif !defined(__FMA__)
+            #error FMA feature is not available
+        #elif defined(__AVX2__)
+            #error AVX2 feature is available
+        #elif defined(__AVX512F__)
+            #error AVX512F feature is available
+        #else
+            #define EIGEN_VECTORIZE_AVX
+            #define EIGEN_VECTORIZE_FMA
+            #define EIGEN_MAX_ALIGN_BYTES 32
+        #endif
+
+    #elif (SANDSTONE_EIGEN_VECTORIZATION == SANDSTONE_EIGEN_AVX2)
+        #if !defined(__AVX__)
+            #error AVX feature is not available
+        #elif !defined(__AVX2__)
+            #error AVX2 feature is not available
+        #elif !defined(__FMA__)
+            #error FMA feature is not available
+        #elif defined(__AVX512F__)
+            #error AVX512F feature is available
+        #else
+            #define EIGEN_VECTORIZE_AVX
+            #define EIGEN_VECTORIZE_AVX2
+            #define EIGEN_VECTORIZE_FMA
+            #define EIGEN_MAX_ALIGN_BYTES 32
+        #endif
+
+    #elif (SANDSTONE_EIGEN_VECTORIZATION == SANDSTONE_EIGEN_AVX512)
+        #if !defined(__AVX__)
+            #error AVX feature is not available
+        #elif !defined(__AVX2__)
+            #error AVX2 feature is not available
+        #elif !defined(__FMA__)
+            #error FMA feature is not available
+        #elif !defined(__AVX512F__)
+            #error AVX512F feature is not available
+        #else
+            #define EIGEN_VECTORIZE_AVX
+            #define EIGEN_VECTORIZE_AVX2
+            #define EIGEN_VECTORIZE_FMA
+            #define EIGEN_VECTORIZE_AVX512
+            // horizontal ADD is not enabled
+            #define EIGEN_MAX_ALIGN_BYTES 64
+        #endif
+
+    #elif (SANDSTONE_EIGEN_VECTORIZATION == SANDSTONE_EIGEN_AVX512_DQ_ER)
+        #if !defined(__AVX__)
+            #error AVX feature is not available
+        #elif !defined(__AVX2__)
+            #error AVX2 feature is not available
+        #elif !defined(__FMA__)
+            #error FMA feature is not available
+        #elif !defined(__AVX512F__)
+            #error AVX512F feature is not available
+        #elif !defined(__AVX512DQ__)
+            #error AVX512DQ feature is not available
+        #elif !defined(__AVX512ER__)
+            #error AVX512ER feature is not available
+        #else
+            #define EIGEN_VECTORIZE_AVX
+            #define EIGEN_VECTORIZE_AVX2
+            #define EIGEN_VECTORIZE_FMA
+            #define EIGEN_VECTORIZE_AVX512
+            #define EIGEN_VECTORIZE_AVX512DQ
+            #define EIGEN_VECTORIZE_AVX512ER
+            #define EIGEN_MAX_ALIGN_BYTES 64
+        #endif
+
+    #elif (SANDSTONE_EIGEN_VECTORIZATION == SANDSTONE_EIGEN_FP16)
+        #if !defined(__AVX__)
+            #error AVX feature is not available
+        #elif !defined(__AVX2__)
+            #error AVX2 feature is not available
+        #elif !defined(__FMA__)
+            #error FMA feature is not available
+        #elif !defined(__AVX512F__)
+            #error AVX512F feature is not available
+        #elif !defined(__AVX512FP16__)
+            #error AVX512FP16 feature is not available
+        #else
+            #define EIGEN_VECTORIZE_AVX
+            #define EIGEN_VECTORIZE_AVX2
+            #define EIGEN_VECTORIZE_FMA
+            #define EIGEN_VECTORIZE_AVX512
+            #define EIGEN_VECTORIZE_AVX512FP16
+            // horizontal ADD is not enabled
+            #define EIGEN_MAX_ALIGN_BYTES 64
+        #endif
+
+    #else
+        #error Not handled vectorization requested
+    #endif
+
+#endif // SANDSTONE_EIGEN_VECTORIZATION
+#endif // SANDSTONE_EIGEN_CONFIGURATOR_H

--- a/tests/eigen_svd/svd_cdouble_avx512.cpp
+++ b/tests/eigen_svd/svd_cdouble_avx512.cpp
@@ -5,16 +5,17 @@
  * Copyright 2022 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
- * @test @b eigen_svd_cdouble
+ * @test @b eigen_svd_cdouble_avx512
  * @parblock
  * This piece of code aims to stress test the FMA execution units of
  * the CPU, among others, by repetitively solving the singular value
  * decomposition problem on given input matrices, which involve a lot
  * of matrix multiplication operations underneath.
  *
- * The test is intended to verify FMA feature, must be built without
- * AVX512 features enabled (t.i with Eigen pre-3.4 or without AVX512F
- * feature available).
+ * The test is intended to use AVX512 instructions, which are available
+ * with Eigen 3.4 (and up) with AVX512 enabled. The test should not be
+ * created for other configurations (Eigen 3.3.x or GCC pre-12 or below
+ * SKX target)
  *
  * The logic comes from the 3rd party library Eigen. The first thread
  * that gets to run computes a "golden value" of the results, those
@@ -30,8 +31,7 @@
  * @endparblock
  */
 
-// Test is expected *not" to test AVX2/FMA only (to follow Eigen 3.3.8)
-#define SANDSTONE_EIGEN_VECTORIZATION SANDSTONE_EIGEN_AVX2
+#define SANDSTONE_EIGEN_VECTORIZATION SANDSTONE_EIGEN_AVX512
 #include <sandstone_eigen_configurator.h>
 
 #include "sandstone_eigen_common.h"
@@ -44,11 +44,12 @@ typedef Eigen::BDCSVD < Mat > SVD;
 #define M_DIM 300               // weird dim on purpose
 
 using eigen_svd_cdouble_test = EigenSVDTest<SVD, M_DIM>;
-DECLARE_TEST(eigen_svd_cdouble, "Eigen SVD (Singular Value Decomposition) solving payload, which issues a bunch of matrix multiplies underneath, now operating on std::complex<double>")
+DECLARE_TEST(eigen_svd_cdouble_avx512, "Eigen SVD (Singular Value Decomposition) solving payload, which issues a bunch of matrix multiplies underneath, now operating on std::complex<double>")
   .groups = DECLARE_TEST_GROUPS(&group_math),
   .test_init = eigen_svd_cdouble_test::init,
   .test_run = eigen_svd_cdouble_test::run,
   .test_cleanup = eigen_svd_cdouble_test::cleanup,
+  .minimum_cpu = cpu_feature_avx512f,
   .fracture_loop_count = 5,
-  .quality_level = TEST_QUALITY_PROD,
+  .quality_level = TEST_QUALITY_BETA,
 END_DECLARE_TEST

--- a/tests/eigen_svd/svd_cdouble_noavx512.cpp
+++ b/tests/eigen_svd/svd_cdouble_noavx512.cpp
@@ -12,6 +12,10 @@
  * decomposition problem on given input matrices, which involve a lot
  * of matrix multiplication operations underneath.
  *
+ * The test is intended to verify FMA feature, must be built without
+ * AVX512 features enabled (t.i with Eigen pre-3.4 or without AVX512F
+ * feature available).
+ *
  * The logic comes from the 3rd party library Eigen. The first thread
  * that gets to run computes a "golden value" of the results, those
  * being output matrices "U" and "V". Subsequent runs have results
@@ -25,6 +29,9 @@
  * @note This test requires at least 2 threads to run.
  * @endparblock
  */
+
+#define SANDSTONE_EIGEN_VECTORIZATION SANDSTONE_EIGEN_AVX2
+#include <sandstone_eigen_configurator.h>
 
 #include "sandstone_eigen_common.h"
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -58,6 +58,7 @@ tests_set_base.add(
 		'eigen_gemm/gemm_float_dynamic_square.cpp',
 		'eigen_sparse/eigen_sparse.cpp',
 		'eigen_svd/svd.cpp',
+		'eigen_svd/svd_cdouble.cpp',
 		'eigen_svd/svd_cdouble_noavx512.cpp',
 		'eigen_svd/svd_double.cpp',
 		'eigen_svd/svd_fvectors.cpp',
@@ -71,7 +72,7 @@ tests_set_base.add(
 tests_set_skx.add(
 	when : eigen3_dep,
 	if_true : files(
-		'eigen_svd/svd_cdouble.cpp',
+		'eigen_svd/svd_cdouble_avx512.cpp',
 	)
 )
 
@@ -159,7 +160,6 @@ if host_machine.cpu_family() == 'x86_64'
 		cpp_args : [
 			tests_common_cpp_args,
 			'-march=skylake-avx512',
-			'-DEigen=EigenAVX512',
 		],
 	)
 


### PR DESCRIPTION
Eigen 3.3.8 uses FMA feature to run calculations, while 3.4.0 is able
to use AVX512F (with main focus on vfmadd with ZMM registers). To keep
backward compatibility eigen_svd_cdouble must be kept with FMA and
new test (eigen_svd_cdouble_avx512) added when AVX512F is properly handled
(what implies at least Eigen 3.4.0 and ICX architecture).

Signed-off-by: Jarek Poswiata <jaroslaw.poswiata@intel.com>