### PR TITLE
Silencing false positive warnings from writev

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -796,9 +796,9 @@ void logging_printf(int level, const char *fmt, ...)
     if (msg.empty())
         return;     // can happen if fmt was "%s" and the string ended up empty
 
-    IoVec vec[] = {
-        indent_spaces(),
-        std::string_view(msg)
+    iovec vec[] = {
+        IoVec(indent_spaces()),
+        IoVec(std::string_view(msg))
     };
 
     if (level <= sApp->verbosity && file_log_fd != real_stdout_fd) {
@@ -814,7 +814,7 @@ void logging_printf(int level, const char *fmt, ...)
     std::string timestamp;
     if (current_output_format() != SandstoneApplication::OutputFormat::yaml) {
         timestamp = log_timestamp();
-        vec[0] = std::string_view(timestamp);
+        vec[0] = IoVec(std::string_view(timestamp));
     }
 
     int fd = file_log_fd;
@@ -1499,11 +1499,11 @@ static void print_content_indented(int fd, std::string_view indent, std::string_
         if (!newline)
             newline = end;
 
-        IoVec vec[] = {
-            indent_spaces(),
-            indent,
-            std::string_view(line, newline - line),
-            "\n"
+        iovec vec[] = {
+            IoVec(indent_spaces()),
+            IoVec(indent),
+            IoVec(std::string_view(line, newline - line)),
+            IoVec("\n")
         };
         IGNORE_RETVAL(writev(fd, vec, std::size(vec)));
         line = newline + 1;
@@ -2120,7 +2120,7 @@ inline void YamlLogger::print_one_message(int fd, int level, std::string_view me
     }
 
     // we'll print in a single line, thank you
-    IoVec vec[] = { indent_spaces(), "    - { level: ", levels[level] };
+    iovec vec[] = { IoVec(indent_spaces()), IoVec("    - { level: "), IoVec(levels[level]) };
     IGNORE_RETVAL(writev(fd, vec, std::size(vec)));
     print_content_single_line(fd, ", text: '", message, "' }");
 }

--- a/framework/sandstone_iovec.h
+++ b/framework/sandstone_iovec.h
@@ -13,29 +13,25 @@
 #include <unistd.h>
 
 namespace {
-struct IoVec : iovec
+[[maybe_unused]] static struct iovec IoVec(struct iovec vec)
 {
-    constexpr IoVec() : iovec{nullptr, 0} {}
-    IoVec(char &c)
-        : IoVec(std::string_view(&c, 1))
-    {
-    }
-    IoVec(const char *str)
-        : IoVec(std::string_view(str))
-    {
-    }
-    IoVec(std::string_view str)
-    {
-        iov_base = const_cast<char *>(str.data());
-        iov_len = str.size();
-    }
-};
-static_assert(sizeof(IoVec[2]) == sizeof(struct iovec[2]));
+    return vec;
+}
+
+[[maybe_unused]] static struct iovec IoVec(std::string_view str = {})
+{
+    return { .iov_base = const_cast<char *>(str.data()), .iov_len = str.size() };
+}
+
+[[maybe_unused]] static struct iovec IoVec(const char *str)
+{
+    return IoVec(std::string_view(str));
+}
 
 template <typename... Args>
 [[maybe_unused]] ssize_t writeln(int fd, Args &&... args)
 {
-    IoVec vec[] = { IoVec(args)..., "\n" };
+    iovec vec[] = { IoVec(args)..., IoVec("\n") };
     return writev(fd, vec, std::size(vec));
 }
 


### PR DESCRIPTION
GCC 12 incorrectly reports reads outside boundry of an object when we
call writev with IoVec wrapper. We get warning as if it was a single
object and not an array:

    ../opendcdiag/framework/sandstone_iovec.h:39:18: warning: ‘ssize_t writev(int, const iovec*, int)’ reading 48 bytes from a region of size 16 [-Wstringop-overread]
       39 |     return writev(fd, vec, std::size(vec));
          |            ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    ../opendcdiag/framework/sandstone_iovec.h:16:8: note: source object ‘{anonymous}::IoVec::<anonymous>’ of size 16
       16 | struct IoVec : iovec
          |        ^~~~~
    In file included from ../opendcdiag/framework/sandstone_p.h:24,
                     from ../opendcdiag/framework/sandstone.cpp:64:
    /usr/include/sys/uio.h:52:16: note: in a call to function ‘ssize_t writev(int, const iovec*, int)’ declared with attribute ‘access (read_only, 2, 3)’
       52 | extern ssize_t writev (int __fd, const struct iovec *__iovec, int __count)
          |                ^~~~~~

This commit provides a simple wrapper that ensures there is enough space
by using size deduction from builtin arrays and silences the warning on
the glibc boundary call.

Signed-off-by: Wlazlyn, Patryk <patryk.wlazlyn@intel.com>