### PR TITLE
FW/Win32: replace the use of GetModuleFilenameA with _pgmptr

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -229,16 +229,7 @@ static void find_thyself(char *argv0)
     program_invocation_name = argv0;
 #endif
 
-#if defined(_WIN32)
-    std::string &path = sApp->path_to_self;
-    path.resize(PATH_MAX);
-    DWORD copied = GetModuleFileNameA(nullptr, &path[0], path.size());
-    if (copied == 0 || copied == path.size()) {
-        perror("GetModuleFileNameA");
-        exit(EX_OSERR);
-    }
-    path.resize(copied);
-#elif defined(AT_EXECPATH)          // FreeBSD
+#if defined(AT_EXECPATH)          // FreeBSD
     std::string &path = sApp->path_to_self;
     path.resize(PATH_MAX);
     if (elf_aux_info(AT_EXECPATH, &path[0], path.size()) == 0)
@@ -250,8 +241,11 @@ static void find_thyself(char *argv0)
 
 static const char *path_to_exe()
 {
-#ifdef __linux__
+#if defined(__linux__)
     return "/proc/self/exe";
+#elif defined(_WIN32)
+    // see https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamea
+    return _pgmptr;
 #else
     return sApp->path_to_self.c_str();
 #endif

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -339,7 +339,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     LogicalProcessorSet enabled_cpus;
     int thread_count;
 
-#ifndef __linux__
+#if !defined(__linux__) && !defined(_WIN32)
     std::string path_to_self;
 #endif
 


### PR DESCRIPTION
The documentation for that Win32 function[1] says:

> The global variable _pgmptr is automatically initialized to the full
> path of the executable file, and can be used to retrieve the full path
> name of an executable file.

[1] https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamea

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>