### PR TITLE
bats: regex fix to match suffixes in version string

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -114,7 +114,7 @@ test_yaml_regexp() {
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/command-line" ".* $args"
-    test_yaml_regexp "/version" '([a-z-]+-)?(v[0-9.]+ \([0-9a-f]{40}\)|[0-9]+-[0-9]+-g[0-9a-f]+|[0-9a-f]{12}|[0-9a-f]{40})(-.*)?'
+    test_yaml_regexp "/version" '([a-z-]+-)?(v[0-9.]+(-[0-9a-z]+)? \([0-9a-f]{40}\)|[0-9]+-[0-9]+-g[0-9a-f]+|[0-9a-f]{12}|[0-9a-f]{40})(-.*)?'
 
     local os=`uname -sr`
     if [[ "$SANDSTONE" = "wine "* ]]; then


### PR DESCRIPTION
ie. match name-v123-suffix (1234567890123456789012345678901234567890)

Signed-off-by: dawid-sabat <dawid.sabat@intel.com>