### PR TITLE
FW/Unit-tests: fix BF16 tests on BF16-capable CPUs

### DIFF
--- a/framework/unit-tests/sandstone_data_tests.cpp
+++ b/framework/unit-tests/sandstone_data_tests.cpp
@@ -20,7 +20,7 @@ static inline BFloat16 tobf16_avx512(float f)
 {
     BFloat16 r;
     __m128bh m = _mm_cvtneps_pbh(_mm_set_ss(f));
-    r.payload = m[0];
+    r.payload = std::bit_cast<uint16_t>(m[0]);
     return r;
 }
 


### PR DESCRIPTION
GCC 13[1] and LLVM 16[2] changed their AVX512BF16 intrinsics that used to use short to using __bf16, now that they support said type, as a result of adopting P1467[3]. This caused the code in this test to insert an integer conversion that didn't use to be there. See the side-by-side comparison in
  https://gcc.godbolt.org/z/K1PYMEocT
for an illustration.

We hadn't noticed this until now because we have only recently begun using GCC 13 and the CI that runs those unit tests hadn't had any Cooper Lakes or Sapphire Rapids. The developers' laptops (Ice Lakes and Tiger Lakes) don't have AVX512BF16 support.

[1] https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=87235f1e5c740de9c6f72a5dd7d7eb9cb7df2e1d
[2] https://github.com/llvm/llvm-project/commit/bc1819389fb4701cdeba5e093278e32dd668d6d5
[3] https://wg21.link/p1467