### PR TITLE
Revert "FW: fix current_fork_mode() for Windows under RestrictedCommandLine"

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -366,13 +366,11 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
 
     ForkMode current_fork_mode() const
     {
+#ifndef _WIN32
         if (SandstoneConfig::RestrictedCommandLine) {
-#ifdef _WIN32
-            return SandstoneApplication::exec_each_test;
-#else
             return SandstoneApplication::fork_each_test;
-#endif
         }
+#endif
         return fork_mode;
     }
 


### PR DESCRIPTION


This reverts commit d31aafaf04b11a30777df2c371e30daa827cbef1. That was wrong because the exec-mode runs have two states: parent and child.