### PR TITLE
IFS: Fix false positive report when all threads skips.

### DIFF
--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -274,6 +274,11 @@ static int scan_run(struct test *test, int cpu)
     if (cpu != 0)
         return EXIT_SKIP;
 
+    /* all_skip is a flag to keep track when all threads return "EXIT_SKIP". In the same
+     * way framework behaves, a single "EXIT_SUCCESS" is enough to set flag to false and
+     * therefore, report the whole test as "ok" */
+    bool all_skip = true;
+
     int count = num_cpus();
     for (int i = 0; i < count; i++)
     {
@@ -283,7 +288,12 @@ static int scan_run(struct test *test, int cpu)
             log_skip(ResourceIssueSkipCategory, "IFS feature is not available at the moment");
             return EXIT_SKIP;
         }
+        if (scan_ret == EXIT_SUCCESS)
+            all_skip = false;
     }
+
+    if (all_skip)
+        return EXIT_SKIP;
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Unless all threads return "EXIT_SKIP", the test won't be marked as "SKIP". This is the case for thread 0, which almost always returns "EXIT_SUCCESS", causing false positive reports.

To fix this, a control variable has been added to keep track if at least one "EXIT_SUCCESS" occurred, otherwise test will be marked as "SKIP".