### PR TITLE
Fix crashes of tests_skx tests on Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,12 @@ jobs:
       run: |
         ulimit -St 120
         SANDSTONE_BIN=builddir/opendcdiag bats -t bats/sanity-check
+    - name: run tests quickly
+      run: |
+        ulimit -St 120
+        nproc=`nproc`
+        nproc=$((nproc > 4 ? 4 : nproc))
+        builddir/opendcdiag --quick -o -n$nproc
 
   build-windows:
     runs-on: ubuntu-latest
@@ -100,3 +106,9 @@ jobs:
         wine builddir-windows-cross/opendcdiag.exe --dump-cpu-info
     - name: run selftests
       run: SANDSTONE_BIN=builddir-windows-cross/opendcdiag.exe bats -t bats/sanity-check
+    - name: run tests quickly
+      run: |
+        ulimit -St 120
+        nproc=`nproc`
+        nproc=$((nproc > 4 ? 4 : nproc))
+        wine builddir/opendcdiag.exe --quick -o -n$nproc

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,12 +14,14 @@ tests_common_c_args = [
     debug_c_flags,
     default_c_warn,
     default_c_flags,
+    march_flags,
 ]
 
 tests_common_cpp_args = [
     debug_c_flags,
     default_cpp_warn,
     default_cpp_flags,
+    march_flags,
 ]
 
 tests_common_incdirs = [
@@ -104,11 +106,9 @@ tests_base_a = static_library(
     ],
     c_args : [
         tests_common_c_args,
-        march_flags,
     ],
     cpp_args : [
         tests_common_cpp_args,
-        march_flags,
     ],
 )
 


### PR DESCRIPTION
We forgot to apply the `march_flags` for tests_hsw and tests_skx, which are exactly the ones where we want the -Wa,-muse-unaligned-vector-move option to go. This fixes running the eigen_svd_cdouble test on Windows after commit @442ba21b4e5fed017af80b55503282096397c271 (PR #215) removed the old workaround.
