### PR TITLE
FW/child_debug: use futexes to make the child wait for gdb

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -130,10 +130,11 @@ enum TestResult : int8_t {
     TestSkipped = -1,
 };
 
-enum ThreadState : int_least8_t {
+enum ThreadState : int {
     thread_not_started = 0,
     thread_running = 1,
     thread_failed = 2,
+    thread_debugged = 3,
     thread_succeeded = -1,
     thread_skipped = -2,
 };

--- a/framework/sysdeps/darwin/futex.h
+++ b/framework/sysdeps/darwin/futex.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSDEPS_DARWIN_FUTEX_H
+#define SYSDEPS_DARWIN_FUTEX_H
+
+#include <limits.h>
+#include <stdint.h>
+
+// The Darwin kernel exposes a set of __ulock_{wait,wait2,wake} APIs in
+// https://github.com/apple-oss-distributions/xnu/blob/xnu-8792.81.2/bsd/sys/ulock.h,
+extern "C" {
+// -------- BEGIN OS Declarations --------
+extern int __ulock_wait2(uint32_t operation, void *addr, uint64_t value,
+    uint64_t timeout, uint64_t value2);
+extern int __ulock_wake(uint32_t operation, void *addr, uint64_t wake_value);
+
+/*
+ * operation bits [7, 0] contain the operation code.
+ */
+#define UL_COMPARE_AND_WAIT             1
+#define UL_COMPARE_AND_WAIT_SHARED      3
+#define UL_COMPARE_AND_WAIT64           5
+#define UL_COMPARE_AND_WAIT64_SHARED    6
+
+/*
+ * operation bits [15, 8] contain the flags for __ulock_wake
+ */
+#define ULF_WAKE_ALL                    0x00000100
+#define ULF_WAKE_THREAD                 0x00000200
+#define ULF_WAKE_ALLOW_NON_OWNER        0x00000400
+
+/*
+ * operation bits [15, 8] contain the flags for __ulock_wake
+ */
+#define ULF_WAKE_ALL                    0x00000100
+#define ULF_WAKE_THREAD                 0x00000200
+#define ULF_WAKE_ALLOW_NON_OWNER        0x00000400
+
+/*
+ * operation bits [31, 24] contain the generic flags
+ */
+#define ULF_NO_ERRNO                    0x01000000
+
+// -------- END OS Declarations --------
+} // extern "C"
+
+static constexpr bool FutexAvailable = true;
+
+static inline int futex_wait(void *ptr, int expected)
+{
+    return __ulock_wait2(UL_COMPARE_AND_WAIT, ptr, uint64_t(expected), UINT64_MAX, 0);
+}
+
+static inline int futex_wake_one(void *ptr)
+{
+    return __ulock_wake(UL_COMPARE_AND_WAIT, ptr, 0);
+}
+
+static inline int futex_wake_all(void *ptr)
+{
+    return __ulock_wake(UL_COMPARE_AND_WAIT | ULF_WAKE_ALL, ptr, 0);
+}
+
+#endif // SYSDEPS_DARWIN_FUTEX_H

--- a/framework/sysdeps/freebsd/futex.h
+++ b/framework/sysdeps/freebsd/futex.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSDEPS_FREEBSD_FUTEX_H
+#define SYSDEPS_FREEBSD_FUTEX_H
+
+#include <sys/types.h>
+#include <limits.h>
+
+// https://man.freebsd.org/cgi/man.cgi?query=_umtx_op
+#include <sys/umtx.h>
+
+static constexpr bool FutexAvailable = true;
+
+static inline int futex_wait(void *ptr, int expected)
+{
+    return _umtx_op(ptr, UMTX_OP_WAIT_UINT, u_long(expected), nullptr, nullptr);
+}
+
+static inline int futex_wake_one(void *ptr)
+{
+    return _umtx_op(ptr, UMTX_OP_WAKE, 1, nullptr, nullptr);
+}
+
+static inline int futex_wake_all(void *ptr)
+{
+    return _umtx_op(ptr, UMTX_OP_WAKE, INT_MAX, nullptr, nullptr);
+}
+
+#endif // SYSDEPS_FREEBSD_FUTEX_H

--- a/framework/sysdeps/generic/futex.h
+++ b/framework/sysdeps/generic/futex.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSDEPS_GENERIC_FUTEX_H
+#define SYSDEPS_GENERIC_FUTEX_H
+
+static constexpr bool FutexAvailable = false;
+
+static inline int futex_wait(void *ptr, int expected)
+{
+    return -1;
+}
+
+static inline int futex_wake_one(void *ptr)
+{
+    return -1;
+}
+
+static inline int futex_wake_all(void *ptr)
+{
+    return -1;
+}
+
+#endif // SYSDEPS_GENERIC_FUTEX_H

--- a/framework/sysdeps/linux/futex.h
+++ b/framework/sysdeps/linux/futex.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSDEPS_LINUX_FUTEX_H
+#define SYSDEPS_LINUX_FUTEX_H
+
+#include <limits.h>
+#include <linux/futex.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static constexpr bool FutexAvailable = true;
+
+static inline int futex(void *uaddr, int futex_op, uint32_t val = 0,
+                        const struct timespec *timeout = nullptr, uint32_t *uaddr2 = nullptr,
+                        uint32_t val3 = 0)
+{
+    return syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr, val3);
+}
+
+static inline int futex_wait(void *ptr, int expected)
+{
+    return futex(ptr, FUTEX_WAIT, expected);
+}
+
+static inline int futex_wake_one(void *ptr)
+{
+    return futex(ptr, FUTEX_WAKE, 1);
+}
+
+static inline int futex_wake_all(void *ptr)
+{
+    return futex(ptr, FUTEX_WAKE, INT_MAX);
+}
+
+#endif // SYSDEPS_LINUX_FUTEX_H

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -11,6 +11,8 @@
 #include "sandstone_context_dump.h"
 #include "sandstone_iovec.h"
 
