### PR TITLE
FW/child_debug: stop using ATOMIC_FLAG_INIT in C++

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -203,7 +203,7 @@ static void child_crash_handler(int, siginfo_t *si, void *ucontext)
     if (crashpipe[CrashPipeChild] == -1)
         return;
 
-    static std::atomic_flag in_crash_handler = ATOMIC_FLAG_INIT;
+    static std::atomic_flag in_crash_handler = {};
     if (!in_crash_handler.test_and_set()) {
         // let parent process know
         CrashContext::send(crashpipe[CrashPipeChild], si, ucontext);


### PR DESCRIPTION
We still use ATOMIC_VAR_INIT in C (tmpfile.c, forkfd.c), but in C++ it's deprecated. Found by Clang/libc++:

```
child_debug.cpp:207:48: warning: macro 'ATOMIC_FLAG_INIT' has been marked as deprecated [-Wdeprecated-pragma]
```