### PR TITLE
FW/Linux: don't assume the MSR driver is always a module

### DIFF
--- a/framework/sysdeps/linux/msr.c
+++ b/framework/sysdeps/linux/msr.c
@@ -23,7 +23,7 @@ static void try_load_kmod()
     if (atomic_load_explicit(&tried, memory_order_relaxed))
         return;
 
-    if (access("/sys/module/msr/initstate", F_OK) < 0) {
+    if (access("/sys/module/msr", F_OK) < 0) {
         // try loading the module
         pid_t child = fork();
         if (child == 0) {


### PR DESCRIPTION
In case of CONFIG_X86_MSR=y, there's no "initstate", but /sys/module/msr is there. We could also just check for the /dev/cpu/NN/msr node's existence.