### PR TITLE
Fix the behavior of --test-delay option.

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3599,8 +3599,8 @@ int main(int argc, char **argv)
             tc = 0;
             logging_print_iteration_start();
             initialize_smi_counts();  // used by smi_count test
-        } else if (lastTestResult != TestSkipped) {
-            if (sApp->service_background_scan)
+        } else {
+            if (sApp->service_background_scan && lastTestResult != TestSkipped)
                 background_scan_wait();
             else
                 wait_delay_between_tests();


### PR DESCRIPTION
Unlike background scan mode, --test-delay is an interactive option. If a test is skipped, the framework will constantly attempt to restart it without any delay. Consider the following command-line:

$ opendcdiag -vv -T 24h -e ifs --test-delay 30000

Instead of attempting to run the test every 5 minutes, the above will be constantly trying to restart the test (if it was skipped the first time or when it will be skipped later).