### PR TITLE
FW/SharedMemory: move SApp::ExecState's contents to SharedMemory

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1234,7 +1234,7 @@ void log_data(const char *message, const void *data, size_t size)
         return;                 // short-circuit
 
     std::atomic<int> &messages_logged = sApp->thread_data(thread_num)->messages_logged;
-    std::atomic<size_t> &data_bytes_logged = sApp->thread_data(thread_num)->data_bytes_logged;
+    std::atomic<unsigned> &data_bytes_logged = sApp->thread_data(thread_num)->data_bytes_logged;
     if (messages_logged.fetch_add(1, std::memory_order_relaxed) >= sApp->max_messages_per_thread ||
             (data_bytes_logged.fetch_add(size, std::memory_order_relaxed) > sApp->max_logdata_per_thread))
         return;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -343,7 +343,7 @@ static void __attribute__((noreturn)) report_fail_common()
 void _report_fail(const struct test *test, const char *file, int line)
 {
     /* Keep this very early */
-    if (sApp->ud_on_failure)
+    if (sApp->shmem->ud_on_failure)
         ud2();
 
     if (!SandstoneConfig::NoLogging)
@@ -354,7 +354,7 @@ void _report_fail(const struct test *test, const char *file, int line)
 void _report_fail_msg(const char *file, int line, const char *fmt, ...)
 {
     /* Keep this very early */
-    if (sApp->ud_on_failure)
+    if (sApp->shmem->ud_on_failure)
         ud2();
 
     if (!SandstoneConfig::NoLogging)
@@ -377,7 +377,7 @@ static ptrdiff_t memcmp_offset(const uint8_t *d1, const uint8_t *d2, size_t size
 void _memcmp_fail_report(const void *_actual, const void *_expected, size_t size, DataType type, const char *fmt, ...)
 {
     // Execute UD2 early if we've failed
-    if (sApp->ud_on_failure)
+    if (sApp->shmem->ud_on_failure)
         ud2();
 
     if (!SandstoneConfig::NoLogging) {
@@ -476,8 +476,8 @@ inline void test_the_test_data<true>::test_tests_finish(const struct test *the_t
         return;                     // no point in reporting timing of failed tests
 
     // check the overall time
-    if (sApp->current_test_endtime != MonotonicTimePoint::max() && the_test->desired_duration >= 0) {
-        Duration expected_runtime = sApp->current_test_endtime - sApp->current_test_starttime;
+    if (sApp->shmem->current_test_endtime != MonotonicTimePoint::max() && the_test->desired_duration >= 0) {
+        Duration expected_runtime = sApp->shmem->current_test_endtime - sApp->current_test_starttime;
         Duration min_expected_runtime = expected_runtime - expected_runtime / 4;
         Duration max_expected_runtime = expected_runtime + expected_runtime / 4;
         Duration actual_runtime = now - sApp->current_test_starttime;
@@ -633,7 +633,7 @@ static bool wallclock_deadline_has_expired(MonotonicTimePoint deadline)
 
     if (now > deadline)
         return true;
-    if (sApp->use_strict_runtime && now > sApp->endtime)
+    if (sApp->shmem->use_strict_runtime && now > sApp->endtime)
         return true;
     return false;
 }
@@ -643,7 +643,7 @@ static bool max_loop_count_exceeded(const struct test *the_test)
     PerThreadData::Test *data = sApp->test_thread_data(thread_num);
 
     // unsigned comparisons so sApp->current_max_loop_count == -1 causes an always false
-    if (unsigned(data->inner_loop_count) >= unsigned(sApp->current_max_loop_count))
+    if (unsigned(data->inner_loop_count) >= unsigned(sApp->shmem->current_max_loop_count))
         return true;
 
     /* Desired duration -1 means "runs once" */
@@ -664,7 +664,7 @@ int test_time_condition(const struct test *the_test) noexcept
     if (max_loop_count_exceeded(the_test))
         return 0;  // end the test if max loop count exceeded
 
-    return !wallclock_deadline_has_expired(sApp->current_test_endtime);
+    return !wallclock_deadline_has_expired(sApp->shmem->current_test_endtime);
 }
 
 // Creates a string containing all socket temperatures like: "P0:30oC P2:45oC"
@@ -862,7 +862,7 @@ static void *thread_runner(void *arg)
             this_thread->thread_state.store(new_state, std::memory_order_relaxed);
 
             if (new_state == thread_failed) {
-                if (sApp->ud_on_failure)
+                if (sApp->shmem->ud_on_failure)
                     ud2();
                 logging_mark_thread_failed(thread_number);
             }
@@ -871,7 +871,7 @@ static void *thread_runner(void *arg)
             after.Snapshot(thread_number);
             this_thread->effective_freq_mhz = CPUTimeFreqStamp::EffectiveFrequencyMHz(before, after);
 
-            if (sApp->verbosity >= 3)
+            if (sApp->shmem->verbosity >= 3)
                 log_message(thread_number, SANDSTONE_LOG_INFO "inner loop count for thread %d = %" PRIu64 "\n",
                             thread_number, this_thread->inner_loop_count);
         }
@@ -900,7 +900,8 @@ static void *thread_runner(void *arg)
     return reinterpret_cast<void *>(wrapper.ret);
 }
 
-int num_cpus() {
+int num_cpus()
+{
     return sApp->thread_count;
 }
 
@@ -1464,7 +1465,7 @@ static TestResult run_thread_slices(/*nonconst*/ struct test *test)
         logging_flush();
         run_threads(test);
 
-        if (sApp->use_strict_runtime && wallclock_deadline_has_expired(sApp->endtime)){
+        if (sApp->shmem->use_strict_runtime && wallclock_deadline_has_expired(sApp->endtime)){
             // skip cleanup on the last test when using strict runtime
         } else {
             if (test->test_cleanup)
@@ -1475,68 +1476,6 @@ static TestResult run_thread_slices(/*nonconst*/ struct test *test)
     } while (false);
 
     return state;
-}
-
-/* make_app_state(), write_app_state(), read_app_state() are used in
- * exec_each_test mode to pass the state of application to the newly spawned
- * child process (as opposed to just fork'ed child). */
-static SandstoneApplication::ExecState make_app_state()
-{
-    SandstoneApplication::ExecState app_state;
-
-#define COPY_STATE_FROM_SAPP(id)    \
-    app_state.id = sApp->id;
-    APP_STATE_VARIABLES(COPY_STATE_FROM_SAPP)
-#undef COPY_STATE_FROM_SAPP
-
-#ifndef NO_SELF_TESTS
-    app_state.selftest = (test_set.data() == selftests.data());
-#endif
-    memcpy(app_state.cpu_mask, sApp->enabled_cpus.array, sizeof(LogicalProcessorSet::array));
-    return app_state;
-}
-
-static bool write_app_state(int fd, const SandstoneApplication::ExecState &app_state)
-{
-    size_t total = 0;
-    auto ptr = reinterpret_cast<const uint8_t *>(&app_state);
-    while (total < sizeof(app_state)) {
-        ssize_t bytes = write(fd, ptr + total, sizeof(app_state) - total);
-        if (bytes < 0 && errno != EINTR) {
-            logging_printf(LOG_LEVEL_ERROR,
-                           "# ERROR: writing state to child process: %s. Test will likely fail.\n",
-                           strerror(errno));
-            break;
-        }
-        if (bytes >= 0)
-            total += bytes;
-    }
-    return total == sizeof(app_state);
-}
-
-static SandstoneApplication::ExecState read_app_state(int fd)
-{
-    SandstoneApplication::ExecState app_state;
-    auto ptr = reinterpret_cast<uint8_t *>(&app_state);
-    size_t total = 0;
-
-    while (total < sizeof(app_state)) {
-        ssize_t bytes = read(fd, ptr + total, sizeof(app_state) - total);
-        if (bytes < 0 && errno != EINTR) {
-            fprintf(stderr, "internal error while loading application state: %s\n", strerror(errno));
-            break;
-        }
-        if (bytes == 0)
-            break;
-        if (bytes >= 0)
-            total += bytes;
-    }
-    if (total != sizeof(app_state)) {
-        fprintf(stderr, "internal error: incomplete application state (%zu bytes read, needed %zu)\n",
-                total, sizeof(app_state));
-        exit(EX_IOERR);
-    }
-    return app_state;
 }
 
 static int call_forkfd(intptr_t *child)
@@ -1616,16 +1555,8 @@ static int call_forkfd(intptr_t *child)
 
 static int spawn_child(const struct test *test, intptr_t *hpid)
 {
-    std::array<char, std::numeric_limits<int>::digits10 + 2> statefdstr;
-    int statefd = open_memfd(MemfdInheritOnExec);
-    if (statefd < 0) {
-        perror("internal error: can't create state-transfer file");
-        exit(EX_CANTCREAT);
-    }
-    write_app_state(statefd, make_app_state());
-    lseek(statefd, 0, SEEK_SET);
-    snprintf(statefdstr.begin(), statefdstr.size(), "%u", unsigned(statefd));
-
+    assert(sApp->shmemfd != -1);
+    std::string shmemfdstr = stdprintf("%d", sApp->shmemfd);
     std::string random_seed = random_format_seed();
 
 #ifdef _WIN32
@@ -1637,7 +1568,7 @@ static int spawn_child(const struct test *test, intptr_t *hpid)
     const char *argv[] = {
         // argument order must match exec_mode_run()
         argv0, "-x", test->id, random_seed.c_str(),
-        statefdstr.begin(),
+        shmemfdstr.c_str(),
         nullptr
     };
 
@@ -1691,7 +1622,6 @@ static int spawn_child(const struct test *test, intptr_t *hpid)
     }
 #endif /* __linux__ */
 
-    close(statefd);
     return ret;
 }
 
@@ -1904,18 +1834,18 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
     first_iteration_target = MonotonicTimePoint::clock::now() + 10ms;
 
     if (sApp->max_test_loop_count) {
-        sApp->current_max_loop_count = sApp->max_test_loop_count;
+        sApp->shmem->current_max_loop_count = sApp->max_test_loop_count;
     } else if (test->desired_duration == -1) {
-        sApp->current_max_loop_count = -1;
+        sApp->shmem->current_max_loop_count = -1;
     } else if (sApp->test_tests_enabled()) {
         // don't fracture in the test-the-test mode
-        sApp->current_max_loop_count = -1;
+        sApp->shmem->current_max_loop_count = -1;
     } else if (test->fracture_loop_count == 0) {
         /* for automatic fracture mode, do a 40 loop count */
-        sApp->current_max_loop_count = 40;
+        sApp->shmem->current_max_loop_count = 40;
         auto_fracture = true;
     } else {
-        sApp->current_max_loop_count = test->fracture_loop_count;
+        sApp->shmem->current_max_loop_count = test->fracture_loop_count;
     }
 
     assert(sApp->retest_count >= 0);
@@ -1925,14 +1855,17 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
         init_internal(test);
 
         // calculate starttime->endtime, reduce the overhead to have better test runtime calculations
-        sApp->current_test_endtime = calculate_wallclock_deadline(sApp->current_test_duration - runtime, &sApp->current_test_starttime);
+        sApp->shmem->current_test_endtime =
+                calculate_wallclock_deadline(sApp->current_test_duration - runtime,
+                                             &sApp->current_test_starttime);
         state = run_one_test_once(tc, test);
         runtime += MonotonicTimePoint::clock::now() - sApp->current_test_starttime;
 
         cleanup_internal(test);
 
-        if ((sApp->current_max_loop_count > 0 && MonotonicTimePoint::clock::now() < first_iteration_target && auto_fracture))
-            sApp->current_max_loop_count *= 2;
+        if ((sApp->shmem->current_max_loop_count > 0
+             && MonotonicTimePoint::clock::now() < first_iteration_target && auto_fracture))
+            sApp->shmem->current_max_loop_count *= 2;
 
         if (state > EXIT_SUCCESS) {
             // this counts as the first failure regardless of how many fractures we've run
@@ -1949,7 +1882,7 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
             goto out;
 
         // do we fracture?
-        if (sApp->current_max_loop_count <= 0 || sApp->max_test_loop_count
+        if (sApp->shmem->current_max_loop_count <= 0 || sApp->max_test_loop_count
                 || (runtime >= sApp->current_test_duration))
             goto out;
 
@@ -1961,8 +1894,9 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
     /* now we process retries */
     if (fail_count > 0) {
         // disable fracture
-        if (sApp->current_max_loop_count > 0 && sApp->current_max_loop_count != sApp->max_test_loop_count)
-            sApp->current_max_loop_count = -1;
+        if (sApp->shmem->current_max_loop_count > 0 &&
+                sApp->shmem->current_max_loop_count != sApp->max_test_loop_count)
+            sApp->shmem->current_max_loop_count = -1;
 
         auto should_retry_test = [&]() {
             // allow testing double the regular count if we've only ever
@@ -1979,7 +1913,9 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
                 --sApp->total_retest_count;
             sApp->current_iteration_count = -iterations;
             init_internal(test);
-            sApp->current_test_endtime = calculate_wallclock_deadline(sApp->current_test_duration, &sApp->current_test_starttime);
+            sApp->shmem->current_test_endtime =
+                    calculate_wallclock_deadline(sApp->current_test_duration,
+                                                 &sApp->current_test_starttime);
             state = run_one_test_once(tc, test);
             cleanup_internal(test);
 
@@ -2010,7 +1946,7 @@ static void apply_cpuset_param(char *param)
     if (cpu_info == nullptr)
         load_cpu_info(sys_cpuset);
 
-    LogicalProcessorSet &result = sApp->enabled_cpus;
+    LogicalProcessorSet &result = sApp->shmem->enabled_cpus;
     result.clear();
 
     for (char *arg = strtok(param, ","); arg; arg = strtok(nullptr, ",")) {
@@ -2145,7 +2081,7 @@ static void list_tests(int opt)
             if (include_tests) {
                 if (include_descriptions) {
                     printf("%i %-20s \"%s\"\n", ++i, test->id, test->description);
-                } else if (sApp->verbosity > 0) {
+                } else if (sApp->shmem->verbosity > 0) {
                     // don't report the FW minimum CPU features
                     uint64_t cpuf = test->compiler_minimum_cpu & ~_compilerCpuFeatures;
                     cpuf |= test->minimum_cpu;
@@ -2363,7 +2299,7 @@ static struct test *get_next_test_iteration(void)
                    std::chrono::nanoseconds(elapsed_time).count() / 1000. / 1000);
 
 
-    if (!sApp->use_strict_runtime) {
+    if (!sApp->shmem->use_strict_runtime) {
         /* do we have time for one more run? */
         MonotonicTimePoint end = sApp->endtime;
         if (end != MonotonicTimePoint::max())
@@ -2378,7 +2314,7 @@ static struct test *get_next_test_iteration(void)
 
 static struct test *get_next_test(int tc)
 {
-    if (sApp->use_strict_runtime && wallclock_deadline_has_expired(sApp->endtime))
+    if (sApp->shmem->use_strict_runtime && wallclock_deadline_has_expired(sApp->endtime))
         return nullptr;
 
     if constexpr (InterruptMonitor::InterruptMonitorWorks) {
@@ -2440,24 +2376,20 @@ static int exec_mode_run(int argc, char **argv)
     if (argc < 3)
         return EX_DATAERR;
 
-    SandstoneApplication::ExecState app_state = read_app_state(atoi(argv[2]));
-    assert(app_state.shmemfd != -1);
-    attach_shmem(app_state.shmemfd);
+    {
+        char *end;
+        long shmemfd = strtol(argv[2], &end, 10);
+        if (__builtin_expect(int(shmemfd) != shmemfd || shmemfd < 0 || *end, false))
+            return EX_DATAERR;
+        attach_shmem(shmemfd);
+    }
 
-    // reload the app state
-#define COPY_STATE_TO_SAPP(id)  \
-    sApp->id = app_state.id;
-    APP_STATE_VARIABLES(COPY_STATE_TO_SAPP)
-#undef COPY_STATE_TO_SAPP
-
-    LogicalProcessorSet enabled_cpus = {};
-    memcpy(enabled_cpus.array, app_state.cpu_mask, sizeof(LogicalProcessorSet::array));
-    sApp->thread_count = enabled_cpus.count();
+    sApp->thread_count = sApp->shmem->enabled_cpus.count();
     sApp->user_thread_data.resize(sApp->thread_count);
-    load_cpu_info(enabled_cpus);
+    load_cpu_info(sApp->shmem->enabled_cpus);
 
 #ifndef NO_SELF_TESTS
-    if (app_state.selftest && !SandstoneConfig::RestrictedCommandLine)
+    if (sApp->shmem->selftest && !SandstoneConfig::RestrictedCommandLine)
         test_set = selftests;
 #endif
 
@@ -2500,8 +2432,8 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests, const L
     }
 
     // backup the original verbosity
-    orig_verbosity = sApp->verbosity;
-    sApp->verbosity = -1;
+    orig_verbosity = sApp->shmem->verbosity;
+    sApp->shmem->verbosity = -1;
 
     for (; it != topo.packages.end(); disabled_sockets.push_back(it->id), ++it) {
         vector<Socket>::iterator eit = it;
@@ -2511,7 +2443,7 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests, const L
         for (; eit != topo.packages.end(); ++eit)
             run_cpus.add_package(*eit);
 
-        sApp->enabled_cpus = run_cpus;
+        sApp->shmem->enabled_cpus = run_cpus;
         do {
             ret = run_tests_on_cpu_set(triage_tests, run_cpus);
         } while (!ret && ++k < sApp->retest_count);
@@ -2531,7 +2463,7 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests, const L
         int k = 0;
 
         run_cpus.add_package(topo.packages.at(0));
-        sApp->enabled_cpus = run_cpus;
+        sApp->shmem->enabled_cpus = run_cpus;
 
         do {
             ret = run_tests_on_cpu_set(triage_tests, run_cpus);
@@ -2543,7 +2475,7 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests, const L
     }
 
     // restore the original verbosity
-    sApp->verbosity = orig_verbosity;
+    sApp->shmem->verbosity = orig_verbosity;
 
     return result;
 }
@@ -3040,7 +2972,6 @@ int main(int argc, char **argv)
     thread_num = -1;            /* indicate main thread */
     find_thyself(argv[0]);
     setup_stack_size(argc, argv);
-    sApp->enabled_cpus = init_cpus();
 #ifdef __linux__
     prctl(PR_SET_TIMERSLACK, 1, 0, 0, 0);
 #endif
@@ -3055,6 +2986,7 @@ int main(int argc, char **argv)
     }
 
     init_shmem();
+    sApp->shmem->enabled_cpus = init_cpus();
     while (!SandstoneConfig::RestrictedCommandLine &&
            (opt = simple_getopt(argc, argv, long_options)) != -1) {
         switch (opt) {
@@ -3106,7 +3038,7 @@ int main(int argc, char **argv)
             sApp->file_log_path = optarg;
             break;
         case 'O':
-            sApp->log_test_knobs = true;
+            sApp->shmem->log_test_knobs = true;
             if ( ! set_knob_from_key_value_string(optarg)){
                 fprintf(stderr, "Malformed test knob: %s (should be in the form KNOB=VALUE)\n", optarg);
                 return EX_USAGE;
@@ -3114,7 +3046,7 @@ int main(int argc, char **argv)
             break;
 
         case 'q':
-            sApp->verbosity = 0;
+            sApp->shmem->verbosity = 0;
             break;
         case 's':
             seed = optarg;
@@ -3133,15 +3065,15 @@ int main(int argc, char **argv)
             }
             break;
         case 'v':
-            if (sApp->verbosity < 0)
-                sApp->verbosity = 1;
+            if (sApp->shmem->verbosity < 0)
+                sApp->shmem->verbosity = 1;
             else
-                ++sApp->verbosity;
+                ++sApp->shmem->verbosity;
             break;
         case 'Y':
-            sApp->output_format = SandstoneApplication::OutputFormat::yaml;
+            sApp->shmem->output_format = SandstoneApplication::OutputFormat::yaml;
             if (optarg)
-                sApp->output_yaml_indent = ParseIntArgument<>{
+                sApp->shmem->output_yaml_indent = ParseIntArgument<>{
                         .name = "-Y / --yaml",
                         .max = 160,     // arbitrary
                 }();
@@ -3150,7 +3082,7 @@ int main(int argc, char **argv)
             apply_cpuset_param(optarg);
             break;
         case dump_cpu_info_option:
-            dump_cpu_info(sApp->enabled_cpus);
+            dump_cpu_info(sApp->shmem->enabled_cpus);
             return EXIT_SUCCESS;
         case fatal_skips_option:
             sApp->fatal_skips = true;
@@ -3186,15 +3118,15 @@ int main(int argc, char **argv)
             break;
         case output_format_option:
             if (strcmp(optarg, "key-value") == 0) {
-                sApp->output_format = SandstoneApplication::OutputFormat::key_value;
+                sApp->shmem->output_format = SandstoneApplication::OutputFormat::key_value;
             } else if (strcmp(optarg, "tap") == 0) {
-                sApp->output_format = SandstoneApplication::OutputFormat::tap;
+                sApp->shmem->output_format = SandstoneApplication::OutputFormat::tap;
             } else if (strcmp(optarg, "yaml") == 0) {
-                sApp->output_format = SandstoneApplication::OutputFormat::yaml;
+                sApp->shmem->output_format = SandstoneApplication::OutputFormat::yaml;
             } else if (SandstoneConfig::Debug && strcmp(optarg, "none") == 0) {
                 // for testing only
-                sApp->output_format = SandstoneApplication::OutputFormat::no_output;
-                sApp->verbosity = -1;
+                sApp->shmem->output_format = SandstoneApplication::OutputFormat::no_output;
+                sApp->shmem->verbosity = -1;
             } else {
                 fprintf(stderr, "%s: unknown output format: %s\n", argv[0], optarg);
                 return EX_USAGE;
@@ -3224,7 +3156,7 @@ int main(int argc, char **argv)
             weighted_testrunner_runtimes = ShortenedTestrunTimes;
             break;
         case strict_runtime_option:
-            sApp->use_strict_runtime = true;
+            sApp->shmem->use_strict_runtime = true;
             break;
         case syslog_runtime_option:
             sApp->syslog_ident = program_invocation_name;
@@ -3236,6 +3168,7 @@ int main(int argc, char **argv)
                 return EX_USAGE;
             }
             sApp->requested_quality = 0;
+            sApp->shmem->selftest = true;
             test_set = selftests;
             break;
 #endif
@@ -3246,7 +3179,7 @@ int main(int argc, char **argv)
             sApp->service_background_scan = true;
             break;
         case ud_on_failure_option:
-            sApp->ud_on_failure = true;
+            sApp->shmem->ud_on_failure = true;
             break;
         case use_builtin_test_list_option:
             if (!SandstoneConfig::HasBuiltinTestList) {
@@ -3325,25 +3258,25 @@ int main(int argc, char **argv)
             break;
 
         case max_logdata_option: {
-            sApp->max_logdata_per_thread = ParseIntArgument<unsigned>{
+            sApp->shmem->max_logdata_per_thread = ParseIntArgument<unsigned>{
                     .name = "--max-log-data",
                     .explanation = "maximum number of bytes of test's data to log per thread (0 is unlimited))",
                     .base = 0,      // accept hex
                     .range_mode = OutOfRangeMode::Saturate
             }();
-            if (sApp->max_logdata_per_thread == 0)
-                sApp->max_logdata_per_thread = UINT_MAX;
+            if (sApp->shmem->max_logdata_per_thread == 0)
+                sApp->shmem->max_logdata_per_thread = UINT_MAX;
             break;
         }
         case max_messages_option:
-            sApp->max_messages_per_thread = ParseIntArgument<>{
+            sApp->shmem->max_messages_per_thread = ParseIntArgument<>{
                     .name = "--max-messages",
                     .explanation = "maximum number of messages (per thread) to log in each test (0 is unlimited)",
                     .min = -1,
                     .range_mode = OutOfRangeMode::Saturate
             }();
-            if (sApp->max_messages_per_thread <= 0)
-                sApp->max_messages_per_thread = INT_MAX;
+            if (sApp->shmem->max_messages_per_thread <= 0)
+                sApp->shmem->max_messages_per_thread = INT_MAX;
             break;
         case schedule_by_option:
             if (strcmp(optarg, "thread") == 0) {
@@ -3362,25 +3295,25 @@ int main(int argc, char **argv)
         case one_sec_option:
             test_list_randomize = true;
             test_selection_strategy = Repeating;
-            sApp->use_strict_runtime = true;
+            sApp->shmem->use_strict_runtime = true;
             sApp->endtime = calculate_wallclock_deadline(1s, &sApp->starttime);
             break;
         case thirty_sec_option:
             test_list_randomize = true;
             test_selection_strategy = Repeating;
-            sApp->use_strict_runtime = true;
+            sApp->shmem->use_strict_runtime = true;
             sApp->endtime = calculate_wallclock_deadline(30s, &sApp->starttime);
             break;
         case two_min_option:
             test_list_randomize = true;
             test_selection_strategy = Repeating;
-            sApp->use_strict_runtime = true;
+            sApp->shmem->use_strict_runtime = true;
             sApp->endtime = calculate_wallclock_deadline(2min, &sApp->starttime);
             break;
         case five_min_option:
             test_list_randomize = true;
             test_selection_strategy = Repeating;
-            sApp->use_strict_runtime = true;
+            sApp->shmem->use_strict_runtime = true;
             sApp->endtime = calculate_wallclock_deadline(5min, &sApp->starttime);
             break;
 
@@ -3452,9 +3385,9 @@ int main(int argc, char **argv)
         }
 
         if (SandstoneConfig::NoLogging) {
-            sApp->output_format = SandstoneApplication::OutputFormat::no_output;
+            sApp->shmem->output_format = SandstoneApplication::OutputFormat::no_output;
         } else  {
-            sApp->verbosity = 1;
+            sApp->shmem->verbosity = 1;
         }
 
         sApp->delay_between_tests = 50ms;
@@ -3478,9 +3411,9 @@ int main(int argc, char **argv)
 
     if (unsigned(thread_count) < unsigned(sApp->thread_count)) {
         sApp->thread_count = thread_count;
-        sApp->enabled_cpus.limit_to(thread_count);
+        sApp->shmem->enabled_cpus.limit_to(thread_count);
     }
-    load_cpu_info(sApp->enabled_cpus);
+    load_cpu_info(sApp->shmem->enabled_cpus);
     commit_shmem();
 
     signals_init_global();
@@ -3494,8 +3427,8 @@ int main(int argc, char **argv)
     random_init_global(seed);
     background_scan_init();
 
-    if (sApp->verbosity == -1)
-        sApp->verbosity = (sApp->requested_quality < SandstoneApplication::DefaultQualityLevel) ? 1 : 0;
+    if (sApp->shmem->verbosity == -1)
+        sApp->shmem->verbosity = (sApp->requested_quality < SandstoneApplication::DefaultQualityLevel) ? 1 : 0;
 
     if (InterruptMonitor::InterruptMonitorWorks) {
         sApp->last_thermal_event_count = sApp->count_thermal_events();
@@ -3643,11 +3576,11 @@ int main(int argc, char **argv)
 
     if (total_failures) {
         if (!do_not_triage) {
-            vector<int> sockets = run_triage(triage_tests, sApp->enabled_cpus);
+            vector<int> sockets = run_triage(triage_tests, sApp->shmem->enabled_cpus);
             logging_print_triage_results(sockets);
         }
         logging_print_footer();
-    } else if (sApp->verbosity == 0 && sApp->output_format == SandstoneApplication::OutputFormat::tap) {
+    } else if (sApp->shmem->verbosity == 0 && sApp->shmem->output_format == SandstoneApplication::OutputFormat::tap) {
         logging_printf(LOG_LEVEL_QUIET, "Ran %d tests without error (%d skipped)\n",
                        total_successes, total_tests_run - total_successes);
     }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -914,18 +914,16 @@ static LogicalProcessorSet init_cpus()
     return result;
 }
 
-static void init_shmem(int fd = -1)
+static void init_shmem()
 {
     static_assert(sizeof(PerThreadData::Main) == 64,
             "PerThreadData::Main size grew, please check if it was intended");
     static_assert(sizeof(PerThreadData::Test) == 64,
             "PerThreadData::Testsize grew, please check if it was intended");
+    assert(sApp->current_fork_mode() != SandstoneApplication::child_exec_each_test);
 
     if (sApp->shmem)
         return;                 // already initialized
-
-    // a file descriptor is only allowed in the child side of -fexec
-    assert(fd == -1 || sApp->current_fork_mode() == SandstoneApplication::child_exec_each_test);
 
     int size = ROUND_UP_TO_PAGE(sizeof(SandstoneApplication::SharedMemory));
     switch (sApp->current_fork_mode()) {
@@ -939,7 +937,8 @@ static void init_shmem(int fd = -1)
         break;
 
     case SandstoneApplication::child_exec_each_test:
-        // we must have inherited a file descriptor
+        assert(false && "impossible condition");
+        __builtin_unreachable();
         break;
 
     case SandstoneApplication::no_fork:
@@ -963,13 +962,23 @@ static void init_shmem(int fd = -1)
         exit(EX_CANTCREAT);
     }
 
-    if (fd != -1 && sApp->current_fork_mode() == SandstoneApplication::child_exec_each_test) {
-        close(fd);
-        sApp->shmem = static_cast<SandstoneApplication::SharedMemory *>(base);
-    } else {
-        sApp->shmemfd = fd;
-        sApp->shmem = new (base) SandstoneApplication::SharedMemory;
+    sApp->shmemfd = fd;
+    sApp->shmem = new (base) SandstoneApplication::SharedMemory;
+}
+
+static void attach_shmem(int fd)
+{
+    assert(sApp->current_fork_mode() == SandstoneApplication::child_exec_each_test);
+
+    int size = ROUND_UP_TO_PAGE(sizeof(SandstoneApplication::SharedMemory));
+    void *base = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (base == MAP_FAILED) {
+        perror("internal error: could not map the shared memory file to memory");
+        exit(EX_IOERR);
     }
+
+    close(fd);
+    sApp->shmem = static_cast<SandstoneApplication::SharedMemory *>(base);
 
     // barrier with the parent process
     sApp->shmem->main_thread_data.thread_state.exchange(thread_not_started, std::memory_order_acquire);
@@ -2449,7 +2458,7 @@ static int exec_mode_run(int argc, char **argv)
 
     SandstoneApplication::ExecState app_state = read_app_state(atoi(argv[2]));
     assert(app_state.shmemfd != -1);
-    init_shmem(app_state.shmemfd);
+    attach_shmem(app_state.shmemfd);
 
     // reload the app state
 #define COPY_STATE_TO_SAPP(id)  \

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -346,9 +346,9 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     SharedMemory *shmem = nullptr;
     int shmemfd = -1;
 
+    int requested_quality = DefaultQualityLevel;
     std::string file_log_path;
     static constexpr int DefaultQualityLevel = 50;
-    int requested_quality = DefaultQualityLevel;
     const char *syslog_ident = nullptr;
 
     bool fatal_skips = false;
@@ -431,20 +431,25 @@ private:
 
 struct SandstoneApplication::SharedMemory
 {
+    // state shared with child processes (input only)
+    // test execution
+    MonotonicTimePoint current_test_endtime = {};
+    int current_max_loop_count = 0;
+    bool selftest = false;
+    bool ud_on_failure = false;
+    bool use_strict_runtime = false;
+
+    // logging parameters
     int verbosity = -1;
     int max_messages_per_thread = 5;
     unsigned max_logdata_per_thread = 128;
     OutputFormat output_format = DefaultOutputFormat;
     uint8_t output_yaml_indent = 0;
     bool log_test_knobs = false;
-    bool ud_on_failure = false;
-    bool use_strict_runtime = false;
-    bool selftest = false;
-    int current_max_loop_count = 0;
-    MonotonicTimePoint current_test_endtime = {};
 
     LogicalProcessorSet enabled_cpus;
 
+    // in/out per-thread data
     PerThreadData::Main main_thread_data;
     PerThreadData::Test per_thread[MAX_THREADS];
 };

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -186,7 +186,7 @@ struct Common
     std::atomic<int> messages_logged;
 
     /* Records the number of bytes log_data'ed per thread */
-    std::atomic<size_t> data_bytes_logged;
+    std::atomic<unsigned> data_bytes_logged;
 
     MonotonicTimePoint fail_time;
     bool has_failed() const


### PR DESCRIPTION
This is a massive search-and-replace change with no actual behaviour difference for most of the application. The only actual changes are in the `spawn_child()` and `exec_mode_run()` functions, which must now communicate to each other the file descriptor to the shared memory segment instead of that temporary state file.

This makes the shared memory segment both input and output to the child process.
