### PR TITLE
FW: Fix Openssl link process

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -892,9 +892,8 @@ static std::string libc_info()
 static std::string openssl_info()
 {
     std::string result = "";
-#if __has_include(<openssl/crypto.h>)
-    result = s_OpenSSL_version(0);
-#endif
+    if (s_OpenSSL_version)
+        result = s_OpenSSL_version(0);
     return result;
 }
 #endif

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -76,6 +76,8 @@ framework_config.set10('SANDSTONE_RESTRICTED_CMDLINE', get_option('framework_opt
 framework_config.set10('SANDSTONE_CHILD_BACKTRACE', not get_option('framework_options').contains('no-child-backtrace'))
 
 framework_config.set10('SANDSTONE_SSL_BUILD', get_option('ssl_link_type') != 'none')
+framework_config.set10('SANDSTONE_SSL_LINKED',
+  get_option('ssl_link_type') == 'static' or get_option('ssl_link_type') == 'dynamic')
 
 framework_config_h = configure_file(
 	input : 'sandstone_config.h.in',

--- a/framework/sandstone_config.h.in
+++ b/framework/sandstone_config.h.in
@@ -27,6 +27,7 @@
 
 #mesondefine SANDSTONE_FP16_TYPE
 #mesondefine SANDSTONE_SSL_BUILD
+#mesondefine SANDSTONE_SSL_LINKED
 
 #mesondefine SANDSTONE_DEFAULT_LOGGING
 #mesondefine SANDSTONE_NO_LOGGING

--- a/framework/sandstone_ssl.h
+++ b/framework/sandstone_ssl.h
@@ -1481,7 +1481,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
-#ifdef SANDSTONE_OPENSSL_LINKED
+#if SANDSTONE_OPENSSL_LINKED
 static constexpr bool OpenSSLWorking = true;
 #  define DECLARE_FUNCTIONS(Fn)     static constexpr auto s_ ## Fn = Fn;
 #else


### PR DESCRIPTION
This commit fixes includes:
- Define SANDSTONE_SSL_LINKED. This macro would be use when library is linked (either dynamically or static).
- Log Openssl version only when function is not a null pointer. This could happen when library could not be loaded.
- Initialize functions when library is linked.