### PR TITLE
FW/Unix: print the module name and offset of the crash locus

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -891,7 +891,7 @@ void debug_init_global(const char *on_hang_arg, const char *on_crash_arg)
         } else if (strcmp(on_crash_arg, "kill") == 0) {
             on_crash_action = kill_on_crash;
         } else {
-            fprintf(stderr, "%s: unknown action for --on-crash: %s", program_invocation_name, on_crash_arg);
+            fprintf(stderr, "%s: unknown action for --on-crash: %s\n", program_invocation_name, on_crash_arg);
             exit(EX_USAGE);
         }
 


### PR DESCRIPTION
In case of Position Independent Executables, the RIP alone will be
ambiguous (as OpenDCDiag is more than 4 kB of code).

Running:
```sh
for ((i = 0; i < 10; ++i)); do
  echo -
  ./opendcdiag -Y2 -o - --selftests --retest-on-failure=0 -e selftest_sigsegv
done | yq '.[].tests[].threads[].messages[] | select(.level == "error") | .text'
```
Produces:
```json
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x55d16a03ce7f (opendcdiag+0x61e7f), CR2 = 0x7f5, trap=14 (PF), error_code = 0x4"
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x564016029e7f (opendcdiag+0x61e7f), CR2 = 0xf73, trap=14 (PF), error_code = 0x4"
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x563ab37d9e7f (opendcdiag+0x61e7f), CR2 = 0xe7d, trap=14 (PF), error_code = 0x4"
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x55a2cc47fe7f (opendcdiag+0x61e7f), CR2 = 0x15a, trap=14 (PF), error_code = 0x4"
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x55a1c1e55e7f (opendcdiag+0x61e7f), CR2 = 0xa5a, trap=14 (PF), error_code = 0x4"
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x564846a6ae7f (opendcdiag+0x61e7f), CR2 = 0x453, trap=14 (PF), error_code = 0x4"
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x55da8fefde7f (opendcdiag+0x61e7f), CR2 = 0x98b, trap=14 (PF), error_code = 0x4"
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x564698be0e7f (opendcdiag+0x61e7f), CR2 = 0x9, trap=14 (PF), error_code = 0x4"
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x56235c7d5e7f (opendcdiag+0x61e7f), CR2 = 0x8d0, trap=14 (PF), error_code = 0x4"
"E> Received signal 11 (Segmentation fault) code=1 (SEGV_MAPERR), RIP = 0x563cda299e7f (opendcdiag+0x61e7f), CR2 = 0x3e1, trap=14 (PF), error_code = 0x4"
```
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
