### PR TITLE
Remove x86 aligned vector memory-operation instructions

### DIFF
--- a/framework/sysdeps/windows/win32_stdlib.h
+++ b/framework/sysdeps/windows/win32_stdlib.h
@@ -9,31 +9,6 @@
 #ifndef WIN32_STDLIB_H
 #define WIN32_STDLIB_H
 
-// Force the assembler to not to emit aligned AVX instructions
-//
-// printf 'asm(\n'
-// for i in vmovapd vmovaps vmovdqa vmovdqa32 vmovdqa64; do
-//     printf '    \".macro %s args:vararg\\n\"\n    \"    %s \\\\args\\n\"\n    \".endm\\n\"\n' $i ${i/a/u}
-// done
-// printf ');\n'
-asm(
-    ".macro vmovapd args:vararg\n"
-    "    vmovupd \\args\n"
-    ".endm\n"
-    ".macro vmovaps args:vararg\n"
-    "    vmovups \\args\n"
-    ".endm\n"
-    ".macro vmovdqa args:vararg\n"
-    "    vmovdqu \\args\n"
-    ".endm\n"
-    ".macro vmovdqa32 args:vararg\n"
-    "    vmovdqu32 \\args\n"
-    ".endm\n"
-    ".macro vmovdqa64 args:vararg\n"
-    "    vmovdqu64 \\args\n"
-    ".endm\n"
-);
-
 #define _CRT_RAND_S
 #include <stdlib.h>
 

--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,10 @@ if host_machine.cpu_family() == 'x86_64'
     ]
     if cc.has_argument('-Wa,-muse-unaligned-vector-move')
         march_flags += [ '-Wa,-muse-unaligned-vector-move' ]
+    elif target_machine.system() == 'windows' and cpp.get_id() == 'gcc'
+        warning('GCC for Windows is unable to generate 32-byte-aligned stacks necessary for AVX content. ' +
+                'Please upgrade to a version of binutils that supports the option -muse-unaligned-vector-move (2.38 or later). ' +
+                'The application will randomly crash at runtime otherwise.')
     endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,9 @@ if host_machine.cpu_family() == 'x86_64'
         '-mno-rdrnd',
         '-falign-loops=32',
     ]
+    if cc.has_argument('-Wa,-muse-unaligned-vector-move')
+        march_flags += [ '-Wa,-muse-unaligned-vector-move' ]
+    endif
 endif
 
 debug_nasm_flags = ''


### PR DESCRIPTION
This is something we already did for Windows, due to a GCC limitation
in emitting the necessary SEH metadata (see[1]). This updates the
Linux and other builds to the same, by asking the assembler to
generate only unaligned instructions.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49001

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>
