### PR TITLE
FW/Linux: set the malloc arena count to 2x the number of processors

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -26,7 +26,7 @@
 #include <getopt.h>
 #include <inttypes.h>
 #include <limits.h>
-#ifdef __GLIBC__
+#if __has_include(<malloc.h>)
 #  include <malloc.h>
 #endif
 #include <stdarg.h>
@@ -3055,10 +3055,13 @@ int main(int argc, char **argv)
     thread_num = -1;            /* indicate main thread */
     find_thyself(argv[0]);
     setup_stack_size(argc, argv);
+    sApp->enabled_cpus = init_cpus();
+#ifdef M_ARENA_MAX
+    mallopt(M_ARENA_MAX, sApp->enabled_cpus.count() * 2);
+#endif
 #ifdef __linux__
     prctl(PR_SET_TIMERSLACK, 1, 0, 0, 0);
 #endif
-    sApp->enabled_cpus = init_cpus();
 
     if (argc > 1 && strcmp(argv[1], "-x") == 0) {
         /* exec mode is when a brand new child is launched for each test, as opposed to

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1886,6 +1886,11 @@ static TestResult run_child(/*nonconst*/ struct test *test, SharedMemorySynchron
                             const SandstoneApplication::ExecState *app_state = nullptr)
 {
     if (sApp->current_fork_mode() != SandstoneApplication::no_fork) {
+#ifdef M_TRIM_THRESHOLD
+        // tell malloc we don't need it to trim the heap
+        // (this is a short-lived process)
+        mallopt(M_TRIM_THRESHOLD, -1);
+#endif
         pin_to_logical_processor(LogicalProcessor(-1), "control");
         setup_child_signals();
         debug_init_child();


### PR DESCRIPTION

We do want to have an arena per thread that we will start, to avoid
contention in malloc() of every thread. Instead, it's much better to
simply allow each thread to have its own arena.

glibc's ptmalloc implementation creates a certain number of arenas
("M_ARENA_TEST", which defaults to 8 on 64-bit systems) before querying
the system config. Up until glibc 2.36, the query had a bug[1] that
failed to initialise some memory, so glibc concluded that the system had
lots of threads available, which albeit incorrect, was actually good for
us: OpenDCDiag sets the affinity for the worker threads to exactly 1
logical processor.

[ChangeLog][Framework] Fixed an issue encountered with glibc version
2.35.1 or later, which caused memory allocations in test threads to
contend with each other. This caused some tests to have reduced
efficiency in detecting SDEs.

[1] https://sourceware.org/bugzilla/show_bug.cgi?id=28850

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
