### PR TITLE
FW: call the application footer code in case of OOM/timeout conditions too

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1944,7 +1944,8 @@ static TestResult run_one_test_once(int *tc, const struct test *test)
     case TestOutOfMemory:
         if (!sApp->ignore_os_errors) {
             logging_flush();
-            _exit(logging_close_global(2));
+            int exit_code = print_application_footer(2, {});
+            _exit(logging_close_global(exit_code));
         } else {
             // not a pass either, but won't affect the result
             real_state = TestSkipped;


### PR DESCRIPTION
I added that in commit @131c56580d7cfcbd69f7e8f1a9cb22914ef07dde but didn't add to everything. Another case is on SIGINT, but that's ok.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>