### PR TITLE
cpu_features.h::x86_architectures sorted properly

### DIFF
--- a/framework/scripts/x86simd_generate.pl
+++ b/framework/scripts/x86simd_generate.pl
@@ -283,7 +283,7 @@ struct X86Architecture
 };
 
 static const struct X86Architecture x86_architectures[] = {|;
-for (sort { $b <=> $a } keys %sorted_archs) {
+for (sort keys %sorted_archs) {
     my $arch = $sorted_archs{$_};
     next if $arch->{base} eq "<>";
     printf "    { cpu_%s, \"%s\" },\n", $arch->{id}, $arch->{prettyname};


### PR DESCRIPTION
Natural sorting of 'x86_architectures' array to keep binary images identical from compilation to compilation. CPU generations are alphanumerically sorted by features (t.i. list containing number of enabled features as '%02d' and names of these features).

Signed-off-by: Jarek Poswiata <jaroslaw.poswiata@intel.com>