### PR TITLE
FW/SharedMemory: don't pass state variables to the child that the child doesn't need

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -431,7 +431,6 @@ private:
     F(ud_on_failure)                        \
     F(current_max_loop_count)               \
     F(current_test_endtime)                 \
-    F(current_test_duration)                \
     F(test_time)                            \
     F(max_test_time)
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -427,12 +427,10 @@ private:
     F(output_yaml_indent)                   \
     F(use_strict_runtime)                   \
     F(log_test_knobs)                       \
-    F(force_test_time)                      \
     F(ud_on_failure)                        \
     F(current_max_loop_count)               \
     F(current_test_endtime)                 \
-    F(test_time)                            \
-    F(max_test_time)
+    /**/
 
 struct SandstoneApplication::ExecState
 {


### PR DESCRIPTION
`current_test_duration` was used in the sliding-window slicing code, which was removed in 8f59e10b04ad82724d3bf2975d827f0aeb1ca022 (PR #271).

The other variables don't appear to ever have been needed in the child.
