### PR TITLE
FW: only require trivial copying and destructing for SharedMemory

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2808,7 +2808,6 @@ static void background_scan_init()
         std::atomic<int> dummy;
         std::array<MonotonicTimePoint::rep, 24> timestamp;
     };
-    static_assert(std::is_trivial_v<FileLayout>, "mmapped file must have trivial construction");
 
     if (!sApp->service_background_scan)
         return;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -496,7 +496,8 @@ private:
     }
 };
 
-static_assert(std::is_trivial_v<SandstoneApplication::SharedMemory>);
+static_assert(std::is_trivially_copyable_v<SandstoneApplication::SharedMemory>);
+static_assert(std::is_trivially_destructible_v<SandstoneApplication::SharedMemory>);
 static_assert(std::is_trivially_copyable_v<SandstoneApplication::ExecState>);
 static_assert(std::is_trivially_destructible_v<SandstoneApplication::ExecState>);
 


### PR DESCRIPTION
We do new() it properly, so it's irrelevant whether it's trivially
constructible or not. Because it won't be in C++20, as std::atomic is no
longer trivially constructible either.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>