### PR TITLE
FW/Win32: Fix build with UCRT

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1339,7 +1339,7 @@ template <typename Prototype> void SharedMemorySynchronization::transfer(Prototy
 #if (__GLIBC__ * 1000 + __GLIBC_MINOR__) >= 2032
             // new API added in glibc 2.32 to replace the old, BSD one below
             errname = strerrordesc_np(errno);
-#else
+#elif !defined(_UCRT)
             if (errno < sys_nerr)
                 errname = sys_errlist[errno];
 #endif

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -341,7 +341,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     LogicalProcessorSet enabled_cpus;
     int thread_count;
 
-#if !defined(__linux__) && !defined(_WIN32)
+#ifndef __linux__
     std::string path_to_self;
 #endif
 #ifdef NDEBUG


### PR DESCRIPTION
This replaces the direct access to [`_pgmptr`.](https://learn.microsoft.com/en-us/cpp/c-runtime-library/pgmptr-wpgmptr) with [`_get_pgmptr`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/get-pgmptr).

It also removes the access to `sys_nerr` and `sys_errlist` because those are likewise not declared with UCRT. I'm not bothering with a replacement because this code was removed by PR #272 (commit 6526b2af82900a3545482e41713938b35388bb90) in the `socket-separation` branch.