### PR TITLE
Fix file descriptor insufficiency on Linux

### DIFF
--- a/framework/random.cpp
+++ b/framework/random.cpp
@@ -408,7 +408,7 @@ static inline int open_random_file(const char *filename)
     return open(filename, O_RDONLY | O_CLOEXEC);
 }
 
-void random_global_init(const char *seed_from_user)
+void random_init_global(const char *seed_from_user)
 {
     auto make_engine = [](EngineType engine_type) {
         switch (engine_type) {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3632,6 +3632,7 @@ int main(int argc, char **argv)
 
     load_cpu_info(sApp->enabled_cpus);
     signals_init_global();
+    resource_init_global();
 
     init_shmem(UseSharedMemory);
     debug_init_global(on_hang_arg, on_crash_arg);

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2600,7 +2600,7 @@ static int exec_mode_run(int argc, char **argv)
     if (!test_to_run) return EX_DATAERR;
 
     logging_init_global_child();
-    random_global_init(argv[1]);
+    random_init_global(argv[1]);
 
     std::vector<struct test *> test_list;
     add_test(test_list, test_to_run);
@@ -3640,7 +3640,7 @@ int main(int argc, char **argv)
     print_application_banner();
     logging_init_global();
     cpu_specific_init();
-    random_global_init(seed);
+    random_init_global(seed);
     background_scan_init();
 
     if (sApp->verbosity == -1)

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1857,7 +1857,7 @@ static TestResult run_child(/*nonconst*/ struct test *test, SharedMemorySynchron
 {
     if (sApp->current_fork_mode() != SandstoneApplication::no_fork) {
         pin_to_logical_processor(LogicalProcessor(-1), "control");
-        setup_child_signals();
+        signals_init_child();
         debug_init_child();
         shmemsync.prepare_child();
     }
@@ -3631,7 +3631,7 @@ int main(int argc, char **argv)
         sApp->total_retest_count = 10 * sApp->retest_count; // by default, 100
 
     load_cpu_info(sApp->enabled_cpus);
-    setup_signals();
+    signals_init_global();
 
     init_shmem(UseSharedMemory);
     debug_init_global(on_hang_arg, on_crash_arg);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -539,16 +539,6 @@ void random_init();
 /* sandstone.cpp */
 TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::PerCpuFailures &per_cpu_fails);
 
-/* stacksize.cpp */
-#ifdef _WIN32
-static inline void setup_stack_size(int, char **)
-{
-    // On Windows, we know the OS obeys the -Wl,--stack= argument
-}
-#else
-void setup_stack_size(int argc, char **argv);
-#endif
-
 #endif
 
 #if SANDSTONE_NO_LOGGING

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -531,7 +531,7 @@ static inline void logging_stream_close(FILE *log)
 TestResult logging_print_results(ChildExitStatus status, int *tc, const struct test *test);
 
 /* random.cpp */
-void random_global_init(const char *argument);
+void random_init_global(const char *argument);
 void random_advance_seed();
 std::string random_format_seed();
 void random_init();

--- a/framework/sandstone_system.h
+++ b/framework/sandstone_system.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SANDSTONE_SYSTEM_H
+#define SANDSTONE_SYSTEM_H
+
+#include <stdint.h>
+
+/* signals.cpp */
+struct SignalState
+{
+    intptr_t signal;
+    intptr_t count;
+};
+
+void setup_signals();
+void setup_child_signals();
+SignalState last_signal();
+void enable_interrupt_catch();      // Unix only
+void disable_interrupt_catch();     // Unix only
+
+/* stacksize.cpp */
+#ifdef _WIN32
+static inline void setup_stack_size(int, char **)
+{
+    // On Windows, we know the OS obeys the -Wl,--stack= argument
+}
+#else
+void setup_stack_size(int argc, char **argv);
+#endif
+
+#endif // SANDSTONE_SYSTEM_H

--- a/framework/sandstone_system.h
+++ b/framework/sandstone_system.h
@@ -15,8 +15,8 @@ struct SignalState
     intptr_t count;
 };
 
-void setup_signals();
-void setup_child_signals();
+void signals_init_global();
+void signals_init_child();
 SignalState last_signal();
 void enable_interrupt_catch();      // Unix only
 void disable_interrupt_catch();     // Unix only

--- a/framework/sandstone_system.h
+++ b/framework/sandstone_system.h
@@ -8,6 +8,9 @@
 
 #include <stdint.h>
 
+/* resource.cpp */
+void resource_init_global();
+
 /* signals.cpp */
 struct SignalState
 {

--- a/framework/sandstone_utils.h
+++ b/framework/sandstone_utils.h
@@ -22,6 +22,7 @@
  * Extra exit codes, from systemd.exec(3)
  * Make sure they're listed in sysexit_reason() in logging.cpp too.
  */
+#define EXIT_NOPERMISSION 4     /* The user has insufficient privileges. */
 #define EXIT_NOTINSTALLED 5     /* The program is not installed. */
 #define EXIT_MEMORY     204     /* Failed to perform an action due to memory shortage. */
 

--- a/framework/sysdeps/unix/meson.build
+++ b/framework/sysdeps/unix/meson.build
@@ -3,6 +3,7 @@
 
 sysdeps_unix_files = files(
     'child_debug.cpp',
+    'resource.cpp',
     'signals.cpp',
     'splitlock_detect.c',
     'stacksize.cpp',

--- a/framework/sysdeps/unix/meson.build
+++ b/framework/sysdeps/unix/meson.build
@@ -3,6 +3,7 @@
 
 sysdeps_unix_files = files(
     'child_debug.cpp',
+    'signals.cpp',
     'splitlock_detect.c',
     'stacksize.cpp',
     'tmpfile.c',

--- a/framework/sysdeps/unix/resource.cpp
+++ b/framework/sysdeps/unix/resource.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sandstone_system.h>
+#include <sandstone_config.h>
+#include <sandstone_p.h>
+
+#include <algorithm>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/resource.h>
+
+void resource_init_global()
+{
+    // rounded up so it doesn't look precise
+    static const int FileDescriptorOverhead = 64;
+    static const int FileDescriptorsPerThread = 4;
+    rlim_t desired_fd_count = num_cpus() * FileDescriptorsPerThread + FileDescriptorOverhead;
+    desired_fd_count = ROUND_UP_TO(desired_fd_count, 256);
+
+    struct rlimit oldlimit;
+    if (getrlimit(RLIMIT_NOFILE, &oldlimit) < 0) {
+        perror("getrlimit");
+        exit(EX_OSERR);
+    }
+    if (oldlimit.rlim_cur < desired_fd_count) {
+        // increase it
+        struct rlimit newlimit;
+        newlimit.rlim_cur = desired_fd_count;
+        newlimit.rlim_max = std::max(desired_fd_count, oldlimit.rlim_max);
+        if (setrlimit(RLIMIT_NOFILE, &newlimit) < 0) {
+            int exit_reason = errno == EPERM ? EXIT_NOPERMISSION : EX_OSERR;
+            fprintf(stderr, "%s: failed to increase file descriptor limit: %m\n",
+                    program_invocation_name);
+            fprintf(stderr, "The number of file descriptors for this system (soft %zu, hard %zu) is "
+                            "too low for the number of CPUs being tested (%d).\n"
+                            "Either increase the number of allowed file descriptors to %zu or "
+                            "decrease the number of CPUs being tested, using taskset(1)"
+#if SANDSTONE_RESTRICTED_CMDLINE
+                            " or schedtool(1).\n"
+#else
+                            ", or schedtool(1), or the --cpuset command-line option.\n"
+#endif
+                            "If using bash, type 'help ulimit' for information on increasing the "
+                            "file descriptor limit.\n",
+                    oldlimit.rlim_cur, oldlimit.rlim_max, num_cpus(), desired_fd_count);
+            exit(exit_reason);
+        }
+    }
+}

--- a/framework/sysdeps/unix/signals.cpp
+++ b/framework/sysdeps/unix/signals.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sandstone_system.h>
+#include <sandstone.h>
+
+#include <initializer_list>
+
+#include <signal.h>
+#include <sys/wait.h>
+
+static constexpr std::initializer_list<int> termination_signals = {
+    SIGHUP, SIGINT, SIGTERM, SIGPIPE
+};
+
+#  if (defined(__WAIT_INT) && defined(__linux__)) || defined(__APPLE__)
+// glibc prior to 2.24 defined WTERMSIG with compatibility with BSD union wait
+// Apple libc does the same
+static constexpr uint32_t SignalMask = 0x7f;
+#  else
+static constexpr uint32_t SignalMask = WTERMSIG(~0);
+#  endif
+static constexpr int SignalBits = __builtin_clz(SignalMask + 1);
+static_assert(SignalMask >> SignalBits == 0, "Sanity check");
+static std::atomic<uint32_t> signal_control;
+
+static void signal_handler(int signum)
+{
+    // communicate which signal we've received
+    uint32_t expected = 0;
+    if (signal_control.compare_exchange_strong(expected, W_EXITCODE(1, signum), std::memory_order_relaxed)) {
+        // initial clean up
+    } else {
+        // just increment the counter
+        signal_control.fetch_add(W_EXITCODE(1, 0), std::memory_order_relaxed);
+    }
+}
+
+SignalState last_signal()
+{
+    uint32_t cur_sig_state = signal_control.load(std::memory_order_relaxed);
+    int signal = WTERMSIG(cur_sig_state);
+    int count = cur_sig_state >> SignalBits;
+    return { .signal = signal, .count = count };
+}
+
+static void setup_signals(std::initializer_list<int> signals)
+{
+    struct sigaction sa = {};
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESETHAND;
+    sa.sa_handler = signal_handler;
+    for (int sig : signals)
+        sigaction(sig, &sa, nullptr);
+}
+
+void setup_signals()
+{
+     setup_signals(termination_signals);
+}
+
+void setup_child_signals()
+{
+    // create a new session so the parent will get SIGHUP/SIGINT instead of us
+    IGNORE_RETVAL(setsid());
+
+    // restore termination signals
+    struct sigaction sa = {};
+    sigemptyset(&sa.sa_mask);
+    sa.sa_handler = SIG_DFL;
+    for (int sig : termination_signals)
+        sigaction(sig, &sa, nullptr);
+}
+
+void enable_interrupt_catch()
+{
+    setup_signals({ SIGINT });
+}
+
+void disable_interrupt_catch()
+{
+    signal(SIGINT, SIG_DFL);
+}
+

--- a/framework/sysdeps/unix/signals.cpp
+++ b/framework/sysdeps/unix/signals.cpp
@@ -51,12 +51,12 @@ static void setup_signals(std::initializer_list<int> signals)
         sigaction(sig, &sa, nullptr);
 }
 
-void setup_signals()
+void signals_init_global()
 {
      setup_signals(termination_signals);
 }
 
-void setup_child_signals()
+void signals_init_child()
 {
     // create a new session so the parent will get SIGHUP/SIGINT instead of us
     IGNORE_RETVAL(setsid());

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -9,6 +9,7 @@ sysdeps_a = static_library(
         'cpu_affinity.cpp',
         'fcntl.c',
         'mman.c',
+        'signals.cpp',
         'splitlock_detect.c',
         'tmpfile.c',
         'ucrt-mapping.c',

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -9,6 +9,7 @@ sysdeps_a = static_library(
         'cpu_affinity.cpp',
         'fcntl.c',
         'mman.c',
+        'resource.cpp',
         'signals.cpp',
         'splitlock_detect.c',
         'tmpfile.c',

--- a/framework/sysdeps/windows/resource.cpp
+++ b/framework/sysdeps/windows/resource.cpp
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+void resource_init_global()
+{
+}

--- a/framework/sysdeps/windows/signals.cpp
+++ b/framework/sysdeps/windows/signals.cpp
@@ -9,12 +9,12 @@
 #include <windows.h>
 
 #warning "Check if we need to handle SIGINT in one or both of these functions"
-void setup_signals()
+void signals_init_global()
 {
     SetErrorMode(SEM_FAILCRITICALERRORS);
 }
 
-void setup_child_signals()
+void signals_init_child()
 {
     SetErrorMode(SEM_FAILCRITICALERRORS);
 }

--- a/framework/sysdeps/windows/signals.cpp
+++ b/framework/sysdeps/windows/signals.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sandstone_system.h>
+#include <sandstone.h>
+
+#include <windows.h>
+
+#warning "Check if we need to handle SIGINT in one or both of these functions"
+void setup_signals()
+{
+    SetErrorMode(SEM_FAILCRITICALERRORS);
+}
+
+void setup_child_signals()
+{
+    SetErrorMode(SEM_FAILCRITICALERRORS);
+}


### PR DESCRIPTION
Along with other cleanups to the signal handling.

Linux defaults to 1024 file descriptors by default (a legacy caused by
FD_SETSIZE being 1024). The logging framework needs 1 file descriptor
for each thread for the logging file. If a test required two file
descriptors per thread, as in the example of creating a pipe, we were
limited to 341 processors before starting to get unexpected OS errors.

There are many 8-socket systems commercially available that exceed those
limits. An 8-socket 28-core system of the Cascade Lake generation would
add up to 448 logical processors. An 8-socket 60-core Sapphire Rapids
racks up to 960 logical processors.

This commit assumes that 4 file descriptors per thread will be enough
for all tests, plus a reasonable, baseline overhead. This means we won't
touch the Linux default for anything under 240 logical processors.

This can be tested by forcing the hard limit to less than 256:
```
 $ (ulimit -Hn 255; strace -e prlimit64 ./opendcdiag --selftests -e selftest_pass)
 prlimit64(0, RLIMIT_STACK, NULL, {rlim_cur=8192*1024, rlim_max=RLIM64_INFINITY}) = 0
 prlimit64(0, RLIMIT_NOFILE, NULL, {rlim_cur=255, rlim_max=255}) = 0
 prlimit64(0, RLIMIT_NOFILE, {rlim_cur=256, rlim_max=256}, NULL) = -1 EPERM (Operation not permitted)
 ./opendcdiag: failed to increase file descriptor limit: Operation not permitted
 The number of file descriptors for this system (soft 255, hard 255) is too low for the number of CPUs being tested (8).
 Either increase the number of allowed file descriptors to 256 or decrease the number of CPUs being tested, using taskset(1), or schedtool(1), or the --cpuset command-line option.
 If using bash, type 'help ulimit' for information on increasing the file descriptor limit.
 +++ exited with 4 +++
```