### PR TITLE
Fix test listing behavior and enabling/disabling tests

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2592,6 +2592,8 @@ static struct test *get_next_test(int tc)
     }
 
     auto next_test = test_selector->get_next_test();
+    while (next_test && next_test->quality_level < sApp->requested_quality)
+        next_test = test_selector->get_next_test();
 
     if (next_test == nullptr){
         return get_next_test_iteration();


### PR DESCRIPTION
The tests listing (options -l, --list-tests, --list-groups) are not 
taking into account the set of tests specified on the command line,
either test list, built in tests list, or --enable/--disable options.

Before any option modifying the actual test list were ignored by the 
list options. With this change, the actual tests that would be executed
are listed. However, the default behavior of 'opendcdiag -l' stays the 
same.

Some examples illustrating the new behavior:
```
$ ./builddir/opendcdiag -vv -l -e eigen_svd -e zstd1
1 eigen_svd            "Eigen SVD (Singular Value Decomposition) solving payload, which issues a bunch of matrix multiplies underneath"
2 zstd1                "ZStandard compression test - ZStandard compression and decompression with random data (level 1)" 

Groups:
@compression           "Tests that drive compression routines in various libraries"
  zstd1
@math                  "Tests that perform math using, e.g., Eigen"
  eigen_svd
$ ./builddir/opendcdiag -vv -l -e eigen_svd -e zstd1 --disable=zstd1
1 eigen_svd            "Eigen SVD (Singular Value Decomposition) solving payload, which issues a bunch of matrix multiplies underneath"

Groups:
@compression           "Tests that drive compression routines in various libraries"
@math                  "Tests that perform math using, e.g., Eigen"
  eigen_svd
$ cat testlist
eigen_svd
zstd1
$ ./builddir/opendcdiag -vv -l --test-list-file=testlist
1 eigen_svd            "Eigen SVD (Singular Value Decomposition) solving payload, which issues a bunch of matrix multiplies underneath"
2 zstd1                "ZStandard compression test - ZStandard compression and decompression with random data (level 1)" 

Groups:
@compression           "Tests that drive compression routines in various libraries"
  zstd1
@math                  "Tests that perform math using, e.g., Eigen"
  eigen_svd
$ ./builddir/opendcdiag -vv -l --test-list-file=testlist --disable=eigen_svd
1 zstd1                "ZStandard compression test - ZStandard compression and decompression with random data (level 1)" 

Groups:
@compression           "Tests that drive compression routines in various libraries"
  zstd1
```

Additionally, issue #213 is fixed.