### PR TITLE
FW: remove duration_is_forever()

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -622,13 +622,7 @@ static MonotonicTimePoint calculate_wallclock_deadline(Duration duration, Monoto
     if (pnow)
         *pnow = later;
 
-    if (duration_is_forever(duration)) {
-        later = MonotonicTimePoint::max();
-    } else if (duration > duration.zero()) {
-        later += duration;
-    }
-
-    return later;
+    return later + duration;
 }
 
 static bool wallclock_deadline_has_expired(MonotonicTimePoint deadline)


### PR DESCRIPTION
Now `calculate_wallclock_deadline()` is only used in two places relating to test times and tests cannot run forever. I don't think this code was in use.