### PR TITLE
FW/Topology: build topology early, in load_cpu_info()

### DIFF
--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -859,7 +859,7 @@ static Topology build_topology()
     return Topology(packages);
 }
 
-Topology Topology::topology()
+const Topology &Topology::topology()
 {
     static int cached_topo_gen = -1;
     static Topology cached_topology = Topology({});

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -878,7 +878,7 @@ static char character_for_mask(uint32_t mask)
     return mask < 0xa ? '0' + mask : 'a' + mask - 0xa;
 }
 
-std::string Topology::build_falure_mask(const struct test *test)
+std::string Topology::build_falure_mask(const struct test *test) const
 {
     std::string result;
     if (!isValid())
@@ -907,7 +907,7 @@ std::string Topology::build_falure_mask(const struct test *test)
             uint32_t threadmask = 0;
             int threadcount = 0;
             int failcount = 0;
-            for (Thread &t : core.threads) {
+            for (const Thread &t : core.threads) {
                 int cpu_id = t.cpu;
                 if (cpu_id < 0)
                     continue;

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -858,7 +858,7 @@ static Topology build_topology()
     if (!valid_topology)
         packages.clear();
 
-    return Topology(packages);
+    return Topology(std::move(packages));
 }
 
 const Topology &Topology::topology()

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -53,7 +53,7 @@ public:
     bool isValid() const        { return !packages.empty(); }
     std::string build_falure_mask(const struct test *test) const;
 
-    static Topology topology();
+    static const Topology &topology();
 };
 
 enum class LogicalProcessor : int {};

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -51,7 +51,7 @@ public:
     }
 
     bool isValid() const        { return !packages.empty(); }
-    std::string build_falure_mask(const struct test *test);
+    std::string build_falure_mask(const struct test *test) const;
 
     static Topology topology();
 };


### PR DESCRIPTION
This removes the need to keep a generation counter.
