### PR TITLE
FW/Win32: find a directory for our temporary files other than "."

### DIFF
--- a/framework/sysdeps/windows/tmpfile.c
+++ b/framework/sysdeps/windows/tmpfile.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <io.h>
 #include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,9 +41,68 @@ static unsigned next_random()
     return result;
 }
 
+static bool is_dir_writable(const wchar_t *dir)
+{
+    if (!dir)
+        return false;
+
+    size_t len = wcslen(dir);
+    if (!len)
+        return false;
+    if (dir[len - 1] == L'\\')
+        return _waccess(dir, W_OK) == 0;
+
+    // append a backslash so we confirm it's a directory
+    wchar_t path[MAX_PATH];
+    wcscpy(path, dir);
+    wcscat(path, L"\\");
+    return _waccess(path, W_OK) == 0;
+}
+
+static const wchar_t *find_alternate_temp_dir()
+{
+    static const wchar_t *dirname = NULL;
+    if (dirname)
+        return dirname;
+
+    dirname = _wgetenv(L"TEMP");
+    if (is_dir_writable(dirname))
+        return dirname;
+
+    dirname = _wgetenv(L"TMP");
+    if (is_dir_writable(dirname))
+        return dirname;
+
+    return NULL;
+}
+
+// fills in the temporary directory in tmpname and returns the length of the path
+// (including the terminating backslash)
+static size_t fill_tmpdir(wchar_t tmpname[MAX_PATH])
+{
+    size_t len = GetTempPathW(MAX_PATH, tmpname);
+    if (len) {
+        wcscat(tmpname, L"\\");
+        if (is_dir_writable(tmpname))
+            return len;
+    }
+
+    const wchar_t *othertmp = find_alternate_temp_dir();
+    if (!othertmp) {
+        // use the CWD as a last resort
+        wcscpy(tmpname, L".\\");
+        return 2;
+    }
+
+    wcscpy(tmpname, othertmp);
+    wcscat(tmpname, L"\\");
+    return wcslen(tmpname);
+}
+
 int open_memfd(enum MemfdCloexecFlag flag)
 {
-    wchar_t tmpname[sizeof SANDSTONE_STRINGIFY(UINT_MAX) ".tmp"];
+    wchar_t tmppath[MAX_PATH];
+    wchar_t *tmpname = tmppath + fill_tmpdir(tmppath);
     HANDLE hFile = INVALID_HANDLE_VALUE;
     SECURITY_ATTRIBUTES sa = {};
     sa.nLength = sizeof(sa);
@@ -55,7 +115,7 @@ int open_memfd(enum MemfdCloexecFlag flag)
         DWORD sharemode = FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE;
         DWORD creation = CREATE_NEW;
         DWORD flags = FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE;
-        hFile = CreateFileW(tmpname, access, sharemode, &sa, creation, flags, NULL);
+        hFile = CreateFileW(tmppath, access, sharemode, &sa, creation, flags, NULL);
     }
     if (hFile != INVALID_HANDLE_VALUE)
         return _open_osfhandle((intptr_t)hFile, _O_BINARY | (sa.bInheritHandle ? 0 : _O_NOINHERIT));


### PR DESCRIPTION
When the tool is installed system-wide (e.g., C:\Program Files), it will not have write access to its current-working directory. So we try, in order:
 - GetTempPath()
 - %TEMP% environment variable
 - %TMP% environment variable
 - C:\Temp
 - the current working directory

We do a similar search in sysdeps/unix/tmpfile.c.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>