### PR TITLE
CI: use real test files instead of redirected file descriptors

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -402,7 +402,9 @@ test_list_file() {
         local -i duration=${entry#*:}
         if (( duration > 0 )); then
             test_yaml_numeric "/tests/$i/test-runtime" "value >= $duration"
-            test_yaml_numeric "/tests/$i/test-runtime" "value <= 2 * $duration"
+            if (( 2 * duration < yamldump[/timing/duration] )); then
+               test_yaml_numeric "/tests/$i/test-runtime" "value <= "${yamldump[/timing/duration]}
+            fi
         fi
 
         i=$((i + 1))


### PR DESCRIPTION
Somehow this has started failing with WINE builds:

"MZ" is the magic of a DOS executable, which Windows executables still
carry as a stub. So somehow sandstone.cpp is reading the wrong file.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>