### PR TITLE
FreeBSD and Clang fixes

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -155,6 +155,9 @@ framework_a = static_library(
         sysdeps_a.extract_all_objects(recursive: true),
         framework_main_a.extract_all_objects(recursive: false),
     ],
+    dependencies: [
+        boost_dep,
+    ],
     c_args : [
         debug_c_flags,
         march_flags,

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -16,8 +16,10 @@
 
 #ifdef __x86_64__
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#  ifndef __clang__
+#    pragma GCC diagnostic ignored "-Wuninitialized"
+#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#  endif
 #include <immintrin.h>
 #pragma GCC diagnostic pop
 #endif

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -17,11 +17,6 @@
 #ifdef __unix__
 #  include <dlfcn.h>
 #endif
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#include <immintrin.h>
-#pragma GCC diagnostic pop
 #include <inttypes.h>
 #include <string.h>
 #include <x86intrin.h>

--- a/framework/sysdeps/unix/signals.cpp
+++ b/framework/sysdeps/unix/signals.cpp
@@ -9,6 +9,7 @@
 #include <initializer_list>
 
 #include <signal.h>
+#include <unistd.h>
 
 static constexpr std::initializer_list<int> termination_signals = {
     SIGHUP, SIGINT, SIGTERM, SIGPIPE

--- a/framework/test_knobs.cpp
+++ b/framework/test_knobs.cpp
@@ -9,6 +9,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 #include <boost/algorithm/string.hpp>
 
 namespace {

--- a/meson.build
+++ b/meson.build
@@ -166,13 +166,15 @@ endif
 default_c_warn = [
     '-Wall',
     '-Wextra',
-    '-Werror=discarded-qualifiers',
     '-Werror=incompatible-pointer-types',
     '-Werror=implicit-function-declaration',
     '-Werror=int-conversion',
     '-Wno-unused-parameter',
     '-Wno-sign-compare',
 ]
+if cc.has_argument('-Werror=discarded-qualifiers')
+    default_c_warn += '-Werror=discarded-qualifiers'
+endif
 
 default_cpp_warn = [
     '-Wall',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -107,7 +107,10 @@ tests_base_a = static_library(
     ],
     dependencies: [
         boost_dep,
+        crypto_dep,
         eigen3_dep,
+        zlib_dep,
+        zstd_dep,
     ],
     c_args : [
         tests_common_c_args,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -105,6 +105,10 @@ tests_base_a = static_library(
     include_directories : [
         tests_common_incdirs,
     ],
+    dependencies: [
+        boost_dep,
+        eigen3_dep,
+    ],
     c_args : [
         tests_common_c_args,
     ],
@@ -152,6 +156,10 @@ if host_machine.cpu_family() == 'x86_64'
         build_by_default: false,
         include_directories : [
             tests_common_incdirs,
+        ],
+        dependencies: [
+            boost_dep,
+            eigen3_dep,
         ],
         c_args : [
             tests_common_c_args,


### PR DESCRIPTION
This fixes:
* Annoying Clang warnings about use of GCC-specific warning names
* Compiling and linking to dependencies, that we forgot to tell Meson were dependencies
* Missing #includes for FreeBSD's C library (`setsid`)
* Missing #includes for LLVM libc++ (`std::vector`)