### PR TITLE
FW/child_debug: environ needs to be explicitly declared on BSDs

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -103,6 +103,8 @@ static tid_t sys_gettid()
 }
 #endif
 
+extern char **environ;
+
 namespace {
 bool must_ignore_sigpipe()
 {


### PR DESCRIPTION
Commit @9707420b45fec98152d2417a1ada1be8fc248eba added use of this variable, which on Linux/glibc is declared in <unistd.h>. But we need to explicitly declare it for FreeBSD.