### PR TITLE
FW/child_debug: let the child inform its PID to the parent

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1370,7 +1370,7 @@ static ChildExitStatus wait_for_child(int ffd, intptr_t child, int *tc, const st
 
         if (pfd[1].revents & POLLIN) {
             /* child is crashing */
-            debug_crashed_child(child);
+            debug_crashed_child();
 
             // debug_crashed_child kill()s the child process, so we can block
             // on forkfd_wait() until it finally does exit

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -96,7 +96,7 @@ void cpu_specific_init(void);
 void debug_init_child(void);
 void debug_init_global(const char *on_hang_arg, const char *on_crash_arg);
 intptr_t debug_child_watch(void);
-void debug_crashed_child(pid_t child);
+void debug_crashed_child();
 void debug_hung_child(pid_t child);
 
 /* splitlock_detect.c */


### PR DESCRIPTION
Instead of having the parent remember what the child's PID is. This allows grandchild processes to crash and still get debugged.

This is incomplete: if more than one child crashes at the same time,
they will all be stopped on read() at

```c++
        // now wait for the parent process to be done with us
        char c;
        IGNORE_RETVAL(read(crashsocket, &c, sizeof(c)));
```

It's unspecified which one we wake up when write()ing back to them. The next commit will fix that.
