### PR TITLE
Logging: Add format_and_print_message function

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -231,19 +231,19 @@ static const char *strnchr(const char *buffer, char c, size_t len)
 static uint8_t message_code(enum LogTypes logType, int level)
 {
     assert((int)logType < 3);
-    unsigned code = ((unsigned)logType + 1) << 6;
-    code |= (level & 0x3f);
+    unsigned code = ((unsigned)logType + 1) << 4;
+    code |= (level & 0xf);
     return (uint8_t)code;
 }
 
 static enum LogTypes log_type_from_code(uint8_t code)
 {
-    return (enum LogTypes)((code >> 6) - 1);
+    return (enum LogTypes)((code >> 4) - 1);
 }
 
 static int level_from_code(uint8_t code)
 {
-    return code & 0x3f;
+    return code & 0xf;
 }
 
 static auto thread_core_spacing()

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <assert.h>
 
 #ifdef __x86_64__
 #pragma GCC diagnostic push


### PR DESCRIPTION
Couple of commits:

1)  Adds `format_and_print_message` function. This function adds the `print_content_single_line` and `print_content_indented` functions. All logging formats use this function to take care of newline and escaping formats. This commit will be used a prerequisite to add skip message feature.

Verified that log messages are fine:

```
threads:
  - thread: main
    messages:
    - level: info
      text: |1
       I> This test requires atleast 
        2 cpus to run
    - level: debug
      text: |1
       d> This test requires atleast 
        2 cpus to run
    - level: warning
      text: |1
       W> This test requires atleast 
        2 cpus to run
    - { level: info, text: 'I> Init function requested skip with code -255' }
# Loop iteration 1 finished, average time 8.6218 ms, total 8.6218 ms
```

``` lock_in_mispredicted_branches_virtualized = no
  - |
    I> This test requires atleast 
     2 cpus to run
  - |
    d> This test requires atleast 
     2 cpus to run
  - |
    W> This test requires atleast 
     2 cpus to run
   - 'I> Init function requested skip with code -255'
# Loop iteration 1 finished, average time 8.08146 ms, total 8.08146 ms
```
```
ok   1 lock_in_mispredicted_branches# (beta test) SKIP
 ---
  info: {version: opendcdiag-a8930bd2b55a-dirty, timestamp: 2023-02-20T18:56:40Z}
  Main thread:
  - |
    I> This test requires atleast 
     2 cpus to run
  - |
    d> This test requires atleast 
     2 cpus to run
  - |
    W> This test requires atleast 
     2 cpus to run
   - 'I> Init function requested skip with code -255'
 ---
# Loop iteration 1 finished, average time 8.60926 ms, total 8.60926 ms
```


2) Will remove YamlLogger's `print_one_message` function since this is redundant. Add `assert.h` to sandstone.h file 
   which is necessary to compile simple_add.c.