### PR TITLE
FW: record for each test the compiler-required CPU features

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -135,8 +135,11 @@ extern "C" {
 #define EXIT_SKIP               -255
 
 #define DECLARE_TEST_INNER2(test_id, test_description) \
-    __attribute__((aligned(alignof(void*)), used, section(SANDSTONE_SECTION_PREFIX "tests"))) struct test _test_ ## test_id = { \
-        .id = SANDSTONE_STRINGIFY(test_id), .description = test_description,
+    __attribute__((aligned(alignof(void*)), used, section(SANDSTONE_SECTION_PREFIX "tests"))) \
+    struct test _test_ ## test_id = {                   \
+        .compiler_minimum_cpu = _compilerCpuFeatures,   \
+        .id = SANDSTONE_STRINGIFY(test_id),             \
+        .description = test_description,
 #define DECLARE_TEST_INNER(test_id, test_description)   DECLARE_TEST_INNER2(test_id, test_description)
 
 #ifndef DECLARE_TEST
@@ -354,6 +357,8 @@ typedef const kvm_config_t *(*kvmconfigfunc)(void);
 
 struct test {
     /* metadata */
+    /// filled in by the DECLARE_TEST macro
+    uint64_t compiler_minimum_cpu;
 
     /// Identifier of the test.  Each test must have a unique string identifier
     const char *id;


### PR DESCRIPTION
The _compilerCpuFeatures (from cpu_features.h) corresponds to the same
bit flags as .minimum_cpu_feature and includes all the features that the
compiler is allowed to use when generating code, according to the
-march= compiler flag.

This should help catch the majority of mistakes of forgetting to set the
CPU feature (at all or some bit). It cannot catch everything when a test
uses extra CPU features via direct assembly or via intrinsics &
__attribute__((target("xxx"))).

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
