### PR TITLE
FW: remove RC4 cipher functions from sandstone_ssl.h

### DIFF
--- a/framework/sandstone_ssl.h
+++ b/framework/sandstone_ssl.h
@@ -834,9 +834,6 @@
     F(EVP_rc2_cfb)                               \
     F(EVP_rc2_ecb)                               \
     F(EVP_rc2_ofb)                               \
-    F(EVP_rc4_40)                                \
-    F(EVP_rc4_hmac_md5)                          \
-    F(EVP_rc4)                                   \
     /*F(EVP_rc5_32_12_16_cbc)                    \
     F(EVP_rc5_32_12_16_cfb64)                    \
     F(EVP_rc5_32_12_16_cfb)                      \


### PR DESCRIPTION
Otherwise, we can't compile against hardened OpenSSL that Linux distributions usually ship.