### PR TITLE
IFS: don't stop execution at failure

### DIFF
--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -261,13 +261,7 @@ static int scan_run(struct test *test, int cpu)
     for (int i = 0; i < count; i++)
     {
         int scan_ret = scan_run_helper(test, i);
-        if (scan_ret >= EXIT_FAILURE)
-        {
-            /* scan_run_helper has called log error, so the thread "i" has been
-             * mark as failed. */
-            break;
-        }
-        else if (scan_ret == IFS_EXIT_CANNOT_START)
+        if (scan_ret == IFS_EXIT_CANNOT_START)
         {
             return EXIT_SKIP;
         }


### PR DESCRIPTION
Instead of stopping execution when a failure is found, keep going untill all cores have been tested. Details about the error will be saved on logs, so no need to worry about override them.