### PR TITLE
CI: fix attempts to run OpenDCDiag after building

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: setup Git
       run: git config --system safe.directory '*'
     - name: meson setup -Dbuildtype=debugoptimized
-      run: meson setup builddir -Dssl_link_type=dynamic
+      run: meson setup builddir -Dssl_link_type=dynamic -Dbuildtype=debugoptimized
     - name: ninja build
       run: ninja -C builddir
     - name: ninja build unittests
@@ -86,7 +86,7 @@ jobs:
     - name: setup Git
       run: git config --system safe.directory '*'
     - name: meson setup
-      run: meson setup builddir-windows-cross --cross-file meson-cross-win32.ini
+      run: meson setup builddir-windows-cross -Dbuildtype=release --cross-file meson-cross-win32.ini
     - name: ninja build
       run: ninja -C builddir-windows-cross
     - name: install Wine

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,12 +57,13 @@ jobs:
         ulimit -St 120
         nproc=`nproc`
         nproc=$((nproc > 4 ? 4 : nproc))
-        builddir/opendcdiag --quick -n$nproc -o -
+        builddir/opendcdiag --quick -n$nproc --retest-on-failure=0 -o -
 
   build-windows:
     runs-on: ubuntu-latest
     container: fedora:34
     env:
+      WINEDEBUG: fixme-all,-dbghelp_stabs
       WINEPREFIX: /tmp/wine_root
       WINEPATH: d:/bin
     steps:
@@ -99,6 +100,8 @@ jobs:
         winecfg
         rpm -ql mingw64-zlib | sed -n '/bin\/zlib1.dll/s///p' | \
             xargs -rtI@ ln -s @ $WINEPREFIX/dosdevices/d:
+        # Disable the GUI debugger
+        wine reg add 'HKEY_LOCAL_MACHINE\Software\Wine\winedbg' /v ShowCrashDialog /t REG_DWORD /d 00000000
     - name: confirm Wine works
       run: |
         wine cmd /c ver
@@ -111,4 +114,4 @@ jobs:
         ulimit -St 120
         nproc=`nproc`
         nproc=$((nproc > 4 ? 4 : nproc))
-        wine builddir/opendcdiag.exe --quick -n$nproc -o -
+        wine builddir-windows-cross/opendcdiag.exe --quick --retest-on-failure=0 -n$nproc -o -

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
 
   build-windows:
     runs-on: ubuntu-latest
-    container: fedora:34
+    container: fedora:38
     env:
       WINEDEBUG: fixme-all,-dbghelp_stabs
       WINEPREFIX: /tmp/wine_root
@@ -69,7 +69,7 @@ jobs:
     steps:
     - name: Install distro packages
       run: |
-        dnf install -y \
+        dnf install --setopt=install_weak_deps=False -y \
             cmake \
             git \
             meson \

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -762,13 +762,9 @@ selftest_crash_common() {
     if ! $is_windows; then
         skip "Windows-only test"
     fi
-    if [[ "$SANDSTONE" = "wine "* ]]; then
-        # WINE doesn't handle __fastfail very well / at all
-        selftest_crash_common selftest_fastfail x x 0xC0000005 'Access violation'
-    else
-        # I don't know *why* we get this error, but we do
-        selftest_crash_common selftest_fastfail x x 0xC0000409 "Stack buffer overrun"
-    fi
+
+    # I don't know *why* we get this error, but we do
+    selftest_crash_common selftest_fastfail x x 0xC0000409 "Stack buffer overrun"
 }
 
 @test "selftest_sigkill" {

--- a/meson.build
+++ b/meson.build
@@ -100,7 +100,6 @@ add_project_arguments([
     '-D__USE_MINGW_ANSI_STDIO',
     '-D_POSIX',
     '-D_WIN32_WINNT=0x0A00',
-    '-gstabs+',
     '-Wa,-mbig-obj',
     '-include',
     meson.current_source_dir() + '/framework/sysdeps/windows/win32_stdlib.h',


### PR DESCRIPTION
It's probably best to build OpenDCDiag in release-like modes, so it doesn't take *too* long to run. This improves the selftests too, because some of the test functions check the timing.

To make the Wine-based run work, I needed to upgrade it, so this PR updates the Windows image to Fedora 38, which carries MinGW/GCC 12 and Wine 8.6.