### PR TITLE
Made WeightedPicker weights 32 bit

### DIFF
--- a/framework/sandstone_test_utils.h
+++ b/framework/sandstone_test_utils.h
@@ -128,8 +128,8 @@ template <typename T>
 struct WeightedPicker {
 
     uint64_t sum_of_weights = 0;
-    std::map<T, uint64_t>  weights;
-    explicit WeightedPicker(std::map<T, uint64_t>  weights){
+    std::map<T, uint32_t>  weights;
+    explicit WeightedPicker(std::map<T, uint32_t>  weights){
         this->weights = weights;
         prepare_picker();
     }
@@ -152,8 +152,8 @@ struct WeightedPicker {
         return weights.begin()->first;
     }
 
-    inline static uint64_t rand_from(uint64_t low, uint64_t high){
-        return (random64() % (high - low + 1)) + low;
+    inline static uint32_t rand_from(uint32_t low, uint32_t high){
+        return (rand() % (high - low + 1)) + low;
     }
 };
 

--- a/framework/unit-tests/sandstone_test_utils_tests.cpp
+++ b/framework/unit-tests/sandstone_test_utils_tests.cpp
@@ -7,12 +7,6 @@
 #include <vector>
 #include "gtest/gtest.h"
 
-// Mocking random64() so I can break the dependency on the sandstone
-// random libraries which brings in  a lot of other dependencies
-size_t random64() {
-    return (size_t) rand();
-}
-
 #include "sandstone_test_utils.h"
 
 


### PR DESCRIPTION
Picker weights are 32 bit to avoid overflow when summing all weights Input weight type must now be uint32_t instead of uint64_t