### PR TITLE
FW/child_debug: only hold the child back if we're attaching GDB

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -133,11 +133,11 @@ private:
 }
 
 enum CrashAction : uint8_t {
+    kill_on_crash           = 0x00,
     coredump_on_crash       = 0x01,
     context_on_crash        = 0x02,
-    backtrace_on_crash      = 0x06,
     attach_gdb_on_crash     = 0x10,
-    kill_on_crash           = 0x20,
+    backtrace_on_crash      = context_on_crash | attach_gdb_on_crash,
 };
 
 enum HangAction {
@@ -208,9 +208,11 @@ static void child_crash_handler(int, siginfo_t *si, void *ucontext)
         // let parent process know
         CrashContext::send(crashpipe[CrashPipeChild], si, ucontext);
 
-        // now wait for the parent process to be done with us
-        char c;
-        IGNORE_RETVAL(read(crashpipe[CrashPipeChild], &c, sizeof(c)));
+        if (on_crash_action & attach_gdb_on_crash) {
+            // now wait for the parent process to be done with us
+            char c;
+            IGNORE_RETVAL(read(crashpipe[CrashPipeChild], &c, sizeof(c)));
+        }
 
         // restore the signal handler so we can be killed
         signal(si->si_signo, SIG_DFL);
@@ -277,7 +279,7 @@ void CrashContext::send(int sockfd, siginfo_t *si, void *ucontext)
 #  endif
 #endif // x86-64
 
-    if ((on_crash_action & backtrace_on_crash) == 0)
+    if ((on_crash_action & context_on_crash) == 0)
         count = 1;
 
     struct msghdr hdr = {};
@@ -295,7 +297,7 @@ void CrashContext::receive_internal(int sockfd)
     };
 
     // transfer our state to the parent process
-    if (on_crash_action & backtrace_on_crash) {
+    if (on_crash_action & context_on_crash) {
 #ifdef __x86_64__
 #  ifdef __linux__
         gpr_size = sizeof(mc.gregs);
@@ -899,18 +901,19 @@ void debug_init_global(const char *on_hang_arg, const char *on_crash_arg)
             }
         }
     } else {
-#  ifdef __x86_64__
-        on_crash_action = context_on_crash;
-#  endif
+#  ifdef __linux__
         // do we have gdb?
         if (gdb_available == -1)
             gdb_available = check_gdb_available();
         if (gdb_available)
             on_crash_action = backtrace_on_crash;
+#  else
+        on_crash_action = context_on_crash;
+#  endif
     }
 
-    if (on_crash_action & (backtrace_on_crash | attach_gdb_on_crash)) {
-#  ifdef __x86_64
+    if (on_crash_action & (context_on_crash | attach_gdb_on_crash)) {
+#  ifdef __x86_64__
         // get the size of the context to transfer
         uint32_t eax, ebx, ecx, edx;
         if (__get_cpuid_count(0xd, 0, &eax, &ebx, &ecx, &edx))
@@ -951,7 +954,7 @@ void debug_init_child()
     if (!SandstoneConfig::ChildBacktrace)
         return;
 
-    if (on_crash_action & (backtrace_on_crash | attach_gdb_on_crash)) {
+    if (on_crash_action & (context_on_crash | attach_gdb_on_crash)) {
         struct sigaction action = {};
         sigemptyset(&action.sa_mask);
         action.sa_sigaction = child_crash_handler;
@@ -989,8 +992,10 @@ void debug_crashed_child(pid_t child)
         print_crash_info(buf, ctx);
 
     // release the child
-    char c = 1;
-    IGNORE_RETVAL(write(crashpipe[CrashPipeParent], &c, sizeof(c)));
+    if (on_crash_action != context_on_crash) {
+        char c = 1;
+        IGNORE_RETVAL(write(crashpipe[CrashPipeParent], &c, sizeof(c)));
+    }
 }
 
 void debug_hung_child(pid_t child)


### PR DESCRIPTION
For the case of the context transfer, we don't need to wait, so let the child simply proceed.