### PR TITLE
Meson: force -Og on Windows on debug builds

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,6 +33,11 @@ if target_machine.cpu_family() != 'x86_64'
     # warning was left behind
     tests_common_cpp_args += '-Wno-deprecated-copy'
 endif
+if target_machine.system() == 'windows' and get_option('buildtype') == 'debug'
+    # Force a little bit of optimization, otherwise we get:
+    # Fatal error: tests/libtests_base.a.p/eigen_svd_svd_cdouble_noavx512.cpp.obj: file too big
+    tests_common_cpp_args += '-Og'
+endif
 
 tests_set_base.add(
     files(


### PR DESCRIPTION
Looks like our Eigen SVD cdouble builds are so big that they are too big for the PE COFF file format, even with `-Wa,-mbig-obj`.

```
as.exe: tests/libtests_base.a.p/eigen_svd_svd_cdouble_noavx512.cpp.obj: section .pdata$_ZN5Eigen8internal31generic_dense_assignment_kernelINS0_9evaluatorINS_6MatrixISt7complexIdELin1ELin1ELi0ELin1ELin1EEEEENS2_INS_9TransposeIKNS8_IKNS_5BlockINS_12CwiseUnaryOpINS0_19scalar_conjugate_opIS5_EEKS6_EELin1ELin1ELb0EEEEEEEEENS0_9assign_opIS5_S5_EELi0EE11assignCoeffExx: string table overflow at offset 10000017
C:\msys\tmp\ccT4M7r1.s: Assembler messages:
C:\msys\tmp\ccT4M7r1.s: Fatal error: tests/libtests_base.a.p/eigen_svd_svd_cdouble_noavx512.cpp.obj: file too big
```