### PR TITLE
FW: remove the test sliding-slice feature

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -233,17 +233,6 @@ test_yaml_regexp() {
     done
 }
 
-@test "selftest_timedpass_maxthreads1 --timeout 100ms" {
-    if [[ "$SANDSTONE" = "wine "* ]] && [[ "$HOME" = /github/* ]]; then
-        skip "This test runs too slowly on GitHub runners"
-    fi
-    VALIDATION=dump
-    declare -A yamldump
-    sandstone_selftest -e selftest_timedpass_maxthreads1 --timeout 100ms
-    [[ "$status" -eq 0 ]]
-    test_yaml_numeric "/tests/0/test-runtime" 'value > 100'
-}
-
 selftest_pass() {
     declare -A yamldump
     sandstone_selftest "$@"

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -485,8 +485,6 @@ static ThreadLog &log_for_thread(int cpu) noexcept
     assert(cpu < num_cpus());
     assert(cpu >= -1);
 
-    if (cpu >= 0)
-        cpu += sApp->thread_offset;
     ++cpu;
 
     auto &all = all_thread_logs();

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -604,14 +604,11 @@ static Duration test_timeout(Duration regular_duration)
 {
     // use the override value if there is one
     if (sApp->max_test_time != Duration::zero())
-        return sApp->max_test_time * sApp->current_slice_count;
+        return sApp->max_test_time;
 
     Duration result = regular_duration * 5 + 30s;
     if (result < 300s)
         result = 300s;
-
-    // Multiply by the number of slices needed to run on all cpus.
-    result = result * sApp->current_slice_count;
 
     return result;
 }
@@ -727,23 +724,6 @@ static void init_internal(const struct test *test)
     random_init();
 
     logging_init(test);
-
-    int slice_count = 1;
-    int max_threads = num_cpus();
-    if (sApp->slicing) {
-        // if either sApp->max_concurrent_thread_count or test->max_threads is
-        // set, use the smaller of the two as the thread count.
-        int max_concurrent_threads = sApp->max_concurrent_thread_count;
-        int test_max_threads = test->max_threads;
-        if (test_max_threads)
-            max_threads = test_max_threads;
-        if (max_concurrent_threads && max_concurrent_threads < max_threads)
-            max_threads = max_concurrent_threads;
-        if (max_threads < num_cpus())
-            slice_count = (num_cpus() + max_threads - 1) / max_threads;
-    }
-    sApp->current_slice_count = slice_count;
-    sApp->current_max_threads = max_threads;
 }
 
 static void initialize_smi_counts()
@@ -3332,9 +3312,6 @@ int main(int argc, char **argv)
         case mce_check_period_option:
             sApp->mce_check_period = ParseIntArgument<>{"--mce-check-every"}();
             break;
-        case no_slicing_option:
-            sApp->slicing = false;
-            break;
         case no_shared_memory_option:
             init_shmem(DoNotUseSharedMemory);
             break;
@@ -3492,14 +3469,6 @@ int main(int argc, char **argv)
             test_list_randomize = true;
             break;
 
-        case max_concurrent_threads_option:
-            sApp->max_concurrent_thread_count = ParseIntArgument<>{
-                    .name = "--max-concurrent-threads",
-                    .min = 2,
-                    .max = sApp->thread_count,
-                    .range_mode = OutOfRangeMode::Saturate
-            }();
-            break;
         case max_logdata_option: {
             sApp->max_logdata_per_thread = ParseIntArgument<unsigned>{
                     .name = "--max-log-data",
@@ -3571,6 +3540,8 @@ int main(int argc, char **argv)
             break;
 
             /* deprecated options */
+        case no_slicing_option:
+        case max_concurrent_threads_option:
         case mem_sample_time_option:
         case mem_samples_per_log_option:
         case no_mem_sampling_option:

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -366,8 +366,6 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     std::vector<uint32_t> mce_counts_start;
     std::map<int, uint64_t> smi_counts_start;
 
-    int thread_offset;
-
     ForkMode current_fork_mode() const
     {
         if (SandstoneConfig::RestrictedCommandLine) {
@@ -446,7 +444,7 @@ static inline per_thread_data *cpu_data_for_thread(int thread)
 {
     if (thread == -1)
         return &sApp->shmem->main_thread_data;
-    return &sApp->shmem->per_thread[thread + sApp->thread_offset];
+    return &sApp->shmem->per_thread[thread];
 }
 
 static inline per_thread_data *cpu_data()

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -316,7 +316,6 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
 #endif
     bool use_predictable_file_names = false;
     bool log_test_knobs = false;
-    bool slicing = true;
     bool ignore_os_errors = false;
     bool force_test_time = false;
     bool ud_on_failure = false;
@@ -326,10 +325,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     int total_retest_count = -2;
     int max_test_count = INT_MAX;
     int max_test_loop_count = 0;
-    int max_concurrent_thread_count = 0;
     int current_max_loop_count;
-    int current_max_threads;
-    int current_slice_count = 1;
     int current_iteration_count;        // iterations of the same test (positive for fracture; negative for retest)
     MonotonicTimePoint starttime;
     MonotonicTimePoint endtime;
@@ -407,12 +403,9 @@ private:
     F(output_yaml_indent)                   \
     F(use_strict_runtime)                   \
     F(log_test_knobs)                       \
-    F(slicing)                              \
     F(force_test_time)                      \
     F(ud_on_failure)                        \
     F(current_max_loop_count)               \
-    F(current_max_threads)                  \
-    F(current_slice_count)                  \
     F(current_test_endtime)                 \
     F(current_test_duration)                \
     F(test_time)                            \

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -886,12 +886,6 @@ static struct test selftests_array[] = {
     .desired_duration = -1,
 },
 {
-    .id = "selftest_timedpass_maxthreads1",
-    .description = "Runs for the requested time, but on single thread",
-    .test_run = selftest_timedpass_noloop_run<(50000us).count()>,
-    .max_threads = 1,
-},
-{
     .id = "selftest_check_sequential",
     .description = "Checks that threads were run sequentially",
     .test_init = selftest_check_sequential_init,


### PR DESCRIPTION
The slicing feature was added back on 2019-10-23, with the documentation:

>  "Maximum number of threads to assign to the given test. This might be useful when the test does not scale well for a very big number of cores. 0 (default) means use all available. Any other value will make the test_run() function to be called only for a subset of the overall available threads, not all of thread_count. The framework will try to spread out package/core usage as much as it can, when this mode is activated"

At that time, that was really just a limit of the number of threads: all logical processors above that limit simply weren't tested. The sliding window functionality was added on 2019-11-05.

The motivation for the feature is sound and still relevant: there are tests that don't scale well, for example tests with high mutex or spinlock contention, or tests that saturate the bandwidth between CPUs and main memory or between multiple CPUs. However, the solution of simply sliding a window over all the CPUs in the system is not the best. Not only does it multiply the test run time (which can be slow!) by the number of slices, it still keeps logical processors belonging to different sockets in the same test.

Therefore, slicing into sequential sliding  windows is being removed. In its place, we'll run the slices in parallel and the slice size will be dynamically and heuristically determined, aiming at avoiding unnecessary cross-socket talk.

This commit removes the code that implements the sliding feature in the child process side. I've avoided unnecessary churn in this commit, so run_slices() function now is technically incorrectly named. The next commit will clean up in the parent side.
