### PR TITLE
Silencing warnings that come from <immintrin.h> for AVX512

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -14,7 +14,11 @@
 #include <time.h>
 
 #ifdef __x86_64__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <immintrin.h>
+#pragma GCC diagnostic pop
 #endif
 
 #include "cpu_features.h"

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -17,7 +17,11 @@
 #ifdef __unix__
 #  include <dlfcn.h>
 #endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <immintrin.h>
+#pragma GCC diagnostic pop
 #include <inttypes.h>
 #include <string.h>
 #include <x86intrin.h>

--- a/framework/unit-tests/sandstone_utils_tests.cpp
+++ b/framework/unit-tests/sandstone_utils_tests.cpp
@@ -12,7 +12,11 @@
 #include <limits.h>
 #include <locale.h>
 #include <inttypes.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <immintrin.h>
+#pragma GCC diagnostic pop
 
 #ifndef __F16C__
 #  error "Please compile with F16C support"


### PR DESCRIPTION
GCC 12 reports a false positive warning originating in system (libgcc's)
headers that some of the variables can be (or are) used uninitialized.
These variables were explicitly set to undefined values because they do
not affect the computation, but are part of the instruction.

GCC bug is tracked here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105593

Signed-off-by: Wlazlyn, Patryk <patryk.wlazlyn@intel.com>