### PR TITLE
FW/logging: allow for memcmp_offset() failing to find a difference

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -771,6 +771,22 @@ function selftest_logerror_common() {
     done
 }
 
+@test "selftest_datacompare_nodifference" {
+    declare -A yamldump
+    sandstone_selftest -vvv -e selftest_datacompare_nodifference
+    fail_common
+    for ((i = 1; i <= MAX_PROC; ++i)); do
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/level" error
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/type" 'uint8_t'
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/offset" None
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/address" '(0x)?[0-9a-f]+'
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/actual" None
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/expected" None
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/mask" None
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/remark" '.+'
+    done
+}
+
 @test "selftest_freeze" {
     declare -A yamldump
     sandstone_selftest -vvv --on-crash=kill --on-hang=kill -e selftest_freeze --timeout=1s

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1397,23 +1397,6 @@ void log_data(const char *message, const void *data, size_t size)
 static void logging_format_data(DataType type, std::string_view description, const uint8_t *data1,
                                 const uint8_t *data2, ptrdiff_t offset)
 {
-    const char *typeName = SandstoneDataDetails::type_name(type);
-    if (!typeName) {
-        // also a validity check
-        type = UInt8Data;
-        typeName = SandstoneDataDetails::type_name(type);
-    }
-    int typeSize = SandstoneDataDetails::type_real_size(type);
-    unsigned typeAlignment = SandstoneDataDetails::type_alignment(type);
-
-    // The offset may not be the first byte of the data, so realign it
-    ptrdiff_t alignedOffset = offset & ~(typeAlignment - 1);
-
-    // create an XOR mask
-    uint8_t xormask[SandstoneDataDetails::MaxDataTypeSize];
-    for (int i = 0; i < typeSize; ++i)
-        xormask[i] = data1[alignedOffset + i] ^ data2[alignedOffset + i];
-
     std::string spaces(sApp->output_yaml_indent + 7, ' ');
     std::string buffer = { char(message_code(Preformatted, LOG_LEVEL_QUIET)) };
     switch (current_output_format()) {
@@ -1435,26 +1418,59 @@ static void logging_format_data(DataType type, std::string_view description, con
         break;
     }
 
-    buffer +=
-            stdprintf("%sdescription: '%.*s'\n"
-                      "%stype:        %s\n"
-                      "%soffset:      [ %td, %td ]\n"
-                      "%saddress:     '%p'\n",
-                      spaces.c_str(), int(description.size()), description.data(),
-                      spaces.c_str(), typeName,
-                      spaces.c_str(), alignedOffset, offset - alignedOffset,
-                      spaces.c_str(), data1 + offset);
-    if (uint64_t physaddr = retrieve_physical_address(data1 + offset)) {
-        // 2^48-1 requires 12 hex digits
-        buffer +=  stdprintf("%sphysical:    '%#012" PRIx64 "'\n",
-                             spaces.c_str(), physaddr);
+    auto formatAddresses = [&spaces](const uint8_t *ptr) {
+        std::string result = stdprintf("%saddress:     '%p'\n", spaces.c_str(), ptr);
+        if (uint64_t physaddr = retrieve_physical_address(ptr)) {
+            // 2^48-1 requires 12 hex digits
+            result += stdprintf("%sphysical:    '%#012" PRIx64 "'\n",
+                                 spaces.c_str(), physaddr);
+        }
+        return result;
+    };
+
+    const char *typeName = SandstoneDataDetails::type_name(type);
+    if (!typeName) {
+        // also a validity check
+        type = UInt8Data;
+        typeName = SandstoneDataDetails::type_name(type);
     }
-    buffer += stdprintf("%sactual:      '0x%s'\n"
-                        "%sexpected:    '0x%s'\n"
-                        "%smask:        '0x%s'\n",
-                        spaces.c_str(), format_single_type(type, typeSize, data1 + alignedOffset, true).c_str(),
-                        spaces.c_str(), format_single_type(type, typeSize, data2 + alignedOffset, true).c_str(),
-                        spaces.c_str(), format_single_type(type, typeSize, xormask, false).c_str());
+    buffer += stdprintf("%sdescription: '%.*s'\n"
+                        "%stype:        %s\n",
+                        spaces.c_str(), int(description.size()), description.data(),
+                        spaces.c_str(), typeName);
+
+    if (offset >= 0) {
+        // typical case
+        int typeSize = SandstoneDataDetails::type_real_size(type);
+        unsigned typeAlignment = SandstoneDataDetails::type_alignment(type);
+
+        // The offset may not be the first byte of the data, so realign it
+        ptrdiff_t alignedOffset = offset & ~(typeAlignment - 1);
+
+        // create an XOR mask
+        uint8_t xormask[SandstoneDataDetails::MaxDataTypeSize];
+        for (int i = 0; i < typeSize; ++i)
+            xormask[i] = data1[alignedOffset + i] ^ data2[alignedOffset + i];
+
+        buffer += stdprintf("%soffset:      [ %td, %td ]\n",
+                            spaces.c_str(), alignedOffset, offset - alignedOffset);
+        buffer += formatAddresses(data1 + offset);
+        buffer += stdprintf("%sactual:      '0x%s'\n"
+                            "%sexpected:    '0x%s'\n"
+                            "%smask:        '0x%s'\n",
+                            spaces.c_str(), format_single_type(type, typeSize, data1 + alignedOffset, true).c_str(),
+                            spaces.c_str(), format_single_type(type, typeSize, data2 + alignedOffset, true).c_str(),
+                            spaces.c_str(), format_single_type(type, typeSize, xormask, false).c_str());
+    } else {
+        // no difference was found: memcmp_offset() disagrees with memcmp_or_fail()
+        buffer += stdprintf("%soffset:      null\n", spaces.c_str());
+        buffer += formatAddresses(data1);
+        buffer += stdprintf("%sactual:      null\n"
+                            "%sexpected:    null\n"
+                            "%smask:        null\n"
+                            "%sremark:      'memcmp_offset() could not locate difference'\n",
+                            spaces.c_str(), spaces.c_str(), spaces.c_str(), spaces.c_str());
+    }
 
     // +1 so will include the terminating NUL
     IGNORE_RETVAL(write(log_for_thread(thread_num).log_fd,
@@ -1468,10 +1484,17 @@ void logging_report_mismatched_data(DataType type, const uint8_t *actual, const 
     if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
         return;
 
-    // create the description of what failed
-    std::string description, escaped_description;
-    if (fmt && *fmt)
-        description = vstdprintf(fmt, va);
+    {
+        // create the description of what failed
+        std::string description, escaped_description;
+        if (fmt && *fmt)
+            description = vstdprintf(fmt, va);
+
+        logging_format_data(type, escape_for_single_line(description, escaped_description),
+                            actual, expected, offset);
+    }
+    if (offset < 0)
+        return;         // we couldn't find a difference
 
     // log the data that failed
     ptrdiff_t start;
@@ -1485,9 +1508,6 @@ void logging_report_mismatched_data(DataType type, const uint8_t *actual, const 
     } else {
         start = offset - len / 2;
     }
-
-    logging_format_data(type, escape_for_single_line(description, escaped_description),
-			actual, expected, offset);
 
     auto do_log_data = [=](const char *name, const uint8_t *which) {
         std::string message;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -387,7 +387,6 @@ void _memcmp_fail_report(const void *_actual, const void *_expected, size_t size
         auto actual = static_cast<const uint8_t *>(_actual);
         auto expected = static_cast<const uint8_t *>(_expected);
         ptrdiff_t offset = memcmp_offset(actual, expected, size);
-        assert(offset >= 0);
 
         va_list va;
         va_start(va, fmt);

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -341,6 +341,16 @@ template <typename T> static int selftest_datacomparefail_run(struct test *, int
     return EXIT_SUCCESS;
 }
 
+static int selftest_datacompare_nodifference_run(struct test *, int cpu)
+{
+    uint8_t actual[16], expected[16];
+    memset_random(actual, sizeof(actual));
+    memcpy(expected, actual, sizeof(actual));
+
+    memcmp_or_fail(actual, expected, sizeof(actual));        // won't fail
+    memcmp_fail_report(actual, expected, sizeof(actual), nullptr);
+}
+
 static int selftest_cxxthrow_run(struct test *, int cpu) noexcept(false)
 {
     throw SelftestException();
@@ -991,6 +1001,13 @@ static struct test selftests_array[] = {
 },
 FOREACH_DATATYPE(DATACOMPARE_TEST)
 #undef DATACOMPARE_TEST
+{
+    .id = "selftest_datacompare_nodifference",
+    .description = "Fakes a memcmp_or_fail that finds a difference that isn't there",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+            .test_run = selftest_datacompare_nodifference_run,
+    .desired_duration = -1,
+},
 
 {
     .id = "selftest_cxxthrow",


### PR DESCRIPTION
memcmp_or_fail() was introduced to allow easy checking that a given data set was correct, reporting it in a standard format in case it isn't (that includes virtual and physical addresses, in case they are important for debugging). It includes an memcmp(), so we don't call into the framework unless a difference was found. Because memcmp_or_fail() is inline, the compiler often inlines memcmp() itself, replacing what would be a function call into libc with a simpler version.

Interestingly, the mere act of memcmp()ing two data blocks sometimes triggers a Silent Data Error. Therefore, we can't be assured that memcmp() and memcmp_offset() will agree. This commit removes the assertion that memcmp_offset() is able to find a difference and introduces proper reporting.
```yaml
    messages:
    - level: error
      data-miscompare:
       description: ''
       type:        uint8_t
       offset:      null
       address:     '0x7efd96001e00'
       actual:      null
       expected:    null
       mask:        null
       remark:      'memcmp_offset() could not locate difference'
```