### PR TITLE
forkfd: fix Clang 15 ATOMIC_VAR_INIT deprecation warning

### DIFF
--- a/framework/forkfd/forkfd_c11.h
+++ b/framework/forkfd/forkfd_c11.h
@@ -48,7 +48,11 @@ typedef std::atomic<int> ffd_atomic_int;
 typedef atomic_int ffd_atomic_int;
 #endif
 
+#ifdef __cpp_lib_atomic_value_initialization
+#define FFD_ATOMIC_INIT(val)        { val }
+#else
 #define FFD_ATOMIC_INIT(val)        ATOMIC_VAR_INIT(val)
+#endif
 
 #define ffd_atomic_load(ptr, order) \
     atomic_load_explicit(ptr, order)


### PR DESCRIPTION
Replace the macro use with the expansion of the macro as it appears in both libc++ as well as libstdc++.

Fixes Clang 15 C++20 warning-turned-error:
```
  forkfd.c:157:39: error: macro 'ATOMIC_VAR_INIT' has been marked as deprecated [-Werror,-Wdeprecated-pragma]
  static ffd_atomic_int forkfd_status = FFD_ATOMIC_INIT(0);
                                        ^
  forkfd_c11.h:51:37: note: expanded from macro 'FFD_ATOMIC_INIT'
  #define FFD_ATOMIC_INIT(val)        ATOMIC_VAR_INIT(val)
                                      ^
  /d/llvm/15/bin/../include/c++/v1/atomic:2671:43: note: macro marked 'deprecated' here
  #  pragma clang deprecated(ATOMIC_VAR_INIT)
                                            ^
```
Matching Qt review: https://codereview.qt-project.org/c/qt/qtbase/+/436040
Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>