### PR TITLE
FW/child_debug: fix --on-crash=context without gdb

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -951,6 +951,14 @@ selftest_crash_context_common() {
 @test "crash context" {
     declare -A yamldump
     selftest_crash_context_common --on-crash=context
+
+    # Ensure we can use this option even if gdb isn't found
+    # (can't use run_sandstone_yaml here because we empty $PATH)
+    (
+        PATH=
+        run $SANDSTONE -Y --selftests -e selftest_sigsegv --retest-on-failure=0 --on-crash=context -o - >/dev/null
+        [[ $status -eq 1 ]]     # instead of 64 (EX_USAGE)
+    )
 }
 
 @test "crash backtrace" {


### PR DESCRIPTION
This option was introduced so we could get a crash context without gdb, but we still printed:
```
--on-crash=context requires gdb but we couldn't find it.
```

I developed this functionality in the socket-separation branch, probably after commit 704f1415097aacb73d33b74f56b6f4ea74084e1d which changed the enum. So this commit backports that change too.