### PR TITLE
FW/logging: split the crash / OS error result from the result: line

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -715,10 +715,11 @@ selftest_crash_common() {
     sandstone_selftest --on-crash=kill -vvv -e $test
     [[ "$status" -eq 1 ]]
     test_yaml_regexp "/exit" fail
-    test_yaml_regexp "/tests/0/result/crashed" True
-    test_yaml_regexp "/tests/0/result/core-dump" '(True|False)'
-    test_yaml_numeric "/tests/0/result/code" 'value > 0 && value == '$2
-    test_yaml_regexp "/tests/0/result/reason" "$3"
+    test_yaml_regexp "/tests/0/result" "crash"
+    test_yaml_regexp "/tests/0/result-details/crashed" True
+    test_yaml_regexp "/tests/0/result-details/core-dump" '(True|False)'
+    test_yaml_numeric "/tests/0/result-details/code" 'value > 0 && value == '$2
+    test_yaml_regexp "/tests/0/result-details/reason" "$3"
 }
 
 @test "selftest_abortinit" {
@@ -778,10 +779,10 @@ selftest_crash_common() {
     sandstone_selftest -vvv -e selftest_sigkill
     [[ "$status" -eq 2 ]]
     test_yaml_regexp "/exit" invalid    # interpreted as OOM killer
-    test_yaml_regexp "/tests/0/result/crashed" True
-    test_yaml_regexp "/tests/0/result/core-dump" '(True|False)'
-    test_yaml_numeric "/tests/0/result/code" 'value > 0 && value == 9'
-    test_yaml_regexp "/tests/0/result/reason" Killed
+    test_yaml_regexp "/tests/0/result-details/crashed" True
+    test_yaml_regexp "/tests/0/result-details/core-dump" '(True|False)'
+    test_yaml_numeric "/tests/0/result-details/code" 'value > 0 && value == 9'
+    test_yaml_regexp "/tests/0/result-details/reason" Killed
 }
 
 @test "selftest_sigkill --ignore-os-error" {
@@ -792,8 +793,8 @@ selftest_crash_common() {
     sandstone_selftest -vvv -e selftest_sigkill --ignore-os-error
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/exit" pass
-    test_yaml_regexp "/tests/0/result/crashed" True
-    test_yaml_regexp "/tests/0/result/reason" Killed
+    test_yaml_regexp "/tests/0/result-details/crashed" True
+    test_yaml_regexp "/tests/0/result-details/reason" Killed
 }
 
 @test "selftest_malloc_fail" {
@@ -817,7 +818,7 @@ selftest_crash_common() {
     sandstone_selftest --on-crash=backtrace -n1 -vvv -e selftest_sigsegv
     [[ "$status" -eq 1 ]]
     test_yaml_regexp "/exit" fail
-    test_yaml_regexp "/tests/0/result/crashed" True
+    test_yaml_regexp "/tests/0/result-details/crashed" True
     test_yaml_regexp "/tests/0/threads/0/messages/0/level" "info"
     test_yaml_regexp "/tests/0/threads/0/messages/0/text" "Backtrace:.*"
     test_yaml_regexp "/tests/0/threads/1/state" "failed"
@@ -838,10 +839,11 @@ selftest_crash_common() {
     sandstone_selftest --on-crash=kill -vvv -e selftest_oserror
     [[ "$status" -eq 2 ]]
     test_yaml_regexp "/exit" invalid
-    test_yaml_regexp "/tests/0/result/crashed" False
-    test_yaml_regexp "/tests/0/result/core-dump" False
-    test_yaml_numeric "/tests/0/result/code" 'value == 78' # EX_CONFIG
-    test_yaml_regexp "/tests/0/result/reason" "Operating system error: configuration error"
+    test_yaml_regexp "/tests/0/result" "operating system error"
+    test_yaml_regexp "/tests/0/result-details/crashed" False
+    test_yaml_regexp "/tests/0/result-details/core-dump" False
+    test_yaml_numeric "/tests/0/result-details/code" 'value == 78' # EX_CONFIG
+    test_yaml_regexp "/tests/0/result-details/reason" "Operating system error: configuration error"
 }
 
 @test "triage" {

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -833,6 +833,17 @@ selftest_crash_common() {
     fi
 }
 
+@test "selftest_oserror" {
+    declare -A yamldump
+    sandstone_selftest --on-crash=kill -vvv -e selftest_oserror
+    [[ "$status" -eq 2 ]]
+    test_yaml_regexp "/exit" invalid
+    test_yaml_regexp "/tests/0/result/crashed" False
+    test_yaml_regexp "/tests/0/result/core-dump" False
+    test_yaml_numeric "/tests/0/result/code" 'value == 78' # EX_CONFIG
+    test_yaml_regexp "/tests/0/result/reason" "Operating system error: configuration error"
+}
+
 @test "triage" {
     if ! $is_debug; then
         skip "Test only works with Debug builds (to mock the topology)"

--- a/bats/yamltest.py
+++ b/bats/yamltest.py
@@ -95,9 +95,13 @@ with open(sys.argv[1]) as file:
         validate_time(test, 'time-at-start')
         validate_time(test, 'time-at-end')
 
-        if type(result) is str:
-            if not result in ('pass', 'fail', 'skip', 'timed out'):
-                fail("result for test {} was not a valid one (was: {})".format(name, result))
+        if not result in ('pass', 'fail', 'skip', 'timed out', 'crash', 'operating system error'):
+            fail("result for test {} was not a valid one (was: {})".format(name, result))
+            if (result in ('crash', 'operating system error')):
+                test['result-details']['crashed']
+                test['result-details']['coredump']
+                test['result-details']['code']
+                test['result-details']['reason']
         if not type(runtime) is float:
             fail('test-runtime for test{} was not a number'.format(name))
 

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1933,6 +1933,7 @@ std::string TapFormatLogger::fail_info_details()
 {
     assert(status.result == TestOperatingSystemError);
     switch (status.extra) {
+    case EXIT_NOTINSTALLED: return "the program is not installed.";
     case EX_USAGE:      return "command line usage error";
     case EX_DATAERR:    return "data format error";
     case EX_NOINPUT:    return "cannot open input";
@@ -1948,6 +1949,7 @@ std::string TapFormatLogger::fail_info_details()
     case EX_PROTOCOL:   return "remote error in protocol";
     case EX_NOPERM:     return "permission denied";
     case EX_CONFIG:     return "configuration error";
+    case EXIT_MEMORY:   return "failed to perform an action due to memory shortage.";
     }
     return "unknown error";
 }

--- a/framework/sandstone_utils.h
+++ b/framework/sandstone_utils.h
@@ -20,6 +20,7 @@
 
 /*
  * Extra exit codes, from systemd.exec(3)
+ * Make sure they're listed in sysexit_reason() in logging.cpp too.
  */
 #define EXIT_NOTINSTALLED 5     /* The program is not installed. */
 #define EXIT_MEMORY     204     /* Failed to perform an action due to memory shortage. */

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -497,6 +497,11 @@ static int selftest_malloc_fail(struct test *test, int cpu)
     return ret;
 }
 
+static int selftest_oserror_run(struct test *test, int cpu)
+{
+    _exit(EX_CONFIG);
+}
+
 #if defined(STATIC) && defined(__GLIBC__)
 extern "C" {
 [[noreturn]] void __libc_fatal (const char *message);
@@ -1034,6 +1039,13 @@ FOREACH_DATATYPE(DATACOMPARE_TEST)
     .description = "Attempts to malloc a silly amount of memory",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
     .test_run = selftest_malloc_fail,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_oserror",
+    .description = "Exits the test with an operating system error",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_run = selftest_oserror_run,
     .desired_duration = -1,
 },
 {


### PR DESCRIPTION

The other result types were always a string, so some parsers failed to
properly extract the details here and ended up blank.

[ChangeLog][Framework] Changed how the YAML output format logs crashes
and other unexpected operating system errors. Previously, they were a
YAML object in the "results" entry, instead of the "pass" or "fail"
string. Now, those will print either "crash" or "operating system error"
for that entry, with the details moved to the "result-details" entry.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
