### PR TITLE
FW/Win32: fix running OpenDCDiag when the path was 32 characters

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -233,7 +233,7 @@ static void find_thyself(char *argv0)
     std::string &path = sApp->path_to_self;
     path.resize(PATH_MAX);
     DWORD copied = GetModuleFileNameA(nullptr, &path[0], path.size());
-    if (copied == 0 || copied == sizeof(path)) {
+    if (copied == 0 || copied == path.size()) {
         perror("GetModuleFileNameA");
         exit(EX_OSERR);
     }


### PR DESCRIPTION
If OpenDCDiag was unpacked into a dir like
```
  c:\OpenDCDiag-1.0\opendcdiag.exe
```
it would fail to run with the message "GetModuleFileNameA: No error" because the path was exactly 32 characters and no error had occurred (though that use of perror() is also wrong because GetModuleFileName does not set errno).

This was probably introduced during refactor, when the path was a C array, for which sizeof(path) was a correct number. sizeof(std::string) is an implementation detail, 32 bytes on 64-bit libstdc++ with the C++11 ABI.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
