### PR TITLE
Windows: Background scan: Raising system idle threshold

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -241,9 +241,15 @@ struct SandstoneBackgroundScan
     std::span<MonotonicTimePoint> timestamp;
     float load_idle_threshold = 0.0;
 
+#ifdef _WIN32
+    static constexpr float load_idle_threshold_init = 0.35;
+    static constexpr float load_idle_threshold_inc_val = 0.05;
+    static constexpr float load_idle_threshold_max = 1.0;
+#else
     static constexpr float load_idle_threshold_init = 0.2;
     static constexpr float load_idle_threshold_inc_val = 0.05;
     static constexpr float load_idle_threshold_max = 0.8;
+#endif
 };
 
 struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>


### PR DESCRIPTION
We observed, that on Windows, when system is "doing nothing" we read cpu utilization values around 0.3 and always miss the previously used threshold of 0.2 by a little bit.