### PR TITLE
[Floats] Fixing #defs to keep consistent pattern over all types

### DIFF
--- a/framework/Floats.cpp
+++ b/framework/Floats.cpp
@@ -5,7 +5,7 @@
 
 #include <unistd.h>
 #include <sandstone_data.h>
-#include <sandstone.h>
+#include <sandstone_p.h>
 
 /**
  * @brief C++ assertion validators
@@ -84,7 +84,6 @@ static_assert(Float80_11_22.mantissa == 22, "Float80: Incorrect mantissa");
  *
  * @{
  */
-#define MASK(n)  (((n) == 64) ? 0xffffffffffffffffuLL : ((1uLL << (n)) - 1))
 #define QUIET(t)  ((1uLL << (t ## _MANTISSA_BITS - 1)))
 
 static_assert(BFLOAT16_EXPONENT_MASK == FLOAT32_EXPONENT_MASK, "BFloat16 is truncated Float32 (MSB only)");
@@ -93,18 +92,18 @@ static_assert(BFLOAT16_MANTISSA_MASK == (FLOAT32_MANTISSA_MASK >> 16), "BFloat16
 static_assert(sizeof(Float16) == 2, "Float16 structure is not of the correct size");
 static_assert(FLOAT16_NAN_EXPONENT == FLOAT16_EXPONENT_MASK, "Float16::NaNs have all exponent bits set");
 static_assert(FLOAT16_INFINITY_EXPONENT == FLOAT16_EXPONENT_MASK, "Float16::Inf has all exponent bits set");
-static_assert(MASK(FP16_EXPONENT_BITS) == FLOAT16_EXPONENT_MASK, "Float16 exponent mask has different size than the field");
-static_assert(MASK(FP16_MANTISSA_BITS) == FLOAT16_MANTISSA_MASK, "Float16 mantissa mask has different size than the field");
-static_assert(QUIET(FP16) == FLOAT16_MANTISSA_QUIET_NAN_MASK, "Quiet bit is MSB of the mantissa");
-static_assert(FP16_SIGN_BITS + FP16_EXPONENT_BITS + FP16_MANTISSA_BITS == 16, "Bitfields sums to type size");
+static_assert(MASK(FLOAT16_EXPONENT_BITS) == FLOAT16_EXPONENT_MASK, "Float16 exponent mask has different size than the field");
+static_assert(MASK(FLOAT16_MANTISSA_BITS) == FLOAT16_MANTISSA_MASK, "Float16 mantissa mask has different size than the field");
+static_assert(QUIET(FLOAT16) == FLOAT16_MANTISSA_QUIET_NAN_MASK, "Quiet bit is MSB of the mantissa");
+static_assert(FLOAT16_SIGN_BITS + FLOAT16_EXPONENT_BITS + FLOAT16_MANTISSA_BITS == 16, "Bitfields sums to type size");
 
 static_assert(sizeof(BFloat16) == 2, "BFloat16 structure is not of the correct size");
 static_assert(BFLOAT16_NAN_EXPONENT == BFLOAT16_EXPONENT_MASK, "BFloat16::NaNs have all exponent bits set");
 static_assert(BFLOAT16_INFINITY_EXPONENT == BFLOAT16_EXPONENT_MASK, "BFloat16::Inf has all exponent bits set");
-static_assert(MASK(BFLT16_EXPONENT_BITS) == BFLOAT16_EXPONENT_MASK, "BFloat16 exponent mask has different size than the field");
-static_assert(MASK(BFLT16_MANTISSA_BITS) == BFLOAT16_MANTISSA_MASK, "BFloat16 mantissa mask has different size than the field");
-static_assert(QUIET(BFLT16) == BFLOAT16_MANTISSA_QUIET_NAN_MASK, "Quiet bit is MSB of the mantissa");
-static_assert(BFLT16_SIGN_BITS + BFLT16_EXPONENT_BITS + BFLT16_MANTISSA_BITS == 16, "Bitfields sums to type size");
+static_assert(MASK(BFLOAT16_EXPONENT_BITS) == BFLOAT16_EXPONENT_MASK, "BFloat16 exponent mask has different size than the field");
+static_assert(MASK(BFLOAT16_MANTISSA_BITS) == BFLOAT16_MANTISSA_MASK, "BFloat16 mantissa mask has different size than the field");
+static_assert(QUIET(BFLOAT16) == BFLOAT16_MANTISSA_QUIET_NAN_MASK, "Quiet bit is MSB of the mantissa");
+static_assert(BFLOAT16_SIGN_BITS + BFLOAT16_EXPONENT_BITS + BFLOAT16_MANTISSA_BITS == 16, "Bitfields sums to type size");
 
 static_assert(sizeof(Float32) == sizeof(float), "Float32 structure is not of the correct size");
 static_assert(FLOAT32_NAN_EXPONENT == FLOAT32_EXPONENT_MASK, "Float32::NaNs have all exponent bits set");
@@ -142,51 +141,51 @@ extern "C" {
 Float16 new_random_float16()
 {
     Float16 f;
+
     f.sign = random32();
     f.exponent = random32();
-    f.mantissa = set_random_bits(random32() % (FP16_MANTISSA_BITS + 1), FP16_MANTISSA_BITS);
-
+    f.mantissa = set_random_bits(random32() % (FLOAT16_MANTISSA_BITS + 1), FLOAT16_MANTISSA_BITS);
     return f;
 }
 
 BFloat16 new_random_bfloat16()
 {
     BFloat16 f;
+
     f.sign = random32();
     f.exponent = random32();
-    f.mantissa = set_random_bits(random32() % (BFLT16_MANTISSA_BITS + 1), BFLT16_MANTISSA_BITS);
-
+    f.mantissa = set_random_bits(random32() % (BFLOAT16_MANTISSA_BITS + 1), BFLOAT16_MANTISSA_BITS);
     return f;
 }
 
 Float32 new_random_float32()
 {
     Float32 f;
+
     f.sign = random32();
     f.exponent = random32();
     f.mantissa = set_random_bits(random32() % (FLOAT32_MANTISSA_BITS + 1), FLOAT32_MANTISSA_BITS);
-
     return f;
 }
 
 Float64 new_random_float64()
 {
     Float64 f;
+
     f.sign = random32();
     f.exponent = random32();
     f.mantissa = set_random_bits(random32() % (FLOAT64_MANTISSA_BITS + 1), FLOAT64_MANTISSA_BITS);
-
     return f;
 }
 
 Float80 new_random_float80()
 {
     Float80 f;
+
     f.sign = random32();
     f.exponent = random32();
     f.jbit = 1;
     f.mantissa = set_random_bits(random32() % (FLOAT80_MANTISSA_BITS + 1), FLOAT80_MANTISSA_BITS);
-
     return f;
 }
 

--- a/framework/fp_vectors/Floats.h
+++ b/framework/fp_vectors/Floats.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __FP_VECTORS_H
-#define __FP_VECTORS_H
+#ifndef FRAMEWORK_FP_VECTORS_FLOATS_H
+#define FRAMEWORK_FP_VECTORS_FLOATS_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -71,15 +71,15 @@ typedef SANDSTONE_FP16_TYPE fp16_t;
 #define FLOAT64_MANTISSA_QUIET_NAN_MASK  0x8000000000000u
 #define FLOAT80_MANTISSA_QUIET_NAN_MASK  0x4000000000000000u
 
-#define FP16_SIGN_BITS        1
-#define FP16_EXPONENT_BITS    5
-#define FP16_MANTISSA_BITS    10
-#define FP16_QUIET_BITS       1
+#define FLOAT16_SIGN_BITS        1
+#define FLOAT16_EXPONENT_BITS    5
+#define FLOAT16_MANTISSA_BITS    10
+#define FLOAT16_QUIET_BITS       1
 
-#define BFLT16_SIGN_BITS      1
-#define BFLT16_EXPONENT_BITS  8
-#define BFLT16_MANTISSA_BITS  7
-#define BFLT16_QUIET_BITS     1
+#define BFLOAT16_SIGN_BITS      1
+#define BFLOAT16_EXPONENT_BITS  8
+#define BFLOAT16_MANTISSA_BITS  7
+#define BFLOAT16_QUIET_BITS     1
 
 #define FLOAT32_SIGN_BITS     1
 #define FLOAT32_EXPONENT_BITS 8
@@ -97,37 +97,37 @@ typedef SANDSTONE_FP16_TYPE fp16_t;
 #define FLOAT80_MANTISSA_BITS 63
 #define FLOAT80_QUIET_BITS    1
 
-#define FP16_DECIMAL_DIG        5
-#define FP16_DENORM_MIN         5.96046447753906250000000000000000000e-8
-#define FP16_DIG                3
-#define FP16_EPSILON            9.76562500000000000000000000000000000e-4
-#define FP16_HAS_DENORM         1
-#define FP16_HAS_INFINITY       1
-#define FP16_HAS_QUIET_NAN      1
-#define FP16_MANT_DIG           11
-#define FP16_MAX_10_EXP         4
-#define FP16_MAX                6.55040000000000000000000000000000000e+4
-#define FP16_MAX_EXP            16
-#define FP16_MIN_10_EXP         (-4)
-#define FP16_MIN                6.10351562500000000000000000000000000e-5
-#define FP16_MIN_EXP            (-13)
-#define FP16_NORM_MAX           6.55040000000000000000000000000000000e+4
+#define FLOAT16_DECIMAL_DIG        5
+#define FLOAT16_DENORM_MIN         5.96046447753906250000000000000000000e-8
+#define FLOAT16_DIG                3
+#define FLOAT16_EPSILON            9.76562500000000000000000000000000000e-4
+#define FLOAT16_HAS_DENORM         1
+#define FLOAT16_HAS_INFINITY       1
+#define FLOAT16_HAS_QUIET_NAN      1
+#define FLOAT16_MANT_DIG           11
+#define FLOAT16_MAX_10_EXP         4
+#define FLOAT16_MAX                6.55040000000000000000000000000000000e+4
+#define FLOAT16_MAX_EXP            16
+#define FLOAT16_MIN_10_EXP         (-4)
+#define FLOAT16_MIN                6.10351562500000000000000000000000000e-5
+#define FLOAT16_MIN_EXP            (-13)
+#define FLOAT16_NORM_MAX           6.55040000000000000000000000000000000e+4
 
-#define BFLT16_DECIMAL_DIG      3
-#define BFLT16_DENORM_MIN       (0x1p-133)
-#define BFLT16_DIG              2
-#define BFLT16_EPSILON          (FLT_EPSILON * 65536)
-#define BFLT16_HAS_DENORM       1
-#define BFLT16_HAS_INFINITY     1
-#define BFLT16_HAS_QUIET_NAN    1
-#define BFLT16_MANT_DIG         (FLT_MANT_DIG - 16)
-#define BFLT16_MAX_10_EXP       FLT_MAX_10_EXP
-#define BFLT16_MAX_EXP          FLT_MAX_EXP
-#define BFLT16_MAX              (0x1.fep+127f)
-#define BFLT16_MIN_10_EXP       FLT_MIN_10_EXP
-#define BFLT16_MIN_EXP          FLT_MIN_EXP
-#define BFLT16_MIN              (0x1p-126f)
-#define BFLT16_NORM_MAX         BFLT16_MAX
+#define BFLOAT16_DECIMAL_DIG      3
+#define BFLOAT16_DENORM_MIN       (0x1p-133)
+#define BFLOAT16_DIG              2
+#define BFLOAT16_EPSILON          (FLT_EPSILON * 65536)
+#define BFLOAT16_HAS_DENORM       1
+#define BFLOAT16_HAS_INFINITY     1
+#define BFLOAT16_HAS_QUIET_NAN    1
+#define BFLOAT16_MANT_DIG         (FLT_MANT_DIG - 16)
+#define BFLOAT16_MAX_10_EXP       FLT_MAX_10_EXP
+#define BFLOAT16_MAX_EXP          FLT_MAX_EXP
+#define BFLOAT16_MAX              (0x1.fep+127f)
+#define BFLOAT16_MIN_10_EXP       FLT_MIN_10_EXP
+#define BFLOAT16_MIN_EXP          FLT_MIN_EXP
+#define BFLOAT16_MIN              (0x1p-126f)
+#define BFLOAT16_NORM_MAX         BFLOAT16_MAX
 
 #ifdef __cplusplus
 extern "C" {
@@ -137,15 +137,15 @@ struct Float16
 {
     union {
         struct __attribute__((packed)) {
-            uint16_t mantissa : FP16_MANTISSA_BITS;
-            uint16_t exponent : FP16_EXPONENT_BITS;
-            uint16_t sign     : FP16_SIGN_BITS;
+            uint16_t mantissa : FLOAT16_MANTISSA_BITS;
+            uint16_t exponent : FLOAT16_EXPONENT_BITS;
+            uint16_t sign     : FLOAT16_SIGN_BITS;
         };
         struct __attribute__((packed)) {
-            uint16_t payload  : FP16_MANTISSA_BITS - FP16_QUIET_BITS;
-            uint16_t quiet    : FP16_QUIET_BITS;
-            uint16_t exponent : FP16_EXPONENT_BITS;
-            uint16_t sign     : FP16_SIGN_BITS;
+            uint16_t payload  : FLOAT16_MANTISSA_BITS - FLOAT16_QUIET_BITS;
+            uint16_t quiet    : FLOAT16_QUIET_BITS;
+            uint16_t exponent : FLOAT16_EXPONENT_BITS;
+            uint16_t sign     : FLOAT16_SIGN_BITS;
         } as_nan;
 
         uint16_t as_hex;
@@ -161,20 +161,20 @@ struct Float16
 
     constexpr inline Float16(uint16_t s, uint16_t e, uint16_t m): mantissa(m), exponent(e), sign(s) { }
 
-    static constexpr int digits = FP16_MANT_DIG;
-    static constexpr int digits10 = FP16_DIG;
+    static constexpr int digits = FLOAT16_MANT_DIG;
+    static constexpr int digits10 = FLOAT16_DIG;
     static constexpr int max_digits10 = 6;  // log2(digits)
-    static constexpr int min_exponent = FP16_MIN_EXP;
-    static constexpr int min_exponent10 = FP16_MIN_10_EXP;
-    static constexpr int max_exponent = FP16_MAX_EXP;
-    static constexpr int max_exponent10 = FP16_MAX_10_EXP;
+    static constexpr int min_exponent = FLOAT16_MIN_EXP;
+    static constexpr int min_exponent10 = FLOAT16_MIN_10_EXP;
+    static constexpr int max_exponent = FLOAT16_MAX_EXP;
+    static constexpr int max_exponent10 = FLOAT16_MAX_10_EXP;
 
     static constexpr bool radix = 2;
     static constexpr bool is_signed = true;
     static constexpr bool is_integer = false;
     static constexpr bool is_exact = false;
-    static constexpr bool has_infinity = FP16_HAS_INFINITY;
-    static constexpr bool has_quiet_NaN = FP16_HAS_QUIET_NAN;
+    static constexpr bool has_infinity = FLOAT16_HAS_INFINITY;
+    static constexpr bool has_quiet_NaN = FLOAT16_HAS_QUIET_NAN;
     static constexpr bool has_signaling_NaN = has_quiet_NaN;
     static constexpr std::float_denorm_style has_denorm = std::denorm_present;
     static constexpr bool has_denorm_loss = false;
@@ -200,11 +200,9 @@ struct Float16
     constexpr inline bool     is_negative() const         { return sign != 0; }
     constexpr inline bool     is_zero() const             { return (exponent == FLOAT16_DENORM_EXPONENT) && (mantissa == 0); }
     constexpr inline bool     is_denormal() const         { return (exponent == FLOAT16_DENORM_EXPONENT) && (mantissa != 0); }
+    constexpr inline bool     is_inf() const              { return (exponent == FLOAT16_INFINITY_EXPONENT) && (mantissa == 0); }
 
-    // NaNs
-    constexpr inline bool     is_general_nan() const      { return exponent == FLOAT16_NAN_EXPONENT; }
-    constexpr inline bool     is_inf() const              { return is_general_nan() && (mantissa == 0); }
-    constexpr inline bool     is_nan() const              { return is_general_nan() && (mantissa != 0); }
+    constexpr inline bool     is_nan() const              { return (exponent == FLOAT16_NAN_EXPONENT) && (mantissa != 0); }
     constexpr inline bool     is_snan() const             { return is_nan() && ((mantissa & FLOAT16_MANTISSA_QUIET_NAN_MASK) == 0); }
     constexpr inline bool     is_qnan() const             { return is_nan() && ((mantissa & FLOAT16_MANTISSA_QUIET_NAN_MASK) != 0); }
 
@@ -221,10 +219,9 @@ typedef struct Float16 Float16;
 static inline bool     Float16_is_negative(Float16 f)         { return f.sign != 0; }
 static inline bool     Float16_is_zero(Float16 f)             { return (f.exponent == FLOAT16_DENORM_EXPONENT) && (f.mantissa == 0); }
 static inline bool     Float16_is_denormal(Float16 f)         { return (f.exponent == FLOAT16_DENORM_EXPONENT) && (f.mantissa != 0); }
+static inline bool     Float16_is_inf(Float16 f)              { return (f.exponent == FLOAT16_INFINITY_EXPONENT) && (f.mantissa == 0); }
 
-static inline bool     Float16_is_general_nan(Float16 f)      { return f.exponent == FLOAT16_NAN_EXPONENT; }
-static inline bool     Float16_is_inf(Float16 f)              { return Float16_is_general_nan(f) && (f.mantissa == 0); }
-static inline bool     Float16_is_nan(Float16 f)              { return Float16_is_general_nan(f) && (f.mantissa != 0); }
+static inline bool     Float16_is_nan(Float16 f)              { return (f.exponent == FLOAT16_NAN_EXPONENT) && (f.mantissa != 0); }
 static inline bool     Float16_is_snan(Float16 f)             { return Float16_is_nan(f) && (f.as_nan.quiet == 0); }
 static inline bool     Float16_is_qnan(Float16 f)             { return Float16_is_nan(f) && (f.as_nan.quiet != 0); }
 
@@ -235,15 +232,15 @@ struct BFloat16
 {
     union {
         struct __attribute__((packed)) {
-            uint16_t mantissa : BFLT16_MANTISSA_BITS;
-            uint16_t exponent : BFLT16_EXPONENT_BITS;
-            uint16_t sign     : BFLT16_SIGN_BITS;
+            uint16_t mantissa : BFLOAT16_MANTISSA_BITS;
+            uint16_t exponent : BFLOAT16_EXPONENT_BITS;
+            uint16_t sign     : BFLOAT16_SIGN_BITS;
         };
         struct __attribute__((packed)) {
-            uint16_t payload  : BFLT16_MANTISSA_BITS - BFLT16_QUIET_BITS;
-            uint16_t quiet    : BFLT16_QUIET_BITS;
-            uint16_t exponent : BFLT16_EXPONENT_BITS;
-            uint16_t sign     : BFLT16_SIGN_BITS;
+            uint16_t payload  : BFLOAT16_MANTISSA_BITS - BFLOAT16_QUIET_BITS;
+            uint16_t quiet    : BFLOAT16_QUIET_BITS;
+            uint16_t exponent : BFLOAT16_EXPONENT_BITS;
+            uint16_t sign     : BFLOAT16_SIGN_BITS;
         } as_nan;
         uint16_t as_hex;
         uint16_t payload;
@@ -255,8 +252,8 @@ struct BFloat16
     constexpr inline BFloat16(uint16_t s, uint16_t e, uint16_t m): mantissa(m), exponent(e), sign(s) { }
 
     // same API as std::numeric_limits:
-    static constexpr int digits = BFLT16_MANT_DIG;
-    static constexpr int digits10 = BFLT16_DIG;
+    static constexpr int digits = BFLOAT16_MANT_DIG;
+    static constexpr int digits10 = BFLOAT16_DIG;
     static constexpr int max_digits10 = 3;  // log2(digits)
     static constexpr int min_exponent = std::numeric_limits<float>::min_exponent;
     static constexpr int min_exponent10 = std::numeric_limits<float>::min_exponent10;
@@ -297,11 +294,10 @@ struct BFloat16
     constexpr inline bool     is_negative() const       { return sign != 0; }
     constexpr inline bool     is_zero() const           { return (exponent == BFLOAT16_DENORM_EXPONENT) && (mantissa == 0); }
     constexpr inline bool     is_denormal() const       { return (exponent == BFLOAT16_DENORM_EXPONENT) && (mantissa != 0); }
+    constexpr inline bool     is_inf() const            { return (exponent == BFLOAT16_INFINITY_EXPONENT) && (mantissa == 0); }
 
     // NaNs
-    constexpr inline bool     is_general_nan() const    { return exponent == FLOAT32_NAN_EXPONENT; }
-    constexpr inline bool     is_inf() const            { return is_general_nan() && (mantissa == 0); }
-    constexpr inline bool     is_nan() const            { return is_general_nan() && (mantissa != 0); }
+    constexpr inline bool     is_nan() const            { return  (exponent == BFLOAT16_NAN_EXPONENT) && (mantissa != 0); }
     constexpr inline bool     is_snan() const           { return is_nan() && ((mantissa & BFLOAT16_MANTISSA_QUIET_NAN_MASK) == 0); }
     constexpr inline bool     is_qnan() const           { return is_nan() && ((mantissa & BFLOAT16_MANTISSA_QUIET_NAN_MASK) != 0); }
 
@@ -318,10 +314,9 @@ typedef struct BFloat16 BFloat16;
 static inline bool     BFloat16_is_negative(BFloat16 f)         { return f.sign != 0; }
 static inline bool     BFloat16_is_zero(BFloat16 f)             { return (f.exponent == BFLOAT16_DENORM_EXPONENT) && (f.mantissa == 0); }
 static inline bool     BFloat16_is_denormal(BFloat16 f)         { return (f.exponent == BFLOAT16_DENORM_EXPONENT) && (f.mantissa != 0); }
+static inline bool     BFloat16_is_inf(BFloat16 f)              { return (f.exponent == BFLOAT16_INFINITY_EXPONENT) && (f.mantissa == 0); }
 
-static inline bool     BFloat16_is_general_nan(BFloat16 f)      { return f.exponent == FLOAT32_NAN_EXPONENT; }
-static inline bool     BFloat16_is_inf(BFloat16 f)              { return BFloat16_is_general_nan(f) && (f.mantissa == 0); }
-static inline bool     BFloat16_is_nan(BFloat16 f)              { return BFloat16_is_general_nan(f) && (f.mantissa != 0); }
+static inline bool     BFloat16_is_nan(BFloat16 f)              { return (f.exponent == BFLOAT16_NAN_EXPONENT) && (f.mantissa != 0); }
 static inline bool     BFloat16_is_snan(BFloat16 f)             { return BFloat16_is_nan(f) && (f.as_nan.quiet == 0); }
 static inline bool     BFloat16_is_qnan(BFloat16 f)             { return BFloat16_is_nan(f) && (f.as_nan.quiet != 0); }
 
@@ -529,4 +524,4 @@ Float80 new_random_float80();
 } // extern "C"
 #endif
 
-#endif //PROJECT_FP_VECTORS_H
+#endif //FRAMEWORK_FP_VECTORS_FLOATS_H

--- a/framework/unit-tests/sandstone_data_tests.cpp
+++ b/framework/unit-tests/sandstone_data_tests.cpp
@@ -136,15 +136,15 @@ TEST(Float16, FiniteConversions)
     fp16_check(0x1p-15, 0x0200);
 
     // underflow and overflow
-    fp16_check_full(0x1p16, Float16::max().payload, FP16_MAX);
+    fp16_check_full(0x1p16, Float16::max().payload, FLOAT16_MAX);
     fp16_check_full(0x1p-25, 0x0000, 0);
 
     // check constants
-    fp16_check(FP16_MAX, Float16::max().payload);
-    fp16_check(FP16_MIN, Float16::min().payload);
-    fp16_check(-FP16_MAX, Float16::lowest().payload);
-    fp16_check(FP16_DENORM_MIN, Float16::denorm_min().payload);
-    fp16_check(FP16_EPSILON, Float16::epsilon().payload);
+    fp16_check(FLOAT16_MAX, Float16::max().payload);
+    fp16_check(FLOAT16_MIN, Float16::min().payload);
+    fp16_check(-FLOAT16_MAX, Float16::lowest().payload);
+    fp16_check(FLOAT16_DENORM_MIN, Float16::denorm_min().payload);
+    fp16_check(FLOAT16_EPSILON, Float16::epsilon().payload);
     fp16_check(std::numeric_limits<float>::round_error(), Float16::round_error().payload);
 }
 
@@ -198,11 +198,11 @@ TEST(BFloat16, FiniteConversions)
     bf16_check_full(FLT_MAX, BFloat16::infinity().payload, std::numeric_limits<float>::infinity());
 
     // check constants
-    bf16_check(BFLT16_MAX, BFloat16::max().payload);
-    bf16_check(BFLT16_MIN, BFloat16::min().payload);
-    bf16_check(-BFLT16_MAX, BFloat16::lowest().payload);
+    bf16_check(BFLOAT16_MAX, BFloat16::max().payload);
+    bf16_check(BFLOAT16_MIN, BFloat16::min().payload);
+    bf16_check(-BFLOAT16_MAX, BFloat16::lowest().payload);
     //bf16_check(BFLT16_DENORM_MIN, BFloat16::denorm_min().payload);
-    bf16_check(BFLT16_EPSILON, BFloat16::epsilon().payload);
+    bf16_check(BFLOAT16_EPSILON, BFloat16::epsilon().payload);
     bf16_check(std::numeric_limits<float>::round_error(), BFloat16::round_error().payload);
 }
 

--- a/framework/unit-tests/sandstone_utils_tests.cpp
+++ b/framework/unit-tests/sandstone_utils_tests.cpp
@@ -261,7 +261,7 @@ TEST(DataCompare, BFloat16)
     EXPECT_EQ(format_type_helper(my_numeric_limits<BFloat16>::min()), "0080 (0x1p-126)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<BFloat16>::denorm_min()), "0001 (0x1p-133)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<BFloat16>::epsilon()), "3c00 (0x1p-7)");
-    EXPECT_EQ(format_type_helper(BFloat16(1 + BFLT16_EPSILON)), "3f81 (0x1.02p+0)");
+    EXPECT_EQ(format_type_helper(BFloat16(1 + BFLOAT16_EPSILON)), "3f81 (0x1.02p+0)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<BFloat16>::infinity()), "7f80 (inf)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<BFloat16>::neg_infinity()), "ff80 (-inf)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<BFloat16>::quiet_NaN()), "7fc0 (nan)");
@@ -279,7 +279,7 @@ TEST(DataCompare, Float16)
     EXPECT_EQ(format_type_helper(my_numeric_limits<Float16>::min()), "0400 (0x1p-14)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<Float16>::denorm_min()), "0001 (0x1p-24)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<Float16>::epsilon()), "1400 (0x1p-10)");
-    EXPECT_EQ(format_type_helper(Float16(1 + FP16_EPSILON)), "3c01 (0x1.004p+0)");
+    EXPECT_EQ(format_type_helper(Float16(1 + FLOAT16_EPSILON)), "3c01 (0x1.004p+0)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<Float16>::infinity()), "7c00 (inf)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<Float16>::neg_infinity()), "fc00 (-inf)");
     EXPECT_EQ(format_type_helper(my_numeric_limits<Float16>::quiet_NaN()), "7e00 (nan)");


### PR DESCRIPTION
All #defs follows the same pattern of names (to avoid further confusion).
Remved "general NaN" from floats (to keep consistent with the definition).
Some common macros added.
Random functions kept in single place (alloc() moved a bit).

This is a part of '[rng_bits]' PR (https://github.com/opendcdiag/opendcdiag/pull/129), to keep the task tidy.