### PR TITLE
Meson: Fix sysdeps build flags by reorganising the flags

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -19,10 +19,6 @@ framework_incdir = [
     ])
 ]
 
-if target_machine.system() != 'windows' and target_machine.system() != 'cygwin'
-    subdir('sysdeps/unix')
-endif
-subdir(sysdeps_dir)
 
 # Must be a configure_file, not custom_target, so it's created at
 # meson time and thus before everything
@@ -75,29 +71,6 @@ framework_config.set10('SANDSTONE_SSL_BUILD', get_option('ssl_link_type') != 'no
 framework_config.set10('SANDSTONE_SSL_LINKED',
   get_option('ssl_link_type') == 'static' or get_option('ssl_link_type') == 'dynamic')
 
-framework_config_h = configure_file(
-    input : 'sandstone_config.h.in',
-    output : 'sandstone_config.h',
-    configuration : framework_config,
-)
-
-framework_main_a = static_library(
-    'framework_main',
-    files(
-        'main.cpp',
-    ),
-    build_by_default: false,
-    include_directories : [
-        framework_incdir,
-    ],
-    cpp_args : [
-        debug_c_flags,
-        march_generic_flags,
-        default_cpp_flags,
-        default_cpp_warn,
-    ],
-)
-
 framework_files = files(
     'Floats.cpp',
     'generated_vectors.c',
@@ -141,6 +114,34 @@ framework_files += [
     'sandstone_sections.S',
 ]
 endif
+
+if target_machine.system() != 'windows' and target_machine.system() != 'cygwin'
+    subdir('sysdeps/unix')
+endif
+subdir(sysdeps_dir)
+
+framework_config_h = configure_file(
+    input : 'sandstone_config.h.in',
+    output : 'sandstone_config.h',
+    configuration : framework_config,
+)
+
+framework_main_a = static_library(
+    'framework_main',
+    files(
+        'main.cpp',
+    ),
+    build_by_default: false,
+    include_directories : [
+        framework_incdir,
+    ],
+    cpp_args : [
+        debug_c_flags,
+        march_generic_flags,
+        default_cpp_flags,
+        default_cpp_warn,
+    ],
+)
 
 framework_a = static_library(
     'framework',

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -153,7 +153,6 @@ framework_a = static_library(
         framework_incdir,
     ],
     objects: [
-        sysdeps_a.extract_all_objects(recursive: true),
         framework_main_a.extract_all_objects(recursive: false),
     ],
     dependencies: [

--- a/framework/sysdeps/darwin/meson.build
+++ b/framework/sysdeps/darwin/meson.build
@@ -1,6 +1,7 @@
-sysdeps_a = static_library(
-    'sysdeps_darwin',
-    sysdeps_unix_files,
+# Copyright 2022 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+framework_files += \
     files(
         'cpu_affinity.cpp',
         'malloc.cpp',
@@ -9,17 +10,4 @@ sysdeps_a = static_library(
         '../generic/memfpt.c',
         '../generic/msr.c',
         '../generic/physicaladdress.c',
-    ),
-    build_by_default: false,
-    include_directories : [
-        framework_incdir,
-    ],
-    c_args : [
-        default_c_warn,
-        debug_c_flags,
-    ],
-    cpp_args : [
-        default_cpp_warn,
-        debug_c_flags,
-    ],
-)
+    )

--- a/framework/sysdeps/freebsd/meson.build
+++ b/framework/sysdeps/freebsd/meson.build
@@ -1,6 +1,7 @@
-sysdeps_a = static_library(
-    'sysdeps_freebsd',
-    sysdeps_unix_files,
+# Copyright 2022 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+framework_files += \
     files(
         'cpu_affinity.cpp',
         'malloc.cpp',
@@ -8,17 +9,4 @@ sysdeps_a = static_library(
         '../generic/memfpt.c',
         '../generic/msr.c',
         '../generic/physicaladdress.c',
-    ),
-    build_by_default: false,
-    include_directories : [
-        framework_incdir,
-    ],
-    c_args : [
-        default_c_warn,
-        debug_c_flags,
-    ],
-    cpp_args : [
-        default_cpp_warn,
-        debug_c_flags,
-    ],
-)
+    )

--- a/framework/sysdeps/linux/extract-malloc.sh
+++ b/framework/sysdeps/linux/extract-malloc.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -e
+# Copyright 2023 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+#
+while [[ "$1" = *=* ]]; do
+    # Evaluate variable assignments, like AR= and OBJCOPY=
+    eval "$1"
+    shift
+done
+if [[ "$1" = "--" ]]; then
+    shift
+fi
+
+if [[ $# -lt 3 ]]; then
+    cat <<EOF
+Extracts malloc.o from static libc and localizes symbols defined in malloc.cpp.
+Syntax:
+    $0 [variable-assignments] /path/to/libc.a /path/to/malloc.cpp /path/to/output/malloc.o
+Variable assignments can be:
+  AR=/path/to/ar
+EOF
+    exit 0
+fi
+
+# Positional arguments
+libc_a=$1
+malloc_cpp=$2
+output=$3
+output_dirname=${output%/*}
+output_basename=${output##*/}
+
+# Define $AR and $OBJCOPY if they aren't defined.
+: ${AR:=ar}
+: ${OBJCOPY:=objcopy}
+
+# Generate the -L arguments based on DECLARE_OVERRIDE inside malloc.cpp
+objcopy_args=(`sed -En "/^DECLARE_OVERRIDE\((\w+)\).*/s//-L\1/p" "$malloc_cpp"`)
+
+# Extract malloc.o from libc.a
+"$AR" x --output "$output_dirname" "$libc_a" malloc.o
+
+# Rename if necessary
+[[ "$output_basename" = malloc.o ]] || mv -- "$output_dirname/malloc.o" "$output"
+
+# Transform it
+"$OBJCOPY" "${objcopy_args[@]}" "$output"

--- a/framework/sysdeps/linux/malloc.cpp
+++ b/framework/sysdeps/linux/malloc.cpp
@@ -30,14 +30,19 @@
 #  endif
 
 extern "C" {
-extern void *__libc_memalign(size_t alignment, size_t size);
-extern int __libc_posix_memalign (void **memptr, size_t alignment, size_t size);
-extern void *__libc_memalign (size_t alignment, size_t bytes);
-extern void *__libc_valloc (size_t bytes);
-extern void *__libc_pvalloc (size_t bytes);
-extern void *__libc_calloc (size_t n, size_t elem_size);
-extern void *__libc_malloc(size_t size);
-extern void *__libc_realloc (void *oldmem, size_t bytes);
+#define DECLARE_OVERRIDE(FUNC)  extern decltype(FUNC) __libc_ ## FUNC
+
+// The following lines are parsed by the buildsystem, so be careful when
+// modifying them. See extract-malloc.sh.
+DECLARE_OVERRIDE(calloc);
+DECLARE_OVERRIDE(malloc);
+DECLARE_OVERRIDE(memalign);
+DECLARE_OVERRIDE(posix_memalign);
+DECLARE_OVERRIDE(pvalloc);
+DECLARE_OVERRIDE(realloc);
+DECLARE_OVERRIDE(valloc);
+
+#undef DECLARE_OVERRIDE
 }
 
 static void *bzero_block(void *ptr, size_t len)

--- a/framework/sysdeps/linux/meson.build
+++ b/framework/sysdeps/linux/meson.build
@@ -42,35 +42,30 @@ _sysdeps_a = static_library(
 
 if get_option('cpp_link_args').contains('-static')
     ar = find_program('ar')
-    nm = find_program('nm')
     objcopy = find_program('objcopy')
 
     # Need to extract malloc.o from libc.a and transform it
-    # Step 1: extract it:
+    # Step 1: find libc.a by asking the compiler
     libc_a = run_command(cc.cmd_array(), '-print-file-name=libc.a',
            check: true
     )
 
-    orig_glibc_malloc_o = custom_target(
-        'extract-malloc.o',
-        output: 'malloc.o',
-        input: libc_a.stdout().strip(),
-        command: [
-            ar, 'x', '--output', '@OUTDIR@', '@INPUT@', '@OUTPUT@',
-        ]
-    )
-    # Step 2: transform it by localizing (-L) all the symbols from our malloc.cpp
+    # Step 2: run our extractor script
     glibc_malloc_o = custom_target(
         'glibc_malloc.o',
         input: [
-            _sysdeps_a.extract_objects('malloc.cpp'),
-            orig_glibc_malloc_o,
+            libc_a.stdout().strip(),
+            files('malloc.cpp'),
         ],
         output: 'glibc_malloc.o',
         command: [
-            shell, '-c', objcopy.full_path() + ' `' +
-            nm.full_path() + ' --defined $0 | sed -En "/^.* T /s//-L /p"` $1 $2',
-            '@INPUT@', '@OUTPUT@',
+            shell,
+            files('extract-malloc.sh'),
+            'AR=' + ar.full_path(),
+            'OBJCOPY=' + objcopy.full_path(),
+            '--',
+            '@INPUT@',
+            '@OUTPUT@',
         ]
     )
     # Step 3: add this file to the sysdeps library

--- a/framework/sysdeps/linux/meson.build
+++ b/framework/sysdeps/linux/meson.build
@@ -2,43 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if (host_machine.cpu_family() == 'x86_64')
-    sysdeps_arch_files = files(
+    framework_files += files(
         'interrupt_monitor.cpp',
         'kvm.c',
         'msr.c',
     )
 else
-    sysdeps_arch_files = files(
+    framework_files += files(
         '../generic/kvm.c',
         '../generic/msr.c',
     )
 endif
 
-_sysdeps_a = static_library(
-    'sysdeps_linux',
-    sysdeps_unix_files,
-    sysdeps_arch_files,
+framework_files += \
     files(
         'cpu_affinity.cpp',
         'malloc.cpp',
         'memfpt.cpp',
         'physicaladdress.cpp',
-    ),
-    build_by_default: false,
-    include_directories : [
-        framework_incdir,
-    ],
-    c_args : [
-        '-DLINUX',
-        '-D__linux__',
-        default_c_warn,
-        debug_c_flags,
-    ],
-    cpp_args : [
-        default_cpp_warn,
-        debug_c_flags,
-    ],
-)
+    )
 
 if get_option('cpp_link_args').contains('-static')
     ar = find_program('ar')
@@ -68,13 +50,7 @@ if get_option('cpp_link_args').contains('-static')
             '@OUTPUT@',
         ]
     )
-    # Step 3: add this file to the sysdeps library
-    sysdeps_a = static_library(
-        'sysdeps_linux_static',
-        glibc_malloc_o,
-        build_by_default: false,
-        objects: _sysdeps_a.extract_all_objects(recursive: false),
-    )
-else
-    sysdeps_a = _sysdeps_a
+
+    # Step 3: add this file to the file listing
+    framework_files += glibc_malloc_o
 endif # if static

--- a/framework/sysdeps/unix/meson.build
+++ b/framework/sysdeps/unix/meson.build
@@ -1,7 +1,7 @@
 # Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-sysdeps_unix_files = files(
+framework_files += files(
     'child_debug.cpp',
     'resource.cpp',
     'signals.cpp',

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -1,8 +1,7 @@
 # Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-sysdeps_a = static_library(
-    'sysdeps_win32',
+framework_files += \
     files(
         'aligned_alloc.c',
         'child_debug.cpp',
@@ -19,17 +18,4 @@ sysdeps_a = static_library(
         '../generic/memfpt.c',
         '../generic/msr.c',
         '../generic/physicaladdress.c',
-    ),
-    build_by_default: false,
-    include_directories : [
-        framework_incdir,
-    ],
-    c_args : [
-        default_c_flags,
-        default_c_warn,
-    ],
-    cpp_args : [
-        default_cpp_flags,
-        default_cpp_warn,
-    ],
-)
+    )


### PR DESCRIPTION
This simplifies the build process and incidentally also fixes the inconsistency in build flags -- the files from sysdeps/ weren't getting the `march_flags`, for example.

Those `-DLINUX` and `-D__linux__` flags were there since the Meson build system was added to the internal repository prior to open-sourcing, but they don't seem to have a purpose because a) nothing uses the `LINUX` macro and b) the compiler predefines the `__linux__` macro for us.

To do this, I needed to rework the processing of libc.a's malloc.o so it wouldn't depend on having compiled our malloc.cpp. Because of Meson is incapable of using backslashes in custom_target() commands (see bug mesonbuild/meson#1564), I had to write a shell script to execute sed, so I decided to move the ar x command there too.

Drive-by addition of the copyright and SPDX headers to the Darwin and FreeBSD files.
