### PR TITLE
More clang fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ env:
   GIT_CONFIG_SYSTEM: /tmp/gitconfig
 
 jobs:
-  build-linux:
+  build-linux-gcc:
     runs-on: ubuntu-latest
     container: debian:sid
     steps:
@@ -52,6 +52,55 @@ jobs:
       run: |
         ulimit -St 120
         SANDSTONE_BIN=builddir/opendcdiag bats -t bats/sanity-check
+    - name: run tests quickly
+      run: |
+        ulimit -St 120
+        nproc=`nproc`
+        nproc=$((nproc > 4 ? 4 : nproc))
+        builddir/opendcdiag --quick -n$nproc --retest-on-failure=0 -o -
+
+  build-linux-clang:
+    runs-on: ubuntu-latest
+    container: debian:sid
+    env:
+      CC: clang-16
+      CXX: clang++-16
+    steps:
+    - name: Install distro packages
+      run: |
+        DEBIAN_FRONTEND=noninteractive apt-get -y update
+        DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+            bats \
+            ca-certificates \
+            ${CC} \
+            elfutils \
+            file \
+            git \
+            libboost-dev \
+            libeigen3-dev \
+            libgtest-dev \
+            libssl-dev \
+            libzstd-dev \
+            meson \
+            ninja-build \
+            python3-yaml \
+            zlib1g-dev
+    - uses: actions/checkout@v2
+    - name: setup Git
+      run: git config --system safe.directory '*'
+    - name: meson setup -Dbuildtype=debugoptimized
+      run: meson setup builddir -Dssl_link_type=dynamic -Dbuildtype=debugoptimized
+    - name: ninja build
+      run: ninja -C builddir
+    - name: confirm opendcdiag runs
+      run: |
+        builddir/opendcdiag --version
+        builddir/opendcdiag --dump-cpu-info
+# Disabled: some negative tests fail to fail the way they're supposed to
+#    - name: run selftests
+#      run: |
+#        ulimit -St 120
+#        SANDSTONE_BIN=builddir/opendcdiag bats -t bats/sanity-check
     - name: run tests quickly
       run: |
         ulimit -St 120

--- a/framework/sandstone_data.h
+++ b/framework/sandstone_data.h
@@ -58,20 +58,20 @@ struct Float128
     Float128() = default;
     Float128(long double f) : payload(f) {}
 
-    static constexpr int digits = __FLT128_MANT_DIG__;
-    static constexpr int digits10 = __FLT128_DIG__;
+    static constexpr int digits = 113;
+    static constexpr int digits10 = 33;
     static constexpr int max_digits10 = 6;  // log2(digits)
-    static constexpr int min_exponent = __FLT128_MIN_EXP__;
-    static constexpr int min_exponent10 = __FLT128_MIN_10_EXP__;
-    static constexpr int max_exponent = __FLT128_MAX_EXP__;
-    static constexpr int max_exponent10 = __FLT128_MAX_10_EXP__;
+    static constexpr int min_exponent = -16381;
+    static constexpr int min_exponent10 = -4931;
+    static constexpr int max_exponent = 16384;
+    static constexpr int max_exponent10 = 4932;
 
     static constexpr bool radix = 2;
     static constexpr bool is_signed = true;
     static constexpr bool is_integer = false;
     static constexpr bool is_exact = false;
-    static constexpr bool has_infinity = __FLT128_HAS_INFINITY__;
-    static constexpr bool has_quiet_NaN = __FLT128_HAS_QUIET_NAN__;
+    static constexpr bool has_infinity = true;
+    static constexpr bool has_quiet_NaN = true;
     static constexpr bool has_signaling_NaN = has_quiet_NaN;
     static constexpr std::float_denorm_style has_denorm = std::denorm_present;
     static constexpr bool has_denorm_loss = false;

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -580,7 +580,7 @@ static int selftest_libc_fatal_run(struct test *, int)
 }
 #endif
 
-#if defined(__linux__) && defined(__x86_64__)
+#if defined(__linux__) && defined(__x86_64__) && !defined(__clang__)
 BEGIN_ASM_FUNCTION(payload_long_64bit)
     asm("movabs $0x1234deadbeaf5678, %rax\n"
         "mov    $0x12345, %ebx\n"
@@ -900,7 +900,7 @@ static struct test selftests_array[] = {
     .flags = test_schedule_sequential,
 },
 
-#if defined(__linux__) && defined(__x86_64__)
+#if defined(__linux__) && defined(__x86_64__) && !defined(__clang__)
 {
     .id = "kvm_long_64bit",
     .description = "Runs simple 64-bit KVM workload successfully",
@@ -1175,7 +1175,7 @@ FOREACH_DATATYPE(DATACOMPARE_TEST)
     .desired_duration = -1,
 },
 
-#if defined(__linux__) && defined(__x86_64__)
+#if defined(__linux__) && defined(__x86_64__) && !defined(__clang__)
 {
     .id = "kvm_prot_64bit_fail",
     .description = "Runs simple 64-bit KVM workload that fails",

--- a/framework/sysdeps/linux/effective_cpu_freq.hpp
+++ b/framework/sysdeps/linux/effective_cpu_freq.hpp
@@ -24,7 +24,7 @@ public:
     {
         cpu_number = cpu_info[thread_num].cpu_number;
         ns = MonotonicTimePoint::clock::now();
-        tsc = _rdtscp(&tsc_aux);
+        tsc = __rdtscp(&tsc_aux);
 
         if (!read_msr(cpu_number, APERF_MSR, &aperf))
             aperf = 0;


### PR DESCRIPTION
* Hardcode the limit values for `_Float128`, because Clang doesn't define the `__FLT128_xxx__` macros
* Fix build: it only has `__rdtscp`, not `_rdtscp`
* Disable 16-bit KVM tests with Clang, because it can't do `.code16` properly

Finally, I enabled it in the CI (build only).
