### PR TITLE
FW: make TestResult an enum class and sort according to severity

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -119,15 +119,15 @@ struct RandomEngineWrapper;
 struct RandomEngineDeleter { void operator()(RandomEngineWrapper *) const; };
 
 enum TestResult : int8_t {
-    TestPassed = EXIT_SUCCESS,
-    TestFailed = EXIT_FAILURE,
-    TestTimedOut,
-    TestCoreDumped,
-    TestKilled,
-    TestOutOfMemory,
-    TestInterrupted,
-    TestOperatingSystemError,
-    TestSkipped = -1,
+    Passed = EXIT_SUCCESS,
+    Failed = EXIT_FAILURE,
+    TimedOut,
+    CoreDumped,
+    Killed,
+    OutOfMemory,
+    Interrupted,
+    OperatingSystemError,
+    Skipped = -1,
 };
 
 enum ThreadState : int {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -118,16 +118,16 @@ int open_memfd(enum MemfdCloexecFlag);
 struct RandomEngineWrapper;
 struct RandomEngineDeleter { void operator()(RandomEngineWrapper *) const; };
 
-enum TestResult : int8_t {
-    Passed = EXIT_SUCCESS,
-    Failed = EXIT_FAILURE,
-    TimedOut,
-    CoreDumped,
-    Killed,
-    OutOfMemory,
-    Interrupted,
-    OperatingSystemError,
+enum class TestResult : int8_t {
     Skipped = -1,
+    Passed,
+    Failed,
+    Killed,
+    CoreDumped,
+    OperatingSystemError,
+    OutOfMemory,
+    TimedOut,
+    Interrupted,
 };
 
 enum ThreadState : int {


### PR DESCRIPTION
The enum was only used in the C++ side, so I changed it to an `enum class` to ensure there wasn't an accidental cast to/from integers (which there was). Therefore, I introduced an explicit mapping between those, avoiding unnecessarily clever math. Good compilers are perfectly capable of noticing when your switch labels make no transformation or identical ones for some case labels (see [1]).

Then I re-ordered the entries by severity, with the most severe ones having higher values. When we have multiple child processes, the test's condition will be the one with highest severity:
* anything beats a Skip
* any failure beats a Pass
* any crash causes the failed test to be reported as a crash
* core dumps deserve more attention than crashes that don't dump core
* OOM and OS error conditions mean the tool cannot proceed at all
* timeouts beat even OS problems
* interruptions are because the user pressed Ctrl+C


[1] https://gcc.godbolt.org/z/cr9M1xeM9

Note: TimedOut cannot have value 3, because of the Windows runtimes' `abort()` function behaviour. This is enforced by the switch in `test_result_from_exit_code()`.
