### PR TITLE
FW: replace MAX_THREADS with a VLA in run_threads_in_parallel()

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1206,7 +1206,7 @@ static void restart_init(int iterations)
 
 static void run_threads_in_parallel(const struct test *test, const pthread_attr_t *thread_attr)
 {
-    pthread_t pt[MAX_THREADS];
+    pthread_t pt[num_cpus()];       // NOLINT: -Wvla
     int i;
 
     for (i = 0; i < num_cpus(); i++) {


### PR DESCRIPTION
By using a variable-length array, we can avoid the fixed-size one. One more `MAX_THREADS` bites the dust.