### PR TITLE
FW/Unix: disable DEBUGINFO_URLS before launching gdb for backtrace

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -595,6 +595,14 @@ static void generate_backtrace(const char *pidstr, uintptr_t handle = 0, int cpu
         dup2(gdb_out.out(), STDERR_FILENO);
         dup2(gdb_out.out(), STDOUT_FILENO);
         dup2(gdb_in.in(), STDIN_FILENO);
+
+        // unset DEBUGINFO_URLS, if it is set
+        for (char **ptr = environ; *ptr; ++ptr) {
+            static char debuginfo_urls[] = "DEBUGINFO_URLS=";
+            if (strncmp(*ptr, debuginfo_urls, strlen(debuginfo_urls)) == 0)
+                (*ptr)[strlen(debuginfo_urls)] = '\0';
+        }
+
         execlp("gdb", "gdb", "-nw", "-n", "-q", "-p", pidstr, nullptr);
         _exit(EX_UNAVAILABLE);
     }


### PR DESCRIPTION
It could be useful to get glibc debug info, but that's actually easy for us to do from the post-crash backtrace information, as OpenDCDiag prints the glibc version in the header. But the Linux distribution's debug server will definitely not have information about OpenDCDiag or OpenDCDiag-based tools, so it's preferable to get a fast answer than a more detailed one.