### PR TITLE
FW/logging: remove use of FILE* the child logging

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -159,7 +159,7 @@ public:
     static std::string get_current_time();
 
     // non-virtual override
-    void print(int tc, ChildExitStatus status);
+    void print(ChildExitStatus status);
     static void print_header(std::string_view cmdline, Duration test_duration, Duration test_timeout);
 
 private:
@@ -2264,7 +2264,7 @@ std::string YamlLogger::get_current_time()
              iso8601_time_now(Iso8601Format::WithoutMs));
 }
 
-void YamlLogger::print(int, ChildExitStatus status)
+void YamlLogger::print(ChildExitStatus status)
 {
     Duration test_duration = MonotonicTimePoint::clock::now() - sApp->current_test_starttime;
 
@@ -2388,7 +2388,7 @@ TestResult logging_print_results(ChildExitStatus status, int *tc, const struct t
 
     case SandstoneApplication::OutputFormat::yaml: {
         YamlLogger l(test, status.result);
-        l.print(n, status);
+        l.print(status);
         return l.state;
     }
 

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1156,19 +1156,19 @@ void logging_finish()
 {
     auto &all = all_thread_logs();
     for (size_t i = 0; i < all.size(); ++i) {
-        fclose(all[i].log);
+        close(all[i].log_fd);
         all[i] = {};
     }
     if (stderr_fd != -1)
         close(stderr_fd);
 }
 
-FILE *logging_stream_open(int thread_num, int level)
+LoggingStream logging_user_messages_stream(int thread_num, int level)
 {
-    FILE *log = log_for_thread(thread_num).log;
-    fflush(log);
-    fputc(message_code(UserMessages, level), log);
-    return log;
+    LoggingStream stream(log_for_thread(thread_num).log_fd);
+    uint8_t code = message_code(UserMessages, level);
+    stream.write(code);
+    return stream;
 }
 
 static inline void assert_log_message(const char *fmt)

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1479,7 +1479,6 @@ static TestResult run_thread_slices(/*nonconst*/ struct test *test)
 static SandstoneApplication::ExecState make_app_state()
 {
     SandstoneApplication::ExecState app_state;
-    logging_init_child_prefork(&app_state);
 
 #define COPY_STATE_FROM_SAPP(id)    \
     app_state.id = sApp->id;
@@ -1693,8 +1692,7 @@ static int spawn_child(const struct test *test, intptr_t *hpid)
     return ret;
 }
 
-static TestResult run_child(/*nonconst*/ struct test *test,
-                            const SandstoneApplication::ExecState *app_state = nullptr)
+static TestResult run_child(/*nonconst*/ struct test *test)
 {
     if (sApp->current_fork_mode() != SandstoneApplication::no_fork) {
         pin_to_logical_processor(LogicalProcessor(-1), "control");
@@ -1702,7 +1700,6 @@ static TestResult run_child(/*nonconst*/ struct test *test,
         debug_init_child();
     }
 
-    logging_init_child_postexec(app_state);
     TestResult result = run_thread_slices(test);
 
     return result;
@@ -2436,7 +2433,7 @@ static int exec_mode_run(int argc, char **argv)
 
     std::vector<struct test *> test_list;
     add_test(test_list, test_to_run);
-    return run_child(test_to_run, &app_state);
+    return run_child(test_to_run);
 }
 
 // Triage run attempts to figure out which socket(s) are causing test failures.

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -179,6 +179,9 @@ struct alignas(64) per_thread_data
 {
     std::atomic<ThreadState> thread_state;
 
+    /* file descriptor for logging */
+    int log_fd;
+
     /* Records number of messages logged per thread of each test */
     std::atomic<int> messages_logged;
 
@@ -435,8 +438,6 @@ private:
 
 struct SandstoneApplication::ExecState
 {
-    int thread_log_fds[MAX_THREADS + 1];        // +1 for the main thread's log
-
 #define DECLARE_APP_STATE_VARIABLES(id)     decltype(SandstoneApplication::id) id;
     APP_STATE_VARIABLES(DECLARE_APP_STATE_VARIABLES)
 #undef DECLARE_APP_STATE_VARIABLES
@@ -548,9 +549,7 @@ void logging_print_triage_results(const std::vector<int> &sockets);
 void logging_print_version(void);
 void logging_flush(void);
 void logging_init(const struct test *test);
-void logging_init_child_prefork(SandstoneApplication::ExecState *state);
 void logging_init_child_preexec();
-void logging_init_child_postexec(const SandstoneApplication::ExecState *state);
 void logging_finish();
 LoggingStream logging_user_messages_stream(int thread_num, int level);
 TestResult logging_print_results(ChildExitStatus status, int *tc, const struct test *test);


### PR DESCRIPTION
We already opened the `FILE *` in unbuffered mode, so the stdio content was only overhead we didn't need. The few places where we still used it were removed in PR #278. By using only low-level file descriptors, we can store the file descriptor directly in the shared memory segment, reducing the size of that `ExecState` that is passed to the child process (and also removing one more hardcoded `MAX_THREADS`).

The other commits are clean-ups.