### PR TITLE
CI/Bats: allow free-form version numbers in the sanity-check

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -163,7 +163,7 @@ test_yaml_regexp() {
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/command-line" ".* $args"
-    test_yaml_regexp "/version" '([a-z-]+-)?(v[0-9]+(rc[0-9]){0,1}+(-[0-9a-z]+)? \([0-9a-f]{40}\)|[0-9]+-[0-9]+-g[0-9a-f]+|[0-9a-f]{12}|[0-9a-f]{40})(-.*)?'
+    test_yaml_regexp "/version" '.*'
 
     local os=`uname -sr`
     if [[ "$SANDSTONE" = "wine "* ]]; then


### PR DESCRIPTION
The regular expression was too inflexible, preventing things like "pr242". The release process becomes responsible for ensuring the version matches the tool's desired version number.