### PR TITLE
CI/bats: make bats run with non-Linux systems

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -108,9 +108,8 @@ test_yaml_regexp() {
 }
 
 @test "TAP silent output" {
-    opts="--output-format=tap --quick --selftests --quiet --disable=mce_check -e @positive -o $BATS_TEST_TMPDIR/fulloutput.tap"
-    $SANDSTONE $opts > $BATS_TEST_TMPDIR/output.tap || \
-        cat $BATS_TEST_TMPDIR/fulloutput.tap
+    opts="--output-format=tap --quick --selftests --quiet --disable=mce_check -e @positive"
+    $SANDSTONE $opts > $BATS_TEST_TMPDIR/output.tap
 
     sed -i -e 's/\r$//' $BATS_TEST_TMPDIR/output.tap
     {
@@ -132,9 +131,8 @@ test_yaml_regexp() {
 }
 
 @test "YAML silent output" {
-    opts="-Y --quick --selftests --quiet --disable=mce_check -e @positive -o $BATS_TEST_TMPDIR/fulloutput.tap"
-    $SANDSTONE $opts > $BATS_TEST_TMPDIR/output.yaml || \
-        cat $BATS_TEST_TMPDIR/fulloutput.yaml
+    opts="-Y --quick --selftests --quiet --disable=mce_check -e @positive"
+    $SANDSTONE $opts > $BATS_TEST_TMPDIR/output.yaml
 
     sed -i -e 's/\r$//' $BATS_TEST_TMPDIR/output.yaml
     {

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -60,8 +60,8 @@ test_yaml_numeric() {
 test_yaml_regexp() {
     local value
     extract_from_yaml "$1"
-    if printf "%s" "$value" | grep --line-regexp -Pq -e "$2"; then
-        return 0;
+    if python3 -c "rx = r'''$2'''" -c 'import re,sys;exit(re.fullmatch(rx, sys.argv[2], re.S) is None)'; then
+        return 0
     fi
     printf "Regexp match failed:\n"
     printf "query:      %s\n" "$1"

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -822,10 +822,16 @@ selftest_crash_common() {
     fi
 
     local test=$1
+    local code=$2
+    local reason=$3
     if $is_windows; then
-        shift 2
+        code=$4
+        reason=$5
+    else
+        # transform symbolic name to code
+        code=$(kill -l $code)
     fi
-    if [[ "$2" == "" ]]; then
+    if [[ "$code" == "" ]]; then
         skip "Test skipped on this platform"
     fi
 
@@ -835,44 +841,44 @@ selftest_crash_common() {
     test_yaml_regexp "/tests/0/result" "crash"
     test_yaml_regexp "/tests/0/result-details/crashed" True
     test_yaml_regexp "/tests/0/result-details/core-dump" '(True|False)'
-    test_yaml_numeric "/tests/0/result-details/code" 'value > 0 && value == '$2
-    test_yaml_regexp "/tests/0/result-details/reason" "$3"
+    test_yaml_numeric "/tests/0/result-details/code" 'value > 0 && value == '$code
+    test_yaml_regexp "/tests/0/result-details/reason" "$reason"
 }
 
 @test "selftest_abortinit" {
-    selftest_crash_common selftest_abortinit 6 "Aborted" 0xC0000602 "Aborted"
+    selftest_crash_common selftest_abortinit SIGABRT "Aborted" 0xC0000602 "Aborted"
 }
 
 @test "selftest_abort" {
-    selftest_crash_common selftest_abort 6 "Aborted" 0xC0000602 "Aborted"
+    selftest_crash_common selftest_abort SIGABRT "Aborted" 0xC0000602 "Aborted"
 }
 
 @test "selftest_sigill" {
-    selftest_crash_common selftest_sigill 4 "Illegal instruction" 0xC000001D "Illegal instruction"
+    selftest_crash_common selftest_sigill SIGILL "Illegal instruction" 0xC000001D "Illegal instruction"
 }
 
 @test "selftest_sigfpe" {
-    selftest_crash_common selftest_sigfpe 8 "Floating point exception" 0xC0000094 'Integer division by zero'
+    selftest_crash_common selftest_sigfpe SIGFPE "Floating point exception" 0xC0000094 'Integer division by zero'
 }
 
 @test "selftest_sigbus" {
-    selftest_crash_common selftest_sigbus 7 "Bus error"
+    selftest_crash_common selftest_sigbus SIGBUS "Bus error"
 }
 
 @test "selftest_sigsegv_init" {
-    selftest_crash_common selftest_sigsegv 11 "Segmentation fault" 0xC0000005 'Access violation'
+    selftest_crash_common selftest_sigsegv SIGSEGV "Segmentation fault" 0xC0000005 'Access violation'
 }
 
 @test "selftest_sigsegv" {
-    selftest_crash_common selftest_sigsegv 11 "Segmentation fault" 0xC0000005 'Access violation'
+    selftest_crash_common selftest_sigsegv SIGSEGV "Segmentation fault" 0xC0000005 'Access violation'
 }
 
 @test "selftest_sigsegv_cleanup" {
-    selftest_crash_common selftest_sigsegv 11 "Segmentation fault" 0xC0000005 'Access violation'
+    selftest_crash_common selftest_sigsegv SIGSEGV "Segmentation fault" 0xC0000005 'Access violation'
 }
 
 @test "selftest_sigsegv_instruction" {
-    selftest_crash_common selftest_sigsegv_instruction 11 "Segmentation fault" 0xC0000005 'Access violation'
+    selftest_crash_common selftest_sigsegv_instruction SIGSEGV "Segmentation fault" 0xC0000005 'Access violation'
 }
 
 @test "selftest_fastfail" {
@@ -912,7 +918,7 @@ selftest_crash_common() {
 
 @test "selftest_malloc_fail" {
     declare -A yamldump
-    selftest_crash_common selftest_malloc_fail 6 "Aborted" 0xC0000017 "Out of memory condition"
+    selftest_crash_common selftest_malloc_fail SIGABRT "Aborted" 0xC0000017 "Out of memory condition"
     test_yaml_regexp "/tests/0/stderr messages" 'Out of memory condition'
 }
 

--- a/bats/testenv.bash
+++ b/bats/testenv.bash
@@ -18,7 +18,7 @@ if [[ -z "$SANDSTONE" ]]; then
     SANDSTONE=$SANDSTONE_BIN
     if [[ `file $SANDSTONE_BIN` = *ELF* ]]; then
         current=`uname -m`
-        target=`eu-readelf -h $SANDSTONE_BIN | sed -n '/Machine:/{s/.* //;y/-/_/;p;q}'`
+        target=`eu-readelf -h $SANDSTONE_BIN | sed -n '/Machine:/{s/.* //;y/-/_/;p;q;}'`
         if [[ "${current,,}" != "${target,,}" ]]; then
             SANDSTONE="qemu-${target,,} $SANDSTONE"
         fi

--- a/bats/testenv.bash
+++ b/bats/testenv.bash
@@ -26,10 +26,12 @@ if [[ -z "$SANDSTONE" ]]; then
         unset current target
     fi
 fi
-if [[ "$SANDSTONE_BIN" = *.exe ]] && [[ `uname -s` = Linux ]]; then
-    SANDSTONE="wine $SANDSTONE"
+if [[ "$SANDSTONE_BIN" = *.exe ]]; then
     export is_windows=true
-    export WINEDEBUG=-all
+    if [[ `uname -s` = Linux ]]; then
+        SANDSTONE="wine $SANDSTONE"
+        export WINEDEBUG=-all
+    fi
 fi
 SANDSTONE="$SANDSTONE --on-crash=core --on-hang=kill"
 

--- a/bats/testenv.bash
+++ b/bats/testenv.bash
@@ -18,6 +18,7 @@ if [[ -z "$SANDSTONE" ]]; then
     SANDSTONE=$SANDSTONE_BIN
     if [[ `file $SANDSTONE_BIN` = *ELF* ]]; then
         current=`uname -m`
+        [[ "$current" != "amd64" ]] || current=x86_64
         target=`eu-readelf -h $SANDSTONE_BIN | sed -n '/Machine:/{s/.* //;y/-/_/;p;q;}'`
         if [[ "${current,,}" != "${target,,}" ]]; then
             SANDSTONE="qemu-${target,,} $SANDSTONE"


### PR DESCRIPTION
There were a number of dependencies on GNUisms, like:
* missing `;` inside a sed sub-expression
* GNU grep's `--perl-regexp` support (replaced grep with Python instead, which we require anyway)

Plus fixed a mismatch between what FreeBSD's `uname -m` reports compared to elfutils' `eu-readelf`, and stopped hardcoding signal numbers (FreeBSD's `SIGBUS` is 10 on x86-64, not 7, like Linux on SPARC, MIPS, Alpha and PA-RISC).

And when running on Windows, do set `is_windows=true`.