### PR TITLE
   Tap format: print corresponding RNG state.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /opendcdiag-*.yaml
 # typical names for meson build directories
 /build*/
+# ctags
+tags

--- a/bats/testenv.bash
+++ b/bats/testenv.bash
@@ -99,7 +99,7 @@ function run_sandstone_yaml()
         local structure=$(python3 $BATS_TEST_COMMONDIR/dumpyaml.py < /tmp/output.yaml)
         eval "yamldump=($structure)"
     elif [[ "$VALIDATION" != 0 ]]; then
-	python3 $BATS_TEST_COMMONDIR/yamltest.py /tmp/output.yaml
+        python3 $BATS_TEST_COMMONDIR/yamltest.py /tmp/output.yaml
         if type -p yq > /dev/null; then
 	    yq . /tmp/output.yaml > /dev/null
         fi

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1002,7 +1002,6 @@ void logging_print_iteration_start()
     case SandstoneApplication::OutputFormat::key_value:
         return logging_printf(LOG_LEVEL_QUIET, "random_generator_state = %s\n", random_seed.c_str());
     case SandstoneApplication::OutputFormat::tap:
-        return logging_printf(LOG_LEVEL_QUIET, "# Random generator state: %s\n", random_seed.c_str());
     case SandstoneApplication::OutputFormat::yaml:
         return;
     case SandstoneApplication::OutputFormat::no_output:
@@ -1089,6 +1088,7 @@ void logging_init(const struct test *test)
     case SandstoneApplication::OutputFormat::key_value:
     case SandstoneApplication::OutputFormat::tap:
         logging_printf(LOG_LEVEL_VERBOSE(2), "# Executing test %s '%s'\n", test->id, test->description);
+        logging_printf(LOG_LEVEL_VERBOSE(2), "# Seed: %s \n", random_format_seed().c_str());
         break;
     case SandstoneApplication::OutputFormat::yaml:
         // note: see comments in YamlLogger::print() on this first line


### PR DESCRIPTION
This change enhances the TAP output format to match YAML format in what                                                                                                                                           
relates to the random generator state.                                                                                                                                                                            
                                                                                                                                                                                                                  
When using TAP output format, the per-test random generator state is                                                                                                                                              
omitted hence making it difficult (and confusing) to reproduce the test                                                                                                                                           
failure, should it depend on the RNG state. With the information                                                                                                                                                  
printed, the only feasible way to reproduce is to use the execute the                                                                                                                                             
exact same command line (including all the tests which potentially do                                                                                                                                             
not need to be executed).                                                                                                                                                                                         
                                                                                                                                                                                                                  
On the contrary, when using the YAML output format, the RNG state                                                                                                                                                 
corresponding to each test execution is logged thus making it easy to                                                                                                                                             
reproduce by specifying the test seed using '-s' option.                                                                                                                                                          
                                                                                                                                                                                                                  
TAP format before:                                                                                                                                                                                                
                                                                                                                                                                                                                  
```                                                                                                                                                                 
[    0.000000] # opendcdiag -e zstd_aaa -e eigen_gemm_double14 -e eigen_gemm_double14 -o - --output-format tap                                                                                                    
< ... skipped ... >                                                                                                                                                                                               
[    0.000000] # Target test duration is 1000.000 ms per test, timeout 300000.000 ms                                                                                                                              
[    0.003999] # Random generator state: LCG:1937249670                                                                                                                                                           
[    0.003999] # Executing test zstd_aaa 'ZStandard compression test (aaa...) - ZStandard compression and decompression with highly compressible data'                                                            
[    1.075999] ok   1 zstd_aaa                                                                                                                                                                                    
[    1.083999] # Executing test eigen_gemm_double14 'Eigen GEMM payload (double, dynamic, square)'                                                                                                                
[    1.671999] ok   2 eigen_gemm_double14                                                                                                                                                                         
[    1.675999] # Executing test eigen_gemm_double14 'Eigen GEMM payload (double, dynamic, square)'                                                                                                                
[    2.147999] ok   3 eigen_gemm_double14                                                                                                                                                                         
< ... skipped ... >                                                                                                                                                                                               
[    3.219999] exit: pass                                                                                                                                                                                         
```                                                                                                                                                                 
                                                                                                                                                                                                                  
TAP format after:                                                                                                                                                                                                 
                                                                                                                                                                                                                  
