### PR TITLE
FW: kvm: Fix a few issues with the kvm framework code

### DIFF
--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -381,7 +381,9 @@ static int kvm_generic_setup_vcpu(kvm_ctx_t *ctx)
             if (kvm_real16_setup_ram(ctx)) {
                 return EXIT_FAILURE;
             }
-            kvm_real16_setup_sregs(&sregs, ctx);
+            ret = kvm_real16_setup_sregs(&sregs, ctx);
+            if (ret < 0)
+                return EXIT_FAILURE;
             return EXIT_SUCCESS;
         case KVM_ADDR_MODE_PROTECTED_64BIT:
             ctx->ram_sz = kvm_prot64_check_ram_size(ctx->config->ram_size);

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -145,6 +145,7 @@ static int kvm_generic_add_vcpu(kvm_ctx_t *ctx)
 
     ctx->runs = mmap(NULL, ctx->run_sz, PROT_READ | PROT_WRITE, MAP_SHARED, cpu_fd, 0);
     if (ctx->runs == MAP_FAILED) {
+        ctx->runs = NULL;
         close(cpu_fd);
         return -errno;
     }
@@ -161,6 +162,7 @@ static int kvm_real16_setup_ram(kvm_ctx_t *ctx)
 
     ctx->ram = mmap(NULL, ctx->ram_sz, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (ctx->ram == MAP_FAILED) {
+        ctx->ram = NULL;
         return -errno;
     }
 
@@ -486,6 +488,10 @@ int kvm_generic_run(struct test *test, int cpu)
                 close(ctx.cpu_fd);
                 munmap(ctx.runs, ctx.run_sz);
                 munmap(ctx.ram, ctx.ram_sz);
+                ctx.vm_fd = -1;
+                ctx.cpu_fd = -1;
+                ctx.runs = NULL;
+                ctx.ram = NULL;
             }
 
             ctx.vm_fd = kvm_generic_create_vm(kvm_fd);

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -133,18 +133,19 @@ static int kvm_generic_add_vcpu(kvm_ctx_t *ctx)
 {
     int cpu_fd = -1;
 
-    cpu_fd = ioctl(ctx->vm_fd, KVM_CREATE_VCPU, 0);
-    if (cpu_fd == -1) {
-        return -errno;
-    }
-
     ctx->run_sz = ioctl(kvm_fd, KVM_GET_VCPU_MMAP_SIZE, 0);
     if (ctx->run_sz == -1) {
         return -errno;
     }
 
+    cpu_fd = ioctl(ctx->vm_fd, KVM_CREATE_VCPU, 0);
+    if (cpu_fd == -1) {
+        return -errno;
+    }
+
     ctx->runs = mmap(NULL, ctx->run_sz, PROT_READ | PROT_WRITE, MAP_SHARED, cpu_fd, 0);
     if (ctx->runs == MAP_FAILED) {
+        close(cpu_fd);
         return -errno;
     }
 

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -514,7 +514,7 @@ int kvm_generic_run(struct test *test, int cpu)
         }
 
         stop = 0;
-            if (kvm_generic_reset_vcpu(&ctx, &init_regs) != EXIT_SUCCESS) {
+        if (kvm_generic_reset_vcpu(&ctx, &init_regs) != EXIT_SUCCESS) {
             result = EXIT_FAILURE;
             goto epilogue;
         }

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -477,7 +477,7 @@ int kvm_generic_run(struct test *test, int cpu)
     int count = 0;
     do {
         /* Every 16 loops reset the A bit for the memory */
-        if (count % 16 == 0) {
+        if (count && (count % 16 == 0)) {
                 madvise(ctx.ram, ctx.ram_sz, MADV_COLD);
         }
         /* Recycle VM every 128-th time. There's an issue with KVM running and


### PR DESCRIPTION
These were noticed during a review of the code.

- Fix a potential file descriptor leak
- Don't madivse NULL
- Reset file descriptors and memory pointers to their zero state when we recreate the VM
- Fix an indentation issue
- Add a missing error check.