### PR TITLE
FW/SharedMemory: refactor the per-thread shared memory structures and their initialisation

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1013,7 +1013,7 @@ void logging_flush(void)
     // we don't need to fflush() because all our log files are opened without
     // buffering
     do_flush(file_log_fd);
-    do_flush(cpu_data_for_thread(-1)->log_fd);
+    do_flush(sApp->main_thread_data()->log_fd);
 }
 
 void logging_init(const struct test *test)
@@ -1635,7 +1635,7 @@ inline AbstractLogger::AbstractLogger(const struct test *test, ChildExitStatus s
 
     // condense the internal state variable to the three main possibilities
     testResult = TestFailed;
-    if (state_.result == TestPassed && pc == num_cpus() && !sApp->shmem->main_thread_data.has_failed()) {
+    if (state_.result == TestPassed && pc == num_cpus() && !sApp->main_thread_data()->has_failed()) {
         if (sc == num_cpus())
             testResult = TestSkipped;
         else
@@ -2288,7 +2288,7 @@ void YamlLogger::print()
 
     logging_flush();
 
-    struct mmap_region main_mmap = mmap_file(cpu_data_for_thread(-1)->log_fd);
+    struct mmap_region main_mmap = mmap_file(sApp->main_thread_data()->log_fd);
     if (main_mmap.size && sApp->log_test_knobs) {
         int count = print_test_knobs(file_log_fd, main_mmap);
         if (count && real_stdout_fd != file_log_fd

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1704,13 +1704,14 @@ void KeyValuePairLogger::print_thread_header(int fd, int cpu, const char *prefix
     }
 
     struct cpu_info *info = cpu_info + cpu;
-    if (std::string time = format_duration(sApp->shmem->per_thread[cpu].fail_time); time.size()) {
+    per_thread_data *thr = sApp->test_thread_data(cpu);
+    if (std::string time = format_duration(thr->fail_time); time.size()) {
         dprintf(fd, "%s_thread_%d_fail_time = %s\n", prefix, cpu, time.c_str());
         dprintf(fd, "%s_thread_%d_loop_count = %" PRIu64 "\n", prefix, cpu,
-                sApp->shmem->per_thread[cpu].inner_loop_count_at_fail);
+                thr->inner_loop_count_at_fail);
     } else {
         dprintf(fd, "%s_thread_%d_loop_count = %" PRIu64 "\n", prefix, cpu,
-                sApp->shmem->per_thread[cpu].inner_loop_count);
+                thr->inner_loop_count);
     }
     dprintf(fd, "%s_messages_thread_%d_cpu = %d\n", prefix, cpu, info->cpu_number);
     dprintf(fd, "%s_messages_thread_%d_family_model_stepping = %02x-%02x-%02x\n", prefix, cpu,
@@ -1985,12 +1986,13 @@ void TapFormatLogger::print_thread_header(int fd, int cpu, int verbosity)
     writeln(fd, line);
 
     if (verbosity > 1) {
-        if (std::string time = format_duration(sApp->shmem->per_thread[cpu].fail_time); time.size())
+        per_thread_data *thr = sApp->test_thread_data(cpu);
+        if (std::string time = format_duration(thr->fail_time); time.size())
             writeln(fd, "  - failed: { time: ", time,
-                    ", loop-count: ", std::to_string(sApp->shmem->per_thread[cpu].inner_loop_count_at_fail),
+                    ", loop-count: ", std::to_string(thr->inner_loop_count_at_fail),
                     " }");
         else if (verbosity > 2)
-            writeln(fd, "  - loop-count: ", std::to_string(sApp->shmem->per_thread[cpu].inner_loop_count));
+            writeln(fd, "  - loop-count: ", std::to_string(thr->inner_loop_count));
     }
 }
 
@@ -2065,17 +2067,18 @@ void YamlLogger::print_thread_header(int fd, int cpu, int verbosity)
         dprintf(fd, "%s    id: %s\n", indent_spaces().data(), thread_id_header(cpu, verbosity).c_str());
 
         if (verbosity > 1) {
+            per_thread_data *thr = sApp->test_thread_data(cpu);
             auto opts = FormatDurationOptions::WithoutUnit;
-            if (std::string time = format_duration(sApp->shmem->per_thread[cpu].fail_time, opts); time.size()) {
+            if (std::string time = format_duration(thr->fail_time, opts); time.size()) {
                 writeln(fd, indent_spaces(), "    state: failed");
                 writeln(fd, indent_spaces(), "    time-to-fail: ", time);
                 writeln(fd, indent_spaces(), "    loop-count: ",
-                        std::to_string(sApp->shmem->per_thread[cpu].inner_loop_count_at_fail));
+                        std::to_string(thr->inner_loop_count_at_fail));
             } else if (verbosity > 2) {
                 writeln(fd, indent_spaces(), "    loop-count: ",
-                        std::to_string(sApp->shmem->per_thread[cpu].inner_loop_count));
+                        std::to_string(thr->inner_loop_count));
             }
-            const double effective_freq_mhz = sApp->shmem->per_thread[cpu].effective_freq_mhz;
+            const double effective_freq_mhz = thr->effective_freq_mhz;
             if (std::isfinite(effective_freq_mhz))
                 dprintf(fd, "%s    freq_mhz: %.1f\n", indent_spaces().data(), effective_freq_mhz);
         }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1451,7 +1451,7 @@ static TestResult run_thread_slices(/*nonconst*/ struct test *test)
             ret = intptr_t(retptr);
         }
 
-        if (ret > 0 || sApp->shmem->main_thread_data.has_failed()) {
+        if (ret > 0 || sApp->main_thread_data()->has_failed()) {
             logging_mark_thread_failed(-1);
             if (ret > 0)
                 log_error("Init function failed with code %i", ret);

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -716,7 +716,9 @@ static void print_temperature_and_throttle()
 
 static void init_internal(const struct test *test)
 {
-    memset(reinterpret_cast<void *>(sApp->shmem), 0, sizeof(*sApp->shmem));
+    sApp->main_thread_data()->init();
+    for (int i = 0; i < num_cpus(); ++i)
+        sApp->test_thread_data(i)->init();
     print_temperature_and_throttle();
 
     logging_init(test);
@@ -847,7 +849,6 @@ static void *thread_runner(void *arg)
         {
             thread_num = thread_number;
             random_init_thread(thread_number);
-            this_thread->inner_loop_count = 0;
         }
 
         ~TestRunWrapper()

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -424,7 +424,7 @@ inline void test_the_test_data<true>::test_tests_iteration(const struct test *th
         return;
 
     int cpu = thread_num;
-    int n = cpu_data_for_thread(cpu)->inner_loop_count;
+    int n = sApp->test_thread_data(cpu)->inner_loop_count;
     if (n >= DesiredIterations)
         return;
 
@@ -639,7 +639,7 @@ static bool wallclock_deadline_has_expired(MonotonicTimePoint deadline)
 
 static bool max_loop_count_exceeded(const struct test *the_test)
 {
-    per_thread_data *data = cpu_data_for_thread(thread_num);
+    per_thread_data *data = sApp->test_thread_data(thread_num);
 
     // unsigned comparisons so sApp->current_max_loop_count == -1 causes an always false
     if (unsigned(data->inner_loop_count) >= unsigned(sApp->current_max_loop_count))
@@ -658,7 +658,7 @@ int test_time_condition(const struct test *the_test) noexcept
 {
     test_loop_iterate();
     sApp->test_tests_iteration(the_test);
-    cpu_data_for_thread(thread_num)->inner_loop_count++;
+    sApp->test_thread_data(thread_num)->inner_loop_count++;
 
     if (max_loop_count_exceeded(the_test))
         return 0;  // end the test if max loop count exceeded
@@ -820,7 +820,7 @@ void test_loop_iterate() noexcept
 void test_loop_end() noexcept
 {
     using namespace AssemblyMarker;
-    assembly_marker<TestLoop, End>(cpu_data_for_thread(thread_num)->inner_loop_count);
+    assembly_marker<TestLoop, End>(sApp->test_thread_data(thread_num)->inner_loop_count);
 }
 
 #ifndef _WIN32
@@ -842,7 +842,7 @@ static void *thread_runner(void *arg)
         CPUTimeFreqStamp before, after;
 
         TestRunWrapper(int thread_number)
-            : this_thread(cpu_data_for_thread(thread_number)),
+            : this_thread(sApp->test_thread_data(thread_number)),
               thread_number(thread_number)
         {
             thread_num = thread_number;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -639,7 +639,7 @@ static bool wallclock_deadline_has_expired(MonotonicTimePoint deadline)
 
 static bool max_loop_count_exceeded(const struct test *the_test)
 {
-    per_thread_data *data = sApp->test_thread_data(thread_num);
+    PerThreadData::Test *data = sApp->test_thread_data(thread_num);
 
     // unsigned comparisons so sApp->current_max_loop_count == -1 causes an always false
     if (unsigned(data->inner_loop_count) >= unsigned(sApp->current_max_loop_count))
@@ -836,7 +836,7 @@ static void *thread_runner(void *arg)
     pin_to_logical_processor(LogicalProcessor(cpu_info[thread_number].cpu_number), current_test->id);
 
     struct TestRunWrapper {
-        struct per_thread_data *this_thread;
+        PerThreadData::Test *this_thread;
         int ret = EXIT_FAILURE;
         int thread_number;
         CPUTimeFreqStamp before, after;
@@ -918,6 +918,11 @@ static LogicalProcessorSet init_cpus()
 
 static void init_shmem(int fd = -1)
 {
+    static_assert(sizeof(PerThreadData::Main) == 64,
+            "PerThreadData::Main size grew, please check if it was intended");
+    static_assert(sizeof(PerThreadData::Test) == 64,
+            "PerThreadData::Testsize grew, please check if it was intended");
+
     if (sApp->shmem)
         return;                 // already initialized
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -716,9 +716,6 @@ static void print_temperature_and_throttle()
 
 static void init_internal(const struct test *test)
 {
-    sApp->main_thread_data()->init();
-    for (int i = 0; i < num_cpus(); ++i)
-        sApp->test_thread_data(i)->init();
     print_temperature_and_throttle();
 
     logging_init(test);
@@ -1438,6 +1435,9 @@ static TestResult run_thread_slices(/*nonconst*/ struct test *test)
         int ret = 0;
         test->per_thread = sApp->user_thread_data.data();
         std::fill_n(test->per_thread, sApp->thread_count, test_data_per_thread{});
+        sApp->main_thread_data()->init();
+        for (int i = 0; i < num_cpus(); ++i)
+            sApp->test_thread_data(i)->init();
 
         sApp->test_tests_init(test);
         if (test->test_init) {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -450,7 +450,7 @@ inline void test_the_test_data<true>::test_tests_finish(const struct test *the_t
     // check if the test has failed
     bool has_failed = false;
     for (int i = -1; i < num_cpus() && !has_failed; ++i) {
-        if (cpu_data_for_thread(i)->has_failed())
+        if (sApp->thread_data(i)->has_failed())
             has_failed = true;
     }
 
@@ -1938,7 +1938,7 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
         if (state > EXIT_SUCCESS) {
             // this counts as the first failure regardless of how many fractures we've run
             for (int i = 0; i < num_cpus(); ++i) {
-                if (cpu_data_for_thread(i)->has_failed())
+                if (sApp->thread_data(i)->has_failed())
                     per_cpu_fails[i] |= uint64_t(1);
             }
             ++fail_count;
@@ -1986,7 +1986,7 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
 
             if (state > TestPassed) {
                 for (int i = 0; iterations < 64 && i < num_cpus(); ++i) {
-                    if (cpu_data_for_thread(i)->has_failed())
+                    if (sApp->thread_data(i)->has_failed())
                         per_cpu_fails[i] |= uint64_t(1) << iterations;
                 }
                 ++fail_count;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -188,16 +188,16 @@ struct Common
     /* Records the number of bytes log_data'ed per thread */
     std::atomic<size_t> data_bytes_logged;
 
-    uint64_t fail_time;
+    MonotonicTimePoint fail_time;
     bool has_failed() const
     {
-        return fail_time > 0;
+        return fail_time < MonotonicTimePoint::max();
     }
 
     void init()
     {
         thread_state.store(thread_not_started, std::memory_order_relaxed);
-        fail_time = 0;
+        fail_time = MonotonicTimePoint::max();
         messages_logged.store(0, std::memory_order_relaxed);
         data_bytes_logged.store(0, std::memory_order_relaxed);
     }

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -406,6 +406,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     }
 
     per_thread_data *main_thread_data() noexcept;
+    per_thread_data *test_thread_data(int thread);
 
     SandstoneBackgroundScan background_scan;
 
@@ -460,14 +461,19 @@ static inline per_thread_data *cpu_data_for_thread(int thread)
 {
     if (thread == -1)
         return sApp->main_thread_data();
-    assert(thread >= 0);
-    assert(thread < sApp->thread_count);
-    return &sApp->shmem->per_thread[thread];
+    return sApp->test_thread_data(thread);
 }
 
 inline per_thread_data *SandstoneApplication::main_thread_data() noexcept
 {
     return &shmem->main_thread_data;
+}
+
+inline per_thread_data *SandstoneApplication::test_thread_data(int thread)
+{
+    assert(thread >= 0);
+    assert(thread < sApp->thread_count);
+    return &shmem->per_thread[thread];
 }
 
 struct AutoClosingFile

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -405,6 +405,8 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
         return fork_mode;
     }
 
+    per_thread_data *main_thread_data() noexcept;
+
     SandstoneBackgroundScan background_scan;
 
 private:
@@ -457,10 +459,16 @@ inline SandstoneApplication *_sApp() noexcept
 static inline per_thread_data *cpu_data_for_thread(int thread)
 {
     if (thread == -1)
-        return &sApp->shmem->main_thread_data;
+        return sApp->main_thread_data();
+    assert(thread >= 0);
+    assert(thread < sApp->thread_count);
     return &sApp->shmem->per_thread[thread];
 }
 
+inline per_thread_data *SandstoneApplication::main_thread_data() noexcept
+{
+    return &shmem->main_thread_data;
+}
 
 struct AutoClosingFile
 {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -174,7 +174,8 @@ inline int simple_getopt(int argc, char **argv, struct option *options, int *opt
     return getopt_long(argc, argv, cached_short_opts.c_str(), options, optind);
 }
 
-struct alignas(64) per_thread_data
+namespace PerThreadData {
+struct Common
 {
     std::atomic<ThreadState> thread_state;
 
@@ -187,19 +188,28 @@ struct alignas(64) per_thread_data
     /* Records the number of bytes log_data'ed per thread */
     std::atomic<size_t> data_bytes_logged;
 
-    /* Number of iterations of the inner loop (aka #times test_time_condition called) */
-    uint64_t inner_loop_count;
-    uint64_t inner_loop_count_at_fail;
     uint64_t fail_time;
-
-    /* Thread's effective CPU frequency during execution */
-    double effective_freq_mhz;
-
     bool has_failed() const
     {
         return fail_time > 0;
     }
 };
+
+struct alignas(64) Main : Common
+{
+    // nothing yet
+};
+
+struct alignas(64) Test : Common
+{
+    /* Number of iterations of the inner loop (aka #times test_time_condition called) */
+    uint64_t inner_loop_count;
+    uint64_t inner_loop_count_at_fail;
+
+    /* Thread's effective CPU frequency during execution */
+    double effective_freq_mhz;
+};
+} // namespace PerThreadData
 
 template <bool IsDebug> struct test_the_test_data
 {
@@ -318,8 +328,8 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     struct ExecState;
 
     struct SharedMemory {
-        per_thread_data main_thread_data;
-        per_thread_data per_thread[MAX_THREADS];
+        PerThreadData::Main main_thread_data;
+        PerThreadData::Test per_thread[MAX_THREADS];
     };
     std::vector<test_data_per_thread> user_thread_data;
     SharedMemory *shmem = nullptr;
@@ -405,9 +415,9 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
         return fork_mode;
     }
 
-    per_thread_data *thread_data(int thread);
-    per_thread_data *main_thread_data() noexcept;
-    per_thread_data *test_thread_data(int thread);
+    PerThreadData::Common *thread_data(int thread);
+    PerThreadData::Main *main_thread_data() noexcept;
+    PerThreadData::Test *test_thread_data(int thread);
 
     SandstoneBackgroundScan background_scan;
 
@@ -458,19 +468,19 @@ inline SandstoneApplication *_sApp() noexcept
 
 #define sApp    _sApp()
 
-inline per_thread_data *SandstoneApplication::thread_data(int thread)
+inline PerThreadData::Common *SandstoneApplication::thread_data(int thread)
 {
     if (thread == -1)
         return main_thread_data();
     return test_thread_data(thread);
 }
 
-inline per_thread_data *SandstoneApplication::main_thread_data() noexcept
+inline PerThreadData::Main *SandstoneApplication::main_thread_data() noexcept
 {
     return &shmem->main_thread_data;
 }
 
-inline per_thread_data *SandstoneApplication::test_thread_data(int thread)
+inline PerThreadData::Test *SandstoneApplication::test_thread_data(int thread)
 {
     assert(thread >= 0);
     assert(thread < sApp->thread_count);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -405,6 +405,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
         return fork_mode;
     }
 
+    per_thread_data *thread_data(int thread);
     per_thread_data *main_thread_data() noexcept;
     per_thread_data *test_thread_data(int thread);
 
@@ -457,11 +458,11 @@ inline SandstoneApplication *_sApp() noexcept
 
 #define sApp    _sApp()
 
-static inline per_thread_data *cpu_data_for_thread(int thread)
+inline per_thread_data *SandstoneApplication::thread_data(int thread)
 {
     if (thread == -1)
-        return sApp->main_thread_data();
-    return sApp->test_thread_data(thread);
+        return main_thread_data();
+    return test_thread_data(thread);
 }
 
 inline per_thread_data *SandstoneApplication::main_thread_data() noexcept

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -193,6 +193,14 @@ struct Common
     {
         return fail_time > 0;
     }
+
+    void init()
+    {
+        thread_state.store(thread_not_started, std::memory_order_relaxed);
+        fail_time = 0;
+        messages_logged.store(0, std::memory_order_relaxed);
+        data_bytes_logged.store(0, std::memory_order_relaxed);
+    }
 };
 
 struct alignas(64) Main : Common
@@ -208,6 +216,13 @@ struct alignas(64) Test : Common
 
     /* Thread's effective CPU frequency during execution */
     double effective_freq_mhz;
+
+    void init()
+    {
+        Common::init();
+        inner_loop_count = inner_loop_count_at_fail = 0;
+        effective_freq_mhz = 0.0;
+    }
 };
 } // namespace PerThreadData
 

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -203,7 +203,7 @@ static void child_crash_handler(int, siginfo_t *si, void *ucontext)
     // mark thread as failed
     logging_mark_thread_failed(thread_num);
 
-    auto &thread_state = cpu_data_for_thread(-1)->thread_state;
+    auto &thread_state = sApp->main_thread_data()->thread_state;
     thread_state.store(thread_failed, std::memory_order_release);
 
     if (crashpipe[CrashPipeChild] == -1)
@@ -1028,7 +1028,7 @@ void debug_crashed_child()
     }
 
     // release the child
-    auto &thread_state = cpu_data_for_thread(-1)->thread_state;
+    auto &thread_state = sApp->main_thread_data()->thread_state;
     thread_state.load(std::memory_order_acquire);
     if (on_crash_action != context_on_crash) {
         thread_state.store(thread_debugged, std::memory_order_relaxed);

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -827,7 +827,7 @@ std::string Topology::build_falure_mask(const struct test *test)
                 if (cpu_id < 0)
                     continue;
 
-                if (cpu_data_for_thread(cpu_id)->has_failed()) {
+                if (sApp->thread_data(cpu_id)->has_failed()) {
                     threadmask |= 1U << t.id;
                     ++failcount;
                 }


### PR DESCRIPTION
Instead of doing a simple `memset()` in the parent process, move that to the child process and use dedicated functions to do so. This is slightly worse for now, exactly because it's not a `memset()`: that can do 32, 64, or even 128 bytes per cycle. However, once we have multiple children and the work is divided between them, this work will become parallel.

I've also split the main thread's (to become main threads') data structure from the test threads' data structure, so we can have different fields there. An upcoming field will be the test thread data's offset in the shared memory segment.