### PR TITLE
FW/random: move the thread's seeding into the thread itself

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -720,8 +720,6 @@ static void init_internal(const struct test *test)
     memset(reinterpret_cast<void *>(sApp->shmem), 0, sizeof(*sApp->shmem));
     print_temperature_and_throttle();
 
-    random_init();
-
     logging_init(test);
 }
 
@@ -849,6 +847,7 @@ static void *thread_runner(void *arg)
               thread_number(thread_number)
         {
             thread_num = thread_number;
+            random_init_thread(thread_number);
             this_thread->inner_loop_count = 0;
         }
 
@@ -2428,7 +2427,6 @@ static int exec_mode_run(int argc, char **argv)
 
     std::vector<struct test *> test_list;
     add_test(test_list, test_to_run);
-    random_init();
     return run_child(test_to_run, &app_state);
 }
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -536,7 +536,7 @@ TestResult logging_print_results(ChildExitStatus status, int *tc, const struct t
 void random_init_global(const char *argument);
 void random_advance_seed();
 std::string random_format_seed();
-void random_init();
+void random_init_thread(int thread_num);
 
 /* sandstone.cpp */
 TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::PerCpuFailures &per_cpu_fails);

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -155,6 +155,22 @@ static int selftest_logs_options_init(struct test *test)
     return EXIT_SUCCESS;
 }
 
+static int selftest_logs_random_init(struct test *test)
+{
+    // print 4 ints
+    int r1 = random();
+    int r2 = random();
+    int r3 = random();
+    int r4 = random();
+    log_info("%u %u %u %u", r1, r2, r3, r4);
+    return EXIT_SUCCESS;
+}
+
+static int selftest_logs_random_run(struct test *test, int cpu)
+{
+    return selftest_logs_random_init(test);
+}
+
 static int selftest_skip_init(struct test *test)
 {
     log_info("Requesting skip (this message should be visible)");
@@ -796,6 +812,21 @@ static struct test selftests_array[] = {
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_init = selftest_logs_options_init,
     .test_run = selftest_pass_run,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_logs_random_init",
+    .description = "Logs some random numbers in the init function",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_init = selftest_logs_random_init,
+    .test_run = selftest_pass_run,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_logs_random",
+    .description = "Logs some random numbers",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_run = selftest_logs_random_run,
     .desired_duration = -1,
 },
 {


### PR DESCRIPTION
Instead of doing it serially before the child is even started. That removes them from the critical path. It wasn't a lot of time, but it's a nice benefit, especially when you have 960 logical processors (8 sockets of 60 hyperthreaded cores).

This additionally makes it so each thread has a generator state that doesn't depend on how many threads started before it. Previously, if you decided to skip some logical processors in re-testing, the ones you did test wouldn't get the same sequence.