### PR TITLE
FW: introduce test_schedule_sequential to run threads sequentially

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -342,6 +342,13 @@ typedef enum test_flag {
     test_type_regular       = 0x00,     ///! regular test type
     test_type_kvm           = 0x01,     ///! test using Sandstone's KVM functionality
 
+    test_schedule_default           = 0x00,
+    test_schedule_mask              = 0x0e,
+
+    /// Asks the framework to run the threads sequentially, instead of all in
+    /// parallel.
+    test_schedule_sequential        = 0x02,
+
     /// Tells the --test-tests mode to ignore memory consumption for this test
     test_flag_ignore_memory_use     = 0x0010,
 

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -207,6 +207,24 @@ static int selftest_log_skip_newline_run(struct test *test, int cpu)
     return EXIT_FAILURE;
 }
 
+static std::atomic<int> selftest_sequential_last_cpu = -1;
+static int selftest_check_sequential_init(struct test *test)
+{
+    selftest_sequential_last_cpu = thread_num;      // -1
+    return EXIT_SUCCESS;
+}
+
+static int selftest_check_sequential_run(struct test *test, int cpu)
+{
+    usleep(1'000 * (random() % 16u));   // sleep up to 16 ms
+    int n = selftest_sequential_last_cpu.load(std::memory_order_relaxed);
+    log_debug("Last CPU was %d", n);
+    if (n != cpu - 1)
+        report_fail_msg("Last CPU %d was not expected", n);
+    selftest_sequential_last_cpu.store(cpu, std::memory_order_relaxed);
+    return EXIT_SUCCESS;
+}
+
 static int selftest_uses_too_much_mem_run(struct test *, int)
 {
     static constexpr int Size = 1024 * test_the_test_data<true>::MaxAcceptableMemoryUseKB * 2;
@@ -862,6 +880,14 @@ static struct test selftests_array[] = {
     .description = "Runs for the requested time, but on single thread",
     .test_run = selftest_timedpass_noloop_run<(50000us).count()>,
     .max_threads = 1,
+},
+{
+    .id = "selftest_check_sequential",
+    .description = "Checks that threads were run sequentially",
+    .test_init = selftest_check_sequential_init,
+    .test_run = selftest_check_sequential_run,
+    .desired_duration = -1,
+    .flags = test_schedule_sequential,
 },
 
 #if defined(__linux__) && defined(__x86_64__)

--- a/tests/ifs/sandstone_ifs.h
+++ b/tests/ifs/sandstone_ifs.h
@@ -21,8 +21,6 @@
 #define IFS_SW_PARTIAL_COMPLETION               0xFE
 #define IFS_SW_SCAN_CANNOT_START                0x6
 
-#define IFS_EXIT_CANNOT_START                   -2
-
 typedef struct {
     const char *sys_dir;
     bool image_support;

--- a/tests/ifs/unit/ifs_unittests.cpp
+++ b/tests/ifs/unit/ifs_unittests.cpp
@@ -281,7 +281,7 @@ TEST(IFSTrigger, AllCoresPass)
     for (size_t i=0; i < cpu_num; i++)
     {
         char contents[256], expected[256];
-        EXPECT_EQ(scan_run_helper(test_t, i), EXIT_SUCCESS);
+        EXPECT_EQ(scan_run(test_t, i), EXIT_SUCCESS);
 
         // Check we trigger the right cpu
         read_sysfs_file(ifs_info->sys_dir, "run_test", contents);
@@ -311,7 +311,7 @@ TEST(IFSTrigger, AllCoresFail)
     for (size_t i=0; i < cpu_num; i++)
     {
         char contents[256], expected[256];
-        EXPECT_EQ(scan_run_helper(test_t, i), EXIT_FAILURE);
+        EXPECT_EQ(scan_run(test_t, i), EXIT_FAILURE);
 
         // Check we trigger the right cpu
         read_sysfs_file(ifs_info->sys_dir, "run_test", contents);
@@ -338,11 +338,11 @@ TEST(IFSTrigger, SingleCoreFail)
     cpu_info[1].cpu_number = 1;
 
     // First run is expected to pass
-    EXPECT_EQ(scan_run_helper(test_t, 0), EXIT_SUCCESS);
+    EXPECT_EQ(scan_run(test_t, 0), EXIT_SUCCESS);
 
     // Second run us expected to fail
     setup_sysfs_file(ifs_info->sys_dir, "status", "fail");
-    EXPECT_EQ(scan_run_helper(test_t, 1), EXIT_FAILURE);
+    EXPECT_EQ(scan_run(test_t, 1), EXIT_FAILURE);
 
     delete [] cpu_info;
     test_cleanup(test_t, ifs_info, trigger_test3);
@@ -366,7 +366,7 @@ TEST(IFSTrigger, AllCoresUntested)
     for (size_t i=0; i < cpu_num; i++)
     {
         char contents[256], expected[256];
-        EXPECT_EQ(scan_run_helper(test_t, i), IFS_EXIT_CANNOT_START);
+        EXPECT_EQ(scan_run(test_t, i), -EAGAIN);
 
         // Check we trigger the right cpu
         read_sysfs_file(ifs_info->sys_dir, "run_test", contents);

--- a/tests/mce_check/mce_check.cpp
+++ b/tests/mce_check/mce_check.cpp
@@ -98,5 +98,6 @@ struct test mce_test = {  // This variable is used in the framework!
         .desired_duration = -1,
         .fracture_loop_count = -1,
         .quality_level = INT_MAX,
+        .flags = test_schedule_sequential,
 };
 // Do not convert to use the test declaration macros - read above


### PR DESCRIPTION
Not all tests need to run in parallel. In fact, some of them can't run in parallel (the Intel In-Field Scan ones, for example, due to limitation of the kernel API), so they were marked as sequential.

The `mce_test` test is another case.