### PR TITLE
Adding system_idle_load implementation for Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -103,6 +103,7 @@ add_project_link_arguments([
 	'-Wl,--stack,8388608',
 	'-static-libgcc',
 	'-Wl,-static',
+	'-lpdh',
 	'-lpthread',
 	'-lm',
 	'-lssp',


### PR DESCRIPTION
On Linux we are using 5 minute counter from /proc/loadavg to determine if the system was in idle state for the last 5 minutes. This patch implements similar counter but for Windows.

Signed-off-by: Wlazlyn, Patryk <patryk.wlazlyn@intel.com>