+#include "futex.h"
+
 #include <initializer_list>
 #include <limits>
 #include <span>
@@ -200,6 +202,9 @@ static void child_crash_handler(int, siginfo_t *si, void *ucontext)
     // mark thread as failed
     logging_mark_thread_failed(thread_num);
 
+    auto &thread_state = cpu_data_for_thread(-1)->thread_state;
+    thread_state.store(thread_failed, std::memory_order_release);
+
     if (crashpipe[CrashPipeChild] == -1)
         return;
 
@@ -210,8 +215,8 @@ static void child_crash_handler(int, siginfo_t *si, void *ucontext)
 
         if (on_crash_action & attach_gdb_on_crash) {
             // now wait for the parent process to be done with us
-            char c;
-            IGNORE_RETVAL(read(crashpipe[CrashPipeChild], &c, sizeof(c)));
+            while (thread_state.load(std::memory_order_relaxed) == thread_failed)
+                futex_wait(&thread_state, int(thread_failed));
         }
 
         // restore the signal handler so we can be killed
@@ -852,6 +857,8 @@ void debug_init_global(const char *on_hang_arg, const char *on_crash_arg)
 {
 #if SANDSTONE_CHILD_BACKTRACE
     int gdb_available = -1;
+    if (!FutexAvailable)
+        gdb_available = 0;      // we can't synchronize without futexes
 
     if (on_hang_arg) {
         if (strcmp(on_hang_arg, "gdb") == 0 || strcmp(on_hang_arg, "attach-gdb") == 0) {
@@ -998,9 +1005,11 @@ void debug_crashed_child(pid_t child)
         print_crash_info(buf, ctx);
 
     // release the child
+    auto &thread_state = cpu_data_for_thread(-1)->thread_state;
+    thread_state.load(std::memory_order_acquire);
     if (on_crash_action != context_on_crash) {
-        char c = 1;
-        IGNORE_RETVAL(write(crashpipe[CrashPipeParent], &c, sizeof(c)));
+        thread_state.store(thread_debugged, std::memory_order_relaxed);
+        futex_wake_all(&thread_state);
     }
 }
 

--- a/framework/sysdeps/windows/futex.h
+++ b/framework/sysdeps/windows/futex.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSDEPS_WIN32_FUTEX_H
+#define SYSDEPS_WIN32_FUTEX_H
+
+#include <windows.h>
+
+static constexpr bool FutexAvailable = true;
+
+static inline int futex_wait(void *ptr, int expected)
+{
+    return WaitOnAddress(ptr, &expected, sizeof(expected), INFINITE) ? 0 : -1;
+}
+
+static inline int futex_wake_one(void *ptr)
+{
+    WakeByAddressOne(ptr);
+    return 0;
+}
+
+static inline int futex_wake_all(void *ptr)
+{
+    WakeByAddressAll(ptr);
+    return 0;
+}
+
+#endif // SYSDEPS_WIN32_FUTEX_H


### PR DESCRIPTION
I decided to use the thread_state variable in the main thread for this. It's currently unused: instead of setting it to the result of the init() function, we return that state in the process's exit status. But even if it were in use, this state variable can be used, because either the crash happened *in* the init() or cleanup() function or init() returned success.

I needed to enlarge this variable to 32 bits to be able to use it in a futex.
