### PR TITLE
argv[0] is now quoted on Windows before being passed to _spawn

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1831,9 +1831,16 @@ static int spawn_child(const struct test *test, intptr_t *hpid, int shmempipefd)
     snprintf(statefdstr.begin(), statefdstr.size(), "%u", unsigned(statefd));
 
     std::string random_seed = random_format_seed();
+
+#ifdef _WIN32
+    // _spawn on Windows requires argv elements to be quoted if they contain space.
+    const char * const argv0 = SANDSTONE_EXECUTABLE_NAME ".exe";
+#else
+    const char * const argv0 = SANDSTONE_EXECUTABLE_NAME;
+#endif
     const char *argv[] = {
         // argument order must match exec_mode_run()
-        program_invocation_name, "-x", test->id, random_seed.c_str(),
+        argv0, "-x", test->id, random_seed.c_str(),
         statefdstr.begin(), shmempipefd >= 0 ? shmempipefdstr.begin() : nullptr,
         nullptr
     };


### PR DESCRIPTION
MSDN says we have to quote arguments passed in argv if htey contain space and we don't want them to get split:

	Spaces embedded in strings may cause unexpected behavior; for example,
	passing _spawn the string "hi there" will result in the new process
	getting two arguments, "hi" and "there". If the intent was to have the
	new process open a file named "hi there", the process would fail. You
	can avoid this by quoting the string: "\"hi there\"".

The lack of quoting were causing program to exit with error due to invalid argv[0] and thus program_invocation_name in child processes.

Signed-off-by: Wlazlyn, Patryk <patryk.wlazlyn@intel.com>