### PR TITLE
forkfd/linux: add support for LoongArch

### DIFF
--- a/framework/forkfd/forkfd_linux.c
+++ b/framework/forkfd/forkfd_linux.c
@@ -84,7 +84,8 @@ static int sys_clone(unsigned long cloneflags, int *ptid)
     return syscall(__NR_clone, cloneflags, child_stack, stack_size, ptid, newtls, ctid);
 #elif defined(__arc__) || defined(__arm__) || defined(__aarch64__) || defined(__mips__) || \
     defined(__nds32__) || defined(__hppa__) || defined(__powerpc__) || defined(__i386__) || \
-    defined(__x86_64__) || defined(__xtensa__) || defined(__alpha__) || defined(__riscv)
+    defined(__x86_64__) || defined(__xtensa__) || defined(__alpha__) || defined(__riscv) || \
+    defined(__loongarch__)
     /* ctid and newtls are inverted on CONFIG_CLONE_BACKWARDS architectures,
      * but since both values are 0, there's no harm. */
     return syscall(__NR_clone, cloneflags, child_stack, ptid, ctid, newtls);


### PR DESCRIPTION
This architecture is not CLONE_BACKWARDS in any way.

Matching Qt review: https://codereview.qt-project.org/c/qt/qtbase/+/440005

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>