### PR TITLE
FW: make --test-list-file ignore skip-quality tests

### DIFF
--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -681,6 +681,14 @@ static struct test selftests_array[] = {
     .desired_duration = -1,
 },
 {
+    .id = "selftest_pass_low_quality",
+    .description = "Just pass",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_run = selftest_pass_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_SKIP,
+},
+{
     .id = "selftest_timedpass",
     .description = "Loops around usleep() for the regular test time",
     .groups = DECLARE_TEST_GROUPS(&group_positive),

--- a/framework/test_selectors/TestrunSelectorBase.h
+++ b/framework/test_selectors/TestrunSelectorBase.h
@@ -8,33 +8,37 @@
 
 #include <vector>
 #include <unordered_map>
-#include "sandstone.h"
+#include "sandstone_p.h"
 #include "sandstone_tests.h"
 #include "sandstone_utils.h"
 
 class TestrunSelector {
 protected:
     std::vector<struct test *> testinfo;
-    std::unordered_map<std::string, struct test *> test_by_id;
 
     TestrunSelector() = default;
     TestrunSelector(std::vector<struct test *> _tests)
         : testinfo(std::move(_tests))
     {
-        for (auto & i : testinfo){
-            test_by_id[i->id] = i;
-        }
     }
 
-    struct test * testid_to_test(const char * id, bool silent)  {
-        if (test_by_id.count(id) == 0){
-            if (!silent) {
-                fprintf(stderr, "\nERROR: Attempt to specify non-existent test id [%s] in list file\n", id);
-                exit(EX_USAGE);
+    struct test * testid_to_test(const char *id, bool silent)
+    {
+        for (struct test *test: testinfo) {
+            if (strcmp(id, test->id) == 0) {
+                // check the quality level
+                if (test->quality_level >= sApp->requested_quality)
+                    return test;
+
+                // silently skip if the requested quality is too high
+                return nullptr;
             }
-            return nullptr;
         }
-        return test_by_id[id];
+        if (!silent) {
+            fprintf(stderr, "\nERROR: Attempt to specify non-existent test id [%s] in list file\n", id);
+            exit(EX_USAGE);
+        }
+        return nullptr;
     }
 
 public:

--- a/framework/test_selectors/WeightedSelectorBase.cpp
+++ b/framework/test_selectors/WeightedSelectorBase.cpp
@@ -105,7 +105,7 @@ bool WeightedTestrunSelector::should_add_weight(const weighted_run_info * runinf
 {
 
     if ( ! KEY_EXISTS(testid_to_index_map, runinfo->test->id)) return false;
-    if (runinfo->test->quality_level < TEST_QUALITY_PROD) return false;
+    if (runinfo->test->quality_level < sApp->requested_quality) return false;
     if (runinfo->weight <= 0)  return false;
 
     return true;


### PR DESCRIPTION
Instead of printing an error. This allows us to be backwards-compatible with test list files that contain names we've retired. It also makes --test-file-list follow the same behaviour as -e.

Added tests for both.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>