### PR TITLE
Fix openssl interface and logging

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -11,6 +11,9 @@
 #include "sandstone_p.h"
 #include "sandstone_iovec.h"
 #include "sandstone_utils.h"
+#if SANDSTONE_SSL_BUILD
+#  include "sandstone_ssl.h"
+#endif
 #include "test_knobs.h"
 #include "topology.h"
 
@@ -90,9 +93,6 @@ RtlGetVersion(
 #  include <gnu/libc-version.h>
 #endif
 
-#if SANDSTONE_SSL_BUILD
-#   include <openssl/opensslv.h>
-#endif
 
 #define PROGRAM_VERSION         SANDSTONE_EXECUTABLE_NAME "-" GIT_ID
 
@@ -873,13 +873,24 @@ static std::string libc_info()
     return result;
 }
 
+#if SANDSTONE_SSL_BUILD
+static std::string openssl_info()
+{
+    std::string result = "";
+#if __has_include(<openssl/crypto.h>)
+    result = s_OpenSSL_version(0);
+#endif
+    return result;
+}
+#endif
+
 static std::string os_info()
 {
     std::string os_info;
     std::string kernel = kernel_info();
     std::string libc = libc_info();
 #if SANDSTONE_SSL_BUILD
-    std::string libssl = OPENSSL_VERSION_TEXT;
+    std::string libssl = openssl_info();
 #endif
     if (kernel.empty())
         return "<unknown>";

--- a/framework/sandstone_ssl.cpp
+++ b/framework/sandstone_ssl.cpp
@@ -41,13 +41,17 @@ void sandstone_ssl_init()
     };
 #else
     void *libcrypto;
-#ifdef SHLIB_VERSION_NUMBER
-    // For openssl 1.0 and 1.1
-    libcrypto = dlopen("libcrypto.so." SHLIB_VERSION_NUMBER, RTLD_NOW);
-#else
-    // For openssl 3.0 and above
-    libcrypto = dlopen("libcrypto.so." SANDSTONE_STRINGIFY(OPENSSL_SHLIB_VERSION), RTLD_NOW);
-#endif
+
+    // Try open openssl 1.1
+    libcrypto = dlopen("libcrypto.so.1.1", RTLD_NOW);
+
+    // If previous not avialble, try open openssl 3.0
+    if (!libcrypto)
+    {
+        libcrypto = dlopen("libcrypto.so.3", RTLD_NOW);
+    }
+
+    // When none available, don't continue
     if (!libcrypto) {
         return;
     }


### PR DESCRIPTION
Openssl interface fixes.

Both commits fix the problem of framework interface using/printing info of Openssl used during build time instead of using the one available at runtime. 