### PR TITLE
FW: Remove the ability to run without shared memory

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -146,7 +146,6 @@ enum {
     mem_sample_time_option,
     mem_samples_per_log_option,
     no_mem_sampling_option,
-    no_shared_memory_option,
     no_slicing_option,
     no_triage_option,
     on_crash_option,
@@ -3094,7 +3093,6 @@ int main(int argc, char **argv)
         { "mem-samples-per-log", required_argument, nullptr, mem_samples_per_log_option},
         { "no-memory-sampling", no_argument, nullptr, no_mem_sampling_option },
         { "no-slicing", no_argument, nullptr, no_slicing_option },
-        { "no-shared-memory", no_argument, nullptr, no_shared_memory_option },
         { "no-triage", no_argument, nullptr, no_triage_option },
         { "on-crash", required_argument, nullptr, on_crash_option },
         { "on-hang", required_argument, nullptr, on_hang_option },
@@ -3309,8 +3307,6 @@ int main(int argc, char **argv)
         case mce_check_period_option:
             sApp->mce_check_period = ParseIntArgument<>{"--mce-check-every"}();
             break;
-        case no_shared_memory_option:
-            init_shmem(DoNotUseSharedMemory);
             break;
         case no_triage_option:
             do_not_triage = true;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -306,7 +306,6 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
 #else
             fork_each_test;
 #endif
-    bool shared_memory_is_shared = false;
 #ifdef NDEBUG
     static constexpr
 #endif


### PR DESCRIPTION
I added this back in February 2021 to support running with secure enclaves, where each process gets its own memory encryption and thus can't share memory with other processes. It was later used for the early Windows port, before we discovered how to have the child process inherit file descriptors from the parent (you have to use [`_spawnv()`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/spawnv-wspawnv), not directly [`CreateProcessW()`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw)), but isn't needed any more there.

Given the upcoming changes to support multiple child processes, this would be a complexity I could live without, so I'm removing. If the need arises, we can bring it back later, adapting as necessary.

[ChangeLog][Framework] Removed the ability to run without shared memory
between the multiple tool processes. This ability existed to support
process isolation in some secure enclave environments; it is now
necessary to configure such environments to keep all the processes in
the same enclave so they can share memory.
