### PR TITLE
FW/child_debug/Darwin: remove F_SETNOSIGPIPE

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -410,10 +410,6 @@ static void create_crash_pipe(int xsave_size)
     int ret = fcntl(crashpipe[CrashPipeParent], F_GETFL);
     if (ret >= 0)
         fcntl(crashpipe[CrashPipeParent], F_SETFL, ret | O_NONBLOCK);
-
-#ifdef F_SETNOSIGPIPE
-    fcntl(crashpipe[CrashPipeChild], F_SETNOSIGPIPE, 1);
-#endif
 }
 #endif
 


### PR DESCRIPTION
This call hasn't yet made it to Linux nor FreeBSD. And in any case, we do want the child to get SIGPIPE if the parent process has exited.