### PR TITLE
FW: error out early if -O is given while in -fexec mode

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -449,8 +449,9 @@ selftest_pass() {
 }
 
 @test "selftest_logs_options" {
-    if $is_windows; then
-       skip "BROKEN on Windows / -fexec mode"
+    run $SANDSTONE -n1 --selftests -e selftest_logs_options -O dummy=dummy
+    if [[ $status == 64 ]]; then
+       skip "Not supported"
     fi
     declare -A yamldump
     sandstone_selftest -vvv -e selftest_logs_options

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3673,6 +3673,11 @@ int main(int argc, char **argv)
         usage(argv);
         return EX_USAGE;
     }
+    if (sApp->log_test_knobs && sApp->current_fork_mode() == SandstoneApplication::exec_each_test) {
+        fprintf(stderr, "%s: error: --test-option is not supported in this configuration\n",
+                program_invocation_name);
+        return EX_USAGE;
+    }
 
     if (sApp->total_retest_count < -1 || sApp->retest_count == 0)
         sApp->total_retest_count = 10 * sApp->retest_count; // by default, 100


### PR DESCRIPTION
We were silently accepting the option and not acting on it.