### PR TITLE
FW/logging: refactor log_{platform_,}message

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -744,11 +744,9 @@ static void log_message_preformatted(int thread_num, std::string_view msg)
     if (msg[0] == 'E')
         logging_mark_thread_failed(thread_num);
 
-    int &messages_logged = cpu_data_for_thread(thread_num)->messages_logged;
-    if (messages_logged >= sApp->max_messages_per_thread)
+    std::atomic<int> &messages_logged = cpu_data_for_thread(thread_num)->messages_logged;
+    if (messages_logged.fetch_add(1, std::memory_order_relaxed) >= sApp->max_messages_per_thread)
         return;
-
-    messages_logged++;
 
     if (msg[msg.size() - 1] == '\n')
         msg.remove_suffix(1);           // remove trailing newline
@@ -1331,14 +1329,12 @@ void log_data(const char *message, const void *data, size_t size)
     if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
         return;                 // short-circuit
 
-    int &messages_logged = cpu_data_for_thread(thread_num)->messages_logged;
-    size_t &data_bytes_logged = cpu_data_for_thread(thread_num)->data_bytes_logged;
-    if ((messages_logged >= sApp->max_messages_per_thread) ||
-            (data_bytes_logged + size > sApp->max_logdata_per_thread))
+    std::atomic<int> &messages_logged = cpu_data_for_thread(thread_num)->messages_logged;
+    std::atomic<size_t> &data_bytes_logged = cpu_data_for_thread(thread_num)->data_bytes_logged;
+    if (messages_logged.fetch_add(1, std::memory_order_relaxed) >= sApp->max_messages_per_thread ||
+            (data_bytes_logged.fetch_add(size, std::memory_order_relaxed) > sApp->max_logdata_per_thread))
         return;
 
-    messages_logged++;
-    data_bytes_logged += size;
 
     log_data_common(message, static_cast<const uint8_t *>(data), size, false);
 }

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1189,7 +1189,6 @@ void logging_finish()
 FILE *logging_stream_open(int thread_num, int level)
 {
     FILE *log = log_for_thread(thread_num).log;
-    fflush(log);
     fputc(message_code(UserMessages, level), log);
     return log;
 }

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -178,10 +178,10 @@ struct alignas(64) per_thread_data
     std::atomic<ThreadState> thread_state;
 
     /* Records number of messages logged per thread of each test */
-    int messages_logged;
+    std::atomic<int> messages_logged;
 
     /* Records the number of bytes log_data'ed per thread */
-    size_t data_bytes_logged;
+    std::atomic<size_t> data_bytes_logged;
 
     /* Number of iterations of the inner loop (aka #times test_time_condition called) */
     uint64_t inner_loop_count;


### PR DESCRIPTION
This merges the two functions for the most part and makes them use a single `writev()` call to write the content.

This was originally done to fix #153, but that fails because the Linux kernel does not guarantee atomicity of write() calls and I wouldn't care to make a guess what other OSes do. If we want to have `log_platform_message()` be thread-safe, we'll need to insert a mutex.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
