### PR TITLE
Revert "FW/Linux: apply M_TRIM_THRESHOLD to the child process"

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1886,11 +1886,6 @@ static TestResult run_child(/*nonconst*/ struct test *test, SharedMemorySynchron
                             const SandstoneApplication::ExecState *app_state = nullptr)
 {
     if (sApp->current_fork_mode() != SandstoneApplication::no_fork) {
-#ifdef M_TRIM_THRESHOLD
-        // tell malloc we don't need it to trim the heap
-        // (this is a short-lived process)
-        mallopt(M_TRIM_THRESHOLD, -1);
-#endif
         pin_to_logical_processor(LogicalProcessor(-1), "control");
         setup_child_signals();
         debug_init_child();


### PR DESCRIPTION
This reverts commit 7e034044e170ea0e698788e5adf2f5e317f749db.

Restore the default behavior of the glibc memory management. Disabling M_TRIM_THRESHOLD may have undesired side-effects on the behavior of the other memory allocation functions. E.g., the documentation states: "Dynamic adjustment of the mmap threshold is disabled if any of the M_TRIM_THRESHOLD, M_TOP_PAD, M_MMAP_THRESHOLD, or M_MMAP_MAX parameters is set."