### PR TITLE
Fixing progress bar on win32

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -640,13 +640,11 @@ void logging_init_global(void)
 #ifdef _WIN32
         // no tty on win32, open app's console instead
         tty = open("CON:", _O_WRONLY);
-#else
-#ifdef _PATH_TTY
+#elif defined _PATH_TTY
         if (isatty(real_stdout_fd)) {
             // stdout is a tty, so try to open /dev/tty
             tty = open(_PATH_TTY, O_WRONLY | O_NOCTTY | O_CLOEXEC);
         }
-#endif
 #endif
     }
 


### PR DESCRIPTION
This commit fixes progress bar not showing up on Windows. Logging framework tried to open a `/dev/tty` device which is absent when building with `_WIN32` defined (this wouldn't work even under cygwin or msys). Instead of the `tty`, app's console should be used.

Signed-off-by: Lukasz Tuz <lukasz.tuz@intel.com>