### PR TITLE
FW/topology: fix inverted conditional in parsing /proc/cpuinfo

### DIFF
--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -117,7 +117,7 @@ static linux_cpu_info parse_proc_cpuinfo()
             char *endptr = nullptr;
             uint64_t value = strtoull(colon + 1, &endptr, 0);
             if (endptr > colon) {
-                if (value <= result.cpu_fields.size())
+                if (value >= result.cpu_fields.size())
                     result.cpu_fields.resize(value + 1);
                 current = &result.cpu_fields[value];
             } else {


### PR DESCRIPTION
We wanted to increase the vector holding the information about each CPU when we found a new CPU, so it should have been >= the current size. It was working *mostly* fine before this, so long as the Linux processor numbers didn't have any gaps, because the next number would be equal to the vector size. But it could crash the moment a gap existed because we wouldn't resize the vector.

[ChangeLog][Framework] Fixed a bug parsing /proc/cpuinfo on Linux whenever the /proc file had a gap in the processor numbering. This bug could cause the tool to crash on start, but should not cause it to report CPU failures.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>