### PR TITLE
FW/Logging: clean ups in preparation for removing FILE*

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -175,7 +175,6 @@ enum {
     total_retest_on_failure,
     ud_on_failure_option,
     use_builtin_test_list_option,
-    use_predictable_file_names_option,
     version_option,
     weighted_testrun_option,
 };
@@ -2968,7 +2967,6 @@ int main(int argc, char **argv)
         { "gdb-server", required_argument, nullptr, gdb_server_option },
         { "is-debug-build", no_argument, nullptr, is_debug_option },
         { "test-tests", no_argument, nullptr, test_tests_option },
-        { "use-predictable-file-names", no_argument, nullptr, use_predictable_file_names_option },
 #endif
         { nullptr, 0, nullptr, 0 }
     };
@@ -3220,11 +3218,6 @@ int main(int argc, char **argv)
             test_selection_strategy = Ordered;
             if (optarg)
                 builtin_test_list_name = optarg;
-            break;
-        case use_predictable_file_names_option:
-#ifndef NDEBUG
-            sApp->use_predictable_file_names = true;
-#endif
             break;
         case temperature_threshold_option:
             if (strcmp(optarg, "disable") == 0)

--- a/framework/sandstone_iovec.h
+++ b/framework/sandstone_iovec.h
@@ -34,14 +34,6 @@ template <typename... Args>
     iovec vec[] = { IoVec(args)..., IoVec("\n") };
     return writev(fd, vec, std::size(vec));
 }
-
-#ifdef _WIN32
-[[maybe_unused]] int dprintf(int fd, const char *fmt, ...)
-{
-    std::string msg = va_start_and_stdprintf(fmt);
-    return write(fd, msg.data(), msg.size());
-}
-#endif
 }
 
 #endif  // SANDSTONE_IOVEC_H

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -306,10 +306,6 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
 #else
             fork_each_test;
 #endif
-#ifdef NDEBUG
-    static constexpr
-#endif
-    bool use_predictable_file_names = false;
     bool log_test_knobs = false;
     bool ignore_os_errors = false;
     bool force_test_time = false;
@@ -382,14 +378,7 @@ private:
 };
 
 // state from SandstoneApplication:
-#ifdef NDEBUG
-#define APP_STATE_VARIABLES_DEBUGONLY(F)
-#else
-#define APP_STATE_VARIABLES_DEBUGONLY(F)    \
-    F(use_predictable_file_names)
-#endif
 #define APP_STATE_VARIABLES(F)              \
-    APP_STATE_VARIABLES_DEBUGONLY(F)        \
     F(shmemfd)                              \
     F(verbosity)                            \
     F(max_messages_per_thread)              \

--- a/framework/sandstone_utils.h
+++ b/framework/sandstone_utils.h
@@ -17,6 +17,7 @@
 
 #include <stdarg.h>
 #include <sysexits.h>
+#include <unistd.h>
 
 /*
  * Extra exit codes, from systemd.exec(3)
@@ -39,5 +40,13 @@
 std::string format_single_type(DataType type, int typeSize, const uint8_t *data, bool detailed);
 std::string stdprintf(const char *fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 std::string vstdprintf(const char *fmt, va_list va);
+
+#ifdef _WIN32
+inline int dprintf(int fd, const char *fmt, ...)
+{
+    std::string msg = va_start_and_stdprintf(fmt);
+    return write(fd, msg.data(), msg.size());
+}
+#endif
 
 #endif //SANDSTONE_UTILS_H_INCLUDED


### PR DESCRIPTION
This removes the `--use-predictable-file-names` option (undocumented, only available in debug builds) and the associated predictable file name support. This was added during the port to Windows, when we thought that we'd need to have predictable file names so the child process would be able to reopen the files. But it turns out that Windows and the C runtime can let child processes inherit file descriptors.

Then it adds `writevec()`, which does the same as the existing `writeln()` but without a newline (so the latter is reimplemented in terms of the former), then proceeds to using it in framework/logging.cpp.

The actual removal of `FILE *` support will be in another PR. It depends on changes to child_debug.cpp (see #252, #274, #275, etc.)