### PR TITLE
FW/Topology: improve sorting algorithm by sorting the fields

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -324,9 +324,9 @@ struct cpu_info {
     uint64_t ppin;          ///! Processor ID read from MSR
     uint64_t microcode;     ///! Microcode version read from /sys
     int cpu_number;         ///! Logical processor number as seen by OS
-    int package_id;         ///! Topology info from APIC
-    int core_id;            ///! Topology info from APIC
     int thread_id;          ///! Topology info from APIC
+    int core_id;            ///! Topology info from APIC
+    int package_id;         ///! Topology info from APIC
     struct cache_info cache[3]; ///! Cache info from OS
     uint8_t family;         ///! CPU family (usually 6)
     uint8_t stepping;       ///! CPU stepping

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -153,13 +153,16 @@ static linux_cpu_info &proc_cpuinfo()
 
 static void reorder_cpus()
 {
-    static auto cpu_tie = [](const struct cpu_info &cpu) {
-        return std::tie(cpu.package_id, cpu.core_id, cpu.thread_id,
-                        // in case this is a VM with no topology information
-                        cpu.cpu_number);
+    static auto cpu_tuple = [](const struct cpu_info &c) {
+        uint64_t h = (uint64_t(c.package_id) << 32) +
+                unsigned(c.core_id);
+        uint64_t l = ((uint64_t(c.thread_id)) << 32) +
+                unsigned(c.cpu_number);
+        return std::make_tuple(h, l);
     };
+
     auto cpu_compare = [](const struct cpu_info &cpu1, const struct cpu_info &cpu2) {
-        return cpu_tie(cpu1) < cpu_tie(cpu2);
+        return cpu_tuple(cpu1) < cpu_tuple(cpu2);
     };
     std::sort(cpu_info, cpu_info + num_cpus(), cpu_compare);
 }


### PR DESCRIPTION
This is optimised for little-endian CPUs: place the least-significant fields first. This way, the compiler could treat these four 32-bit fields as a single 128-bit integer, provided they were all unsigned. Since they aren't, we help it by making it so.

That means we sort -1 last instead of first, but hopefully there isn't a VM that provides this bad topology data (the tool won't be very effective inside it anyway!).

With GCC, we now generate for the comparison:
```asm
        movq    24(%rsi), %rdx
        movq    24(%rdi), %rcx
        cmpq    %rdx, %rcx
        setb    %al
        je      .L5
        ret
.L5:
        movq    16(%rsi), %rdx
        movq    16(%rdi), %rcx
        cmpq    %rdx, %rcx
        setb    %al
        setne   %dl
        andl    %edx, %eax
        ret
```

Similar for Clang, only without a branch:
```asm
        movq    16(%rdi), %rax
        movq    24(%rdi), %rcx
        xorl    %edx, %edx
        cmpq    16(%rsi), %rax
        setb    %dl
        xorl    %eax, %eax
        cmpq    24(%rsi), %rcx
        setb    %al
        cmovel  %edx, %eax
        retq
```

Which are close enough to the ideal 128-bit comparison:
```asm
        movq    16(%rsi), %rdx
        movq    24(%rdi), %rax
        cmpq    %rdx, 16(%rdi)
        sbbq    24(%rsi), %rax
        setc    %al
        ret
```

To get there, we could do:
```c++
        return (uint128(h) << 64) | l;
```
but meh.