### PR TITLE
FW: mark _sApp() noexcept

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -374,7 +374,7 @@ private:
     SandstoneApplication &operator=(const SandstoneApplication &) = delete;
     friend int internal_main(int argc, char **argv);
     friend int main(int argc, char **argv);
-    friend SandstoneApplication *_sApp();
+    friend SandstoneApplication *_sApp() noexcept;
 };
 
 // state from SandstoneApplication:
@@ -408,7 +408,7 @@ struct SandstoneApplication::ExecState
     bool selftest;
 };
 
-inline SandstoneApplication *_sApp()
+inline SandstoneApplication *_sApp() noexcept
 {
     using App = std::aligned_storage_t<sizeof(SandstoneApplication), alignof(SandstoneApplication)>;
     static App app;


### PR DESCRIPTION
I had a neater solution but that ran afoul of C++ not allowing me to do what I wanted. It was
```c++
union SandstoneApplicationStorage
{
    SandstoneApplication app;
    unsigned char dummy[sizeof(app)];
    constexpr SandstoneApplicationStorage() : dummy{}
    {}
    constexpr ~SandstoneApplicationStorage()
    {}
};
constinit inline SandstoneApplicationStorage _sApp;
#define sApp    (&_sApp.app)
```
This failed to compile with Clang saying this destructor can't be `constexpr` and GCC adds load-time code to register the destructor (meaning it ignored the keyword but didn't allow it to be `constexpr`).