### PR TITLE
Adding PREFETCHI feature detection to simd.conf and x86simd_generate.pl

### DIFF
--- a/framework/scripts/x86simd_generate.pl
+++ b/framework/scripts/x86simd_generate.pl
@@ -13,6 +13,7 @@ my %leaves = (
     Leaf07_00ECX        => "CPUID Leaf 7, Sub-leaf 0, ECX",
     Leaf07_00EDX        => "CPUID Leaf 7, Sub-leaf 0, EDX",
     Leaf07_01EAX        => "CPUID Leaf 7, Sub-leaf 1, EAX",
+    Leaf07_01EDX        => "CPUID Leaf 7, Sub-leaf 1, EDX",
     Leaf13_01EAX        => "CPUID Leaf 13, Sub-leaf 1, EAX",
     Leaf80000001hECX    => "CPUID Leaf 80000001h, ECX",
     Leaf80000008hEBX    => "CPUID Leaf 80000008h, EBX",

--- a/framework/simd.conf
+++ b/framework/simd.conf
@@ -88,6 +88,7 @@ avx512bf16		Leaf07_01EAX	    5	avx512f	# AVX512 Brain Float16
 #fred			Leaf07_01EAX	    17		# Flexible Return and Event Delivery
 #lkgs			Leaf07_01EAX	    18		# Load into Kernel GS
 #lam			Leaf07_01EAX	    26		# Linear Address Masking
+prefetchi		Leaf07_01EDX	    14		# PREFETCHIT0/1 instructions
 #xsaveopt		Leaf13_01EAX	    0		# Optimized XSAVE
 xsavec			Leaf13_01EAX	    1		# XSAVE with Compaction
 #xgetbv1		Leaf13_01EAX	    2		# XGETBV with ECX=1


### PR DESCRIPTION
From Intel Architecture Instruction Set Extensions and Future Features (September 2022):

    PREFETCHIT0/1 instructions are enumerated by CPUID.(EAX=07H, ECX=01H).EDX.PREFETCHI[bit 14].

Signed-off-by: Wlazlyn, Patryk <patryk.wlazlyn@intel.com>