```                                                                                                                                                                 
[    0.000000] # opendcdiag -e zstd_aaa -e eigen_gemm_double14 -e eigen_gemm_double14 -o - --output-format tap                                                                                                    
< ... skipped ... >                                                                                                                                                                                               
[    0.000000] # Target test duration is 1000.000 ms per test, timeout 300000.000 ms                                                                                                                              
[    0.000000] # Executing test zstd_aaa 'ZStandard compression test (aaa...) - ZStandard compression and decompression with highly compressible data'                                                            
[    0.000000] # Seed: LCG:1599338091                                                                                                                                                                             
[    1.067999] ok   1 zstd_aaa                                                                                                                                                                                    
[    1.075999] # Executing test eigen_gemm_double14 'Eigen GEMM payload (double, dynamic, square)'                                                                                                                
[    1.075999] # Seed: LCG:1759364658                                                                                                                                                                             
[    1.671999] ok   2 eigen_gemm_double14                                                                                                                                                                         
[    1.671999] # Executing test eigen_gemm_double14 'Eigen GEMM payload (double, dynamic, square)'                                                                                                                
[    1.671999] # Seed: LCG:1903102056                                                                                                                                                                             
[    2.139999] ok   3 eigen_gemm_double14                                                                                                                                                                         
< ... skipped ... >                                                                                                                                                                                               
[    3.227999] exit: pass                                                                                                                                                                                         
```
                                                                                                                                                                                                                  
YAML format:                                                                                                                                                                                                      
                                                                                                                                                                                                                  
```
command-line: 'opendcdiag -e zstd_aaa -e eigen_gemm_double14 -e eigen_gemm_double14 -o -'                                                                                                                         
< ... skipped ... >                                                                                                                                                                                               
timing: { duration: 1000.000, timeout: 300000.000 }                                                                                                                                                               
cpu-info:                                                                                                                                                                                                         
< ... skipped ... >                                                                                                                                                                                               
tests:                                                                                                                                                                                                            
- test: zstd_aaa                                                                                                                                                                                                  
  details: { quality: production, description: "ZStandard compression test (aaa...) - ZStandard compression and decompression with highly compressible data" }                                                    
  state: { seed: 'AES:4aeabece70431846aa84849f02c1b089b51541318fbce7b9557b7b60fd3e4f76', iteration: 0, retry: false }                                                                                             
  time-at-start: { elapsed:      0.000, now: !!timestamp '2023-02-15T19:13:27Z' }                                                                                                                                 
  result: pass                                                                                                                                                                                                   
  time-at-end:   { elapsed:   1059.999, now: !!timestamp '2023-02-15T19:13:28Z' }                                                                                                                                 
  test-runtime: 1060.226                                                                                                                                                                                          
- test: eigen_gemm_double14                                                                                                                                                                                       
  details: { quality: production, description: "Eigen GEMM payload (double, dynamic, square)" }                                                                                                                   
  state: { seed: 'AES:d4b1c140a0eabaff6a9406edf76b8868b51541318fbce7b9557b7b60fd3e4f76', iteration: 0, retry: false }                                                                                             
  time-at-start: { elapsed:   1067.999, now: !!timestamp '2023-02-15T19:13:28Z' }                                                                                                                                 
  result: pass                                                                                                                                                                                                    
  time-at-end:   { elapsed:   1655.999, now: !!timestamp '2023-02-15T19:13:28Z' }                                                                                                                                 
  test-runtime: 587.372                                                                                                                                                                                           
- test: eigen_gemm_double14                                                                                                                                                                                       
  details: { quality: production, description: "Eigen GEMM payload (double, dynamic, square)" }                                                                                                                   
  state: { seed: 'AES:9dbc9f8bff46ad76be19cc4dcf8fe358b51541318fbce7b9557b7b60fd3e4f76', iteration: 1, retry: false }                                                                                             
  time-at-start: { elapsed:   1655.999, now: !!timestamp '2023-02-15T19:13:28Z' }                                                                                                                                 
  result: pass                                                                                                                                                                                                    
  time-at-end:   { elapsed:   2127.999, now: !!timestamp '2023-02-15T19:13:29Z' }                                                                                                                                 
  test-runtime: 468.911                                                                                                                                                                                           
< ... skipped ... >                                                                                                                                                                                               
exit: pass                                                                                                                                                                                                        
```

Additionally, some clean up:
- Ignore ctags files
- Fix indentation in `bats/testenv.bash`.