### PR TITLE
FW/SharedMemory: don't pass thread_count in the ExecState to the child

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1490,7 +1490,6 @@ static SandstoneApplication::ExecState make_app_state()
     app_state.selftest = (test_set.data() == selftests.data());
 #endif
     memcpy(app_state.cpu_mask, sApp->enabled_cpus.array, sizeof(LogicalProcessorSet::array));
-    app_state.thread_count = sApp->thread_count;
     return app_state;
 }
 
@@ -2419,7 +2418,7 @@ static int exec_mode_run(int argc, char **argv)
 
     LogicalProcessorSet enabled_cpus = {};
     memcpy(enabled_cpus.array, app_state.cpu_mask, sizeof(LogicalProcessorSet::array));
-    sApp->thread_count = app_state.thread_count;
+    sApp->thread_count = enabled_cpus.count();
     sApp->user_thread_data.resize(sApp->thread_count);
     load_cpu_info(enabled_cpus);
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -405,7 +405,6 @@ struct SandstoneApplication::ExecState
 #undef DECLARE_APP_STATE_VARIABLES
 
     uint8_t cpu_mask[sizeof(LogicalProcessorSet::array)];
-    int thread_count;
     bool selftest;
 };
 


### PR DESCRIPTION
It can be calculated from the CPU mask. It's work that doesn't need to be re-done, but this change will come in handy in the future.