### PR TITLE
FW/Win32: use spawnvp to find gdbserver

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1858,7 +1858,7 @@ static int spawn_child(const struct test *test, intptr_t *hpid, int shmempipefd)
 
     if (sApp->gdb_server_comm.size()) {
         // launch gdbserver instead
-        _spawnv(_P_NOWAIT, gdbserverargs[0], const_cast<char **>(gdbserverargs));
+        _spawnvp(_P_NOWAIT, gdbserverargs[0], const_cast<char **>(gdbserverargs));
     }
 
     *hpid = _spawnv(_P_NOWAIT, path_to_exe(), argv);


### PR DESCRIPTION
We don't pass the full path to it, so we need the "p" version to do a PATH search for us.