### PR TITLE
FW/Logging: refactor TapFormatLogger::print() to better use C++

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1761,52 +1761,54 @@ void KeyValuePairLogger::print_child_stderr()
 void TapFormatLogger::print(int tc)
 {
     // build the ok / not ok line
-    const char *qual = quality_string(test);
-    const char *extra = nullptr;
+    std::string extra;
+    if (const char *qual = quality_string(test))
+        extra = qual;
+
+    const char *okstring = "not ok";
     switch (childExitStatus.result) {
     case TestSkipped:
     case TestPassed:
         // recheck, as status.result does not take failing threads into account
-        if (testResult == TestSkipped) {
-            extra = "SKIP";
-            break;
-        } else if (testResult== TestPassed) {
-            break;      // no suffix necessary
-        }
+        if (testResult == TestSkipped)
+            extra += "SKIP";
+        if (testResult != TestFailed)
+            okstring = "ok";
 
         [[fallthrough]];
     case TestFailed:
         break;          // no suffix necessary
     case TestTimedOut:
-        extra = "timed out";
+        extra += "timed out";
         break;
     case TestCoreDumped:
-        extra = "Core Dumped: ";
+        extra += "Core Dumped: ";
+        extra += format_status_code();
         break;
     case TestOutOfMemory:
     case TestKilled:
-        extra = "Killed: ";
+        extra += "Killed: ";
+        extra += format_status_code();
         break;
     case TestInterrupted:
-        extra = "Interrupted";
+        extra += "Interrupted";
         break;
     case TestOperatingSystemError:
-        extra = "Operating system error: ";
+        extra += "Operating system error: ";
+        extra += format_status_code();
         break;
     }
 
-    std::string tap_line = stdprintf("%s %3i %s", testResult == TestFailed ? "not ok" : "ok", tc, test->id);
-    if (qual || extra || childExitStatus.extra) {
-        tap_line.reserve(128);
+    std::string tap_line = stdprintf("%s %3i %s", okstring, tc, test->id);
+    if (extra.size()) {
+        static constexpr std::string_view separator = "# ";
+        size_t newsize = std::max(tap_line.size(), size_t(32)) + separator.size() + extra.size();
+        tap_line.reserve(newsize);
         if (tap_line.size() < 32)
             tap_line.resize(32, ' ');
-        tap_line += "# ";
-        if (qual)
-            tap_line += qual;
-        if (extra)
-            tap_line += extra;
-        if (childExitStatus.extra)
-            tap_line += format_status_code();
+        tap_line += separator;
+        tap_line += extra;
+        extra.clear();
         if (childExitStatus.result == TestPassed && testResult == TestSkipped) { // if test passed in init and skipped on all threads in run
             tap_line += "(RuntimeSkipCategory: All CPUs skipped while executing 'test_run()' function, check log for details)";
         } else if (childExitStatus.result == TestSkipped) {  //if skipped in init


### PR DESCRIPTION
This code was originally written in C, which is why it manipulates two raw pointers. The last version of the logging_print_results() function in C (dated 2020-07-30) still received that `const char *extra` as a parameter.

So it's high time to clean it up and remove some of the fragility. For example, if the `ChildExitStatus::extra` value isn't 0, this code was assuming the result was a crash of some sort, which made me go down the wrong path of debugging to find out why the selftest_pass test was crashing... it wasn't, the log was wrong.

Last C version:
```c
bool logging_print_results(int pc, int tc, struct test *test, const char *extra)
{
    bool failed = (pc >= 0 && (unsigned)pc != (unsigned)thread_count);
    const char *qual = quality_string(test);
    if (qual[0] == '\0' && extra[0] != '\0')
        qual = "# ";

    switch (output_format) {
    case key_value_format:
        logging_printf(LOG_LEVEL_QUIET, "%s_result = %s\n", test->id,
                       pc < 0 ? "skip" : failed ? "fail" : "pass");
        logging_printf(LOG_LEVEL_VERBOSE(1), "%s_seq = %d\n", test->id, tc);
        logging_printf(LOG_LEVEL_VERBOSE(1), "%s_quality = %s\n", test->id, qual);
        logging_printf(LOG_LEVEL_VERBOSE(1), "%s_description = %s\n", test->id, test->name);
        logging_printf(LOG_LEVEL_VERBOSE(1), "%s_pass_count = %d\n", test->id, pc);
        if (pc >= 0)
            logging_printf(LOG_LEVEL_VERBOSE(1), "%s_fail_percent = %.1f\n", test->id,
                           100. * (thread_count - pc) / thread_count);
        break;

    case tap_format:
        if (failed)
            logging_printf(LOG_LEVEL_QUIET, "not ok %2i %-16s %s %s\n", tc, test->id, qual, extra);
        else
            logging_printf(LOG_LEVEL_VERBOSE(1), "ok %2i %-20s %s\n", tc, test->id, extra);
        break;
    }

    logging_flush();
    print_thread_messages(test);
    logging_flush();
    return !failed;
}
```