### PR TITLE
Allow instrumenting TEST_LOOP

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -865,6 +865,7 @@ static void inline __attribute__((always_inline)) assembly_marker(P param = 0)
 }
 
 namespace AssemblyMarker {
+static constexpr uint64_t Test = 0x4e49414d54534554;        // "TESTMAIN"
 static constexpr uint64_t TestLoop = 0x504f4f4c54534554;    // "TESTLOOP"
 static constexpr uint32_t Start = 0x54525453;               // "STRT"
 static constexpr uint64_t Iterate = 0x0045544152455449;     // "ITERATE\0"
@@ -877,24 +878,16 @@ extern "C" {
 // SDE (-start_address test_start -stop_address test_end) and Valgrind
 // (--toggle-collect=thread_runner).
 
-static void __attribute__((noinline)) test_start()
+static void __attribute__((noinline, noclone)) test_start()
 {
-#ifdef __x86_64__
-    __asm__("xchg   %%rbx, %%rbx\n"
-            "xchg   %%rcx, %%rcx\n"
-            "xchg   %%rdx, %%rdx"
-            : : "D" (thread_running));
-#endif
+    using namespace AssemblyMarker;
+    assembly_marker<Test, Start>();
 }
 
-static void __attribute__((noinline)) test_end(ThreadState state)
+static void __attribute__((noinline, noclone, sysv_abi)) test_end(ThreadState state)
 {
-#ifdef __x86_64__
-    __asm__("xchg   %%rdx, %%rdx\n"
-            "xchg   %%rcx, %%rcx\n"
-            "xchg   %%rbx, %%rbx\n"
-            : : "D" (state));
-#endif
+    using namespace AssemblyMarker;
+    assembly_marker<Test, End>(state);
 }
 
 // This wrapper function is needed by emulation to be able to identify

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -738,7 +738,7 @@ static bool max_loop_count_exceeded(const struct test *the_test)
 }
 
 /* returns 1 if the test should keep running, useful for a while () loop */
-int test_time_condition(const struct test *the_test)
+int test_time_condition(const struct test *the_test) noexcept
 {
     sApp->test_tests_iteration(the_test);
     cpu_data()->inner_loop_count++;

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <stdatomic.h>
 #include <stdbool.h>
 #define thread_local _Thread_local
+#define noexcept __attribute__((__nothrow__))
 #endif
 
 #define SANDSTONE_STRINGIFY(name)       SANDSTONE_STRINGIFY2(name)
@@ -453,7 +454,7 @@ extern void _report_fail_msg(const char *file, int line, const char *msg, ...)
 /// may be called inside a test's test_run function.  It returns a
 /// non-zero value if time remains in the test's time slot and the
 /// test should continue to execute.
-extern int test_time_condition(const struct test *test);
+extern int test_time_condition(const struct test *test) noexcept;
 
 /// outputs msg to the logs, prefixing it with the string "Platform issue:"
 /// This function is usually used to log a warning when an error is detected


### PR DESCRIPTION
This adds `test_loop_start` and `test_loop_end` symbols so one can extract the looping of a given OpenDCDiag-driven test. They complement `test_start` and `test_end`, but only work for tests that use `TEST_LOOP`.

All four functions now mark their existence by way of an expensive no-op of `CMPXCHG EAX, EAX`. The RAX register will contain the main type "TESTLOOP" or "TESTMAIN" string, and the EDX one will have the state ("STRT" or "END\0"). Both the instruction and the constants are very distinctive. Doing this was inspired on <valgrind.h>, which communicates with the Valgrind by an expensive NOP of rotating RDI left four times, adding up to 64 bits.