### PR TITLE
FW/Topology: apply the -n value to the enabled_cpus

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -186,4 +186,5 @@ unittests_sources += files(
     'unit-tests/tests_dummy.cpp',
     'unit-tests/test_knob_tests.cpp',
     'unit-tests/thermal_monitor_tests.cpp',
+    'unit-tests/topology_tests.cpp',
 )

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2989,6 +2989,7 @@ int main(int argc, char **argv)
     int total_failures = 0;
     int total_successes = 0;
     int total_skips = 0;
+    int thread_count = -1;
     bool fatal_errors = false;
     bool do_not_triage = false;
     const char *on_hang_arg = nullptr;
@@ -3062,7 +3063,7 @@ int main(int argc, char **argv)
             list_group_members(optarg);
             return EXIT_SUCCESS;
         case 'n':
-            sApp->thread_count = ParseIntArgument<>{
+            thread_count = ParseIntArgument<>{
                     .name = "-n / --threads",
                     .min = 1,
                     .max = sApp->thread_count,
@@ -3115,7 +3116,6 @@ int main(int argc, char **argv)
             break;
         case cpuset_option:
             sApp->enabled_cpus = parse_cpuset_param(optarg);
-            sApp->thread_count = sApp->enabled_cpus.count();
             break;
         case dump_cpu_info_option:
             dump_cpu_info(sApp->enabled_cpus);
@@ -3449,6 +3449,10 @@ int main(int argc, char **argv)
     if (sApp->total_retest_count < -1 || sApp->retest_count == 0)
         sApp->total_retest_count = 10 * sApp->retest_count; // by default, 100
 
+    if (unsigned(thread_count) < unsigned(sApp->thread_count)) {
+        sApp->thread_count = thread_count;
+        sApp->enabled_cpus.limit_to(thread_count);
+    }
     load_cpu_info(sApp->enabled_cpus);
     signals_init_global();
     resource_init_global();

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -9,6 +9,7 @@
 #include <sandstone.h>
 
 #include <array>
+#include <bit>
 #include <optional>
 #include <string>
 #include <vector>
@@ -82,7 +83,7 @@ public:
     {
         int total = 0;
         for (const Word &w : array)
-            total += __builtin_popcountll(w);
+            total += std::popcount(w);
         return total;
     }
 

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -67,7 +67,8 @@ public:
 #endif
 
     using Word = unsigned long long;
-    Word array[Size / (CHAR_BIT * sizeof(Word))];
+    static constexpr int ProcessorsPerWord = CHAR_BIT * sizeof(Word);
+    Word array[Size / ProcessorsPerWord];
 
     void clear()
     { *this = LogicalProcessorSet{}; }
@@ -94,7 +95,8 @@ public:
                 return false;
         return true;
     }
-    void add_package(Topology::Package pkg) {
+    void add_package(Topology::Package pkg)
+    {
         for (Topology::Core& core : pkg.cores)
             for (Topology::Thread& thread : core.threads)
                 set(LogicalProcessor(thread.oscpu));
@@ -103,16 +105,16 @@ public:
 private:
 
     Word &wordFor(LogicalProcessor n)
-    { return array[int(n) / (CHAR_BIT * sizeof(Word))]; }
+    { return array[int(n) / ProcessorsPerWord]; }
     const Word &wordFor(LogicalProcessor n) const
-    { return array[int(n) / (CHAR_BIT * sizeof(Word))]; }
+    { return array[int(n) / ProcessorsPerWord]; }
     static constexpr Word bitFor(LogicalProcessor n)
-    { return 1ULL << (unsigned(n) % (CHAR_BIT * sizeof(Word))); }
+    { return 1ULL << (unsigned(n) % ProcessorsPerWord); }
 };
 
 LogicalProcessorSet ambient_logical_processor_set();
 bool pin_to_logical_processor(LogicalProcessor, const char *thread_name = nullptr);
 
-void load_cpu_info(/*in/out*/ const LogicalProcessorSet &enabled_cpus);
+void load_cpu_info(/*in*/ const LogicalProcessorSet &enabled_cpus);
 
 #endif /* INC_TOPOLOGY_H */

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -102,6 +102,28 @@ public:
                 set(LogicalProcessor(thread.oscpu));
     }
 
+    void limit_to(int limit)
+    {
+        // find the first Word we need to change
+        auto it = std::begin(array);
+        for ( ; it != std::end(array) && limit > 0; ++it) {
+            int n = std::popcount(*it);
+            limit -= n;
+        }
+
+        if (limit < 0) {
+            // clear enough upper bits on the last Word
+            Word &x = it[-1];
+            for ( ; limit < 0; ++limit) {
+                Word bit = std::bit_floor(x);
+                x &= ~bit;
+            }
+        }
+
+        if (it != std::end(array))
+            std::fill(it, std::end(array), 0);      // clear to the end
+    }
+
 private:
 
     Word &wordFor(LogicalProcessor n)

--- a/framework/unit-tests/topology_tests.cpp
+++ b/framework/unit-tests/topology_tests.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gtest/gtest.h"
+#include <topology.h>
+
+#include <initializer_list>
+
+static LogicalProcessorSet make_set(std::initializer_list<uint64_t> list)
+{
+    LogicalProcessorSet result = {};
+    memcpy(result.array, list.begin(), list.size() * sizeof(*list.begin()));
+    return result;
+}
+
+TEST(LogicalProcessorSet, BasicOperations)
+{
+    auto lastProcessor = LogicalProcessor(LogicalProcessorSet::Size - 1);
+    LogicalProcessorSet set = {};
+    EXPECT_EQ(set.count(), 0);
+    EXPECT_FALSE(set.is_set(LogicalProcessor(0)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(1)));
+    EXPECT_FALSE(set.is_set(lastProcessor));
+
+    set.set(LogicalProcessor(0));
+    EXPECT_EQ(set.count(), 1);
+    EXPECT_TRUE(set.is_set(LogicalProcessor(0)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(1)));
+    EXPECT_FALSE(set.is_set(lastProcessor));
+
+    set.unset(LogicalProcessor(0));
+    EXPECT_EQ(set.count(), 0);
+    EXPECT_FALSE(set.is_set(LogicalProcessor(0)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(1)));
+    EXPECT_FALSE(set.is_set(lastProcessor));
+
+    set.set(lastProcessor);
+    EXPECT_EQ(set.count(), 1);
+    EXPECT_FALSE(set.is_set(LogicalProcessor(0)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(1)));
+    EXPECT_TRUE(set.is_set(lastProcessor));
+
+    memset(set.array, -1, sizeof(set.array));
+    EXPECT_EQ(set.count(), LogicalProcessorSet::Size);
+}
+
+TEST(LogicalProcessorSet, FromAmbient)
+{
+    LogicalProcessorSet set = make_set({0xf});
+    EXPECT_EQ(set.count(), 4);
+    EXPECT_TRUE(set.is_set(LogicalProcessor(0)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(1)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(2)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(3)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(4)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(5)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(6)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(7)));
+
+    set = make_set({ uint64_t(-1) });
+    EXPECT_EQ(set.count(), 64);
+    EXPECT_TRUE(set.is_set(LogicalProcessor(0)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(64)));
+
+    set = make_set({ uint64_t(-1), uint32_t(-1) });
+    EXPECT_EQ(set.count(), 96);
+    EXPECT_TRUE(set.is_set(LogicalProcessor(0)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(64)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(96)));
+
+    set = make_set({0x55});
+    EXPECT_EQ(set.count(), 4);
+    EXPECT_TRUE(set.is_set(LogicalProcessor(0)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(1)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(2)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(3)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(4)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(5)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(6)));
+    EXPECT_FALSE(set.is_set(LogicalProcessor(7)));
+
+    set = make_set({0xf, 0xf, 0xf, 0xf});
+    EXPECT_EQ(set.count(), 16);
+    EXPECT_TRUE(set.is_set(LogicalProcessor(0)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(1)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(2)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(3)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(64)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(65)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(66)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(67)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(128)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(129)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(130)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(131)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(192)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(193)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(194)));
+    EXPECT_TRUE(set.is_set(LogicalProcessor(195)));
+}
+
+TEST(LogicalProcessorSet, ApplyLimit)
+{
+    LogicalProcessorSet set = make_set({0xf});
+    EXPECT_EQ(set.count(), 4);
+    set.limit_to(64);
+    EXPECT_EQ(set.array[0], 0xf);
+    set.limit_to(4);
+    EXPECT_EQ(set.array[0], 0xf);
+    set.limit_to(3);
+    EXPECT_EQ(set.array[0], 0x7);
+    set.limit_to(2);
+    EXPECT_EQ(set.array[0], 0x3);
+    set.limit_to(1);
+    EXPECT_EQ(set.array[0], 0x1);
+
+    set = make_set({0xf});
+    set.limit_to(1);
+    EXPECT_EQ(set.array[0], 0x1);
+
+    set = make_set({ uint64_t(-1) });
+    EXPECT_EQ(set.count(), 64);
+    set.limit_to(127);
+    EXPECT_EQ(set.array[0], uint64_t(-1));
+    set.limit_to(64);
+    EXPECT_EQ(set.array[0], uint64_t(-1));
+    set.limit_to(4);
+    EXPECT_EQ(set.array[0], 0xf);
+
+    set = make_set({ uint64_t(-1), uint32_t(-1) });
+    EXPECT_EQ(set.count(), 96);
+    set.limit_to(127);
+    EXPECT_EQ(set.array[0], uint64_t(-1));
+    EXPECT_EQ(set.array[1], uint32_t(-1));
+    set.limit_to(64);
+    EXPECT_EQ(set.array[0], uint64_t(-1));
+    EXPECT_EQ(set.array[1], 0);
+    set.limit_to(4);
+    EXPECT_EQ(set.array[0], 0xf);
+    EXPECT_EQ(set.array[1], 0);
+
+    set = make_set({ uint64_t(-1), uint32_t(-1) });
+    set.limit_to(63);
+    EXPECT_EQ(set.array[0], uint64_t(-1) >> 1);
+    EXPECT_EQ(set.array[1], 0);
+
+    set = make_set({ uint64_t(-1), uint64_t(-1) });
+    EXPECT_EQ(set.count(), 128);
+    set.limit_to(255);
+    EXPECT_EQ(set.array[0], uint64_t(-1));
+    EXPECT_EQ(set.array[1], uint64_t(-1));
+    set.limit_to(128);
+    EXPECT_EQ(set.array[0], uint64_t(-1));
+    EXPECT_EQ(set.array[1], uint64_t(-1));
+    set.limit_to(64);
+    EXPECT_EQ(set.array[0], uint64_t(-1));
+
+    set = make_set({0x55});
+    EXPECT_EQ(set.count(), 4);
+    set.limit_to(4);
+    EXPECT_EQ(set.array[0], 0x55);
+    set.limit_to(3);
+    EXPECT_EQ(set.array[0], 0x15);
+    set.limit_to(2);
+    EXPECT_EQ(set.array[0], 0x5);
+    set.limit_to(1);
+    EXPECT_EQ(set.array[0], 0x1);
+
+    set = make_set({0x55});
+    set.limit_to(2);
+    EXPECT_EQ(set.array[0], 0x5);
+
+    set = make_set({0xaa});
+    EXPECT_EQ(set.count(), 4);
+    set.limit_to(4);
+    EXPECT_EQ(set.array[0], 0xaa);
+    set.limit_to(3);
+    EXPECT_EQ(set.array[0], 0x2a);
+    set.limit_to(2);
+    EXPECT_EQ(set.array[0], 0xa);
+    set.limit_to(1);
+    EXPECT_EQ(set.array[0], 0x2);
+
+    set = make_set({ UINT64_C(0x5555'5555'5555'5555) });
+    EXPECT_EQ(set.count(), 32);
+    set.limit_to(64);
+    EXPECT_EQ(set.array[0], UINT64_C(0x5555'5555'5555'5555));
+    set.limit_to(32);
+    EXPECT_EQ(set.array[0], UINT64_C(0x5555'5555'5555'5555));
+    set.limit_to(16);
+    EXPECT_EQ(set.array[0], UINT64_C(0x5555'5555));
+
+    set = make_set({ UINT64_C(0xaaaa'aaaa'aaaa'aaaa) });
+    EXPECT_EQ(set.count(), 32);
+    set.limit_to(64);
+    EXPECT_EQ(set.array[0], UINT64_C(0xaaaa'aaaa'aaaa'aaaa));
+    set.limit_to(32);
+    EXPECT_EQ(set.array[0], UINT64_C(0xaaaa'aaaa'aaaa'aaaa));
+    set.limit_to(16);
+    EXPECT_EQ(set.array[0], UINT64_C(0xaaaa'aaaa));
+
+    set = make_set({ 1, 1, 1, 0xf, 1 });
+    EXPECT_EQ(set.count(), 8);
+    set.limit_to(7);
+    EXPECT_EQ(set.array[0], 0x1);
+    EXPECT_EQ(set.array[1], 0x1);
+    EXPECT_EQ(set.array[2], 0x1);
+    EXPECT_EQ(set.array[3], 0xf);
+    EXPECT_EQ(set.array[4], 0);
+
+    set = make_set({ 1, 1, 1, 0xf, 1 });
+    set.limit_to(6);
+    EXPECT_EQ(set.array[0], 0x1);
+    EXPECT_EQ(set.array[1], 0x1);
+    EXPECT_EQ(set.array[2], 0x1);
+    EXPECT_EQ(set.array[3], 0x7);
+    EXPECT_EQ(set.array[4], 0);
+}


### PR DESCRIPTION
The -n option isn't documented for end users, but we use it a lot. Let's ensure we mask off the unused CPUs from the ambient CPU set, lest we accidentally use them.

This also adds `Topology::limit_to()` with its unit tests and some code updates.