### PR TITLE
Fixed random test selection issue with --1sec/2min/5min options

### DIFF
--- a/framework/test_selectors/WeightedNonRepeatingSelector.h
+++ b/framework/test_selectors/WeightedNonRepeatingSelector.h
@@ -44,9 +44,10 @@ public:
     }
 
     weighted_run_info * select_test() override {
-        if (sum_of_weights <= 0)
+        if (sum_of_weights <= 0) {
             reset_selector();
-
+            return nullptr;  // Signals end of test list
+        }
         return pick_entry_using_weighted_value(random32() % sum_of_weights);
     }
 

--- a/framework/test_selectors/WeightedSelectorBase.h
+++ b/framework/test_selectors/WeightedSelectorBase.h
@@ -12,7 +12,7 @@
 
 #include "TestrunSelectorBase.h"
 
-#define WEIGHTED_TESTRUNNER_DEFAULT_DURATION  300
+#define WEIGHTED_TESTRUNNER_DEFAULT_DURATION  0   /* Use test natural duration */
 
 class WeightedTestrunSelector : public TestrunSelector {
 protected:
@@ -27,10 +27,14 @@ protected:
 public:
     struct test * get_next_test() override{
         auto weighted_info = this->select_test();
-        test * next_test = testinfo[weighted_info->test_index];
-        if (next_test != nullptr)
-            next_test->desired_duration = weighted_info->duration_ms;
-        return next_test;
+        if (weighted_info == nullptr)
+            return nullptr;   // Indicates end of test list
+        else {
+            test *next_test = testinfo[weighted_info->test_index];
+            if (next_test != nullptr)
+                next_test->desired_duration = weighted_info->duration_ms;
+            return next_test;
+        }
 
     }
     WeightedTestrunSelector(std::vector<struct test *> _tests)

--- a/framework/unit-tests/WeightedTestSelector_tests.cpp
+++ b/framework/unit-tests/WeightedTestSelector_tests.cpp
@@ -95,7 +95,11 @@ protected:
 
     void collect_distribution_counts(TestrunSelector *selector, int num_calls) {
         for (int i = 0; i < num_calls; i++) {
-            const char * selected_test_id = selector->get_next_test()->id;
+            auto test = selector->get_next_test();
+            if (test == nullptr)
+                test = selector->get_next_test();
+
+            const char *selected_test_id = test->id;
             counts[selected_test_id]++;
         }
     }
@@ -300,6 +304,8 @@ TEST_F(WeightedTestSelectorFixture, test_GivenATestIsNotInRuninfoList_WhenWeAddA
 
         for (int num_selections = 0; num_selections < 50; ++num_selections) {
             auto test = selector->get_next_test();
+            if (test == nullptr)
+                test = selector->get_next_test();
             picks.emplace_back(test->id);
             counts[test->id]++;
         }


### PR DESCRIPTION
Test selection for some options like --1sec/--2min/--5min was happening
in a non-random order.  This will restore the randomness to the tests
chosen to execute when using these options.