### PR TITLE
CI/Bats: fix selftest_logdata test on Linux with -fexec

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -437,11 +437,11 @@ selftest_pass() {
 
 @test "selftest_logdata" {
     declare -A yamldump
-    sandstone_selftest -vvv -e selftest_logdata
+    sandstone_selftest -e selftest_logdata
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/result" pass
-    for ((i = 1; i <= MAX_PROC; ++i)); do
+    for ((i = 0; i < MAX_PROC; ++i)); do
         test_yaml_regexp "/tests/0/threads/$i/messages/0/level" info
         test_yaml_regexp "/tests/0/threads/$i/messages/0/text" '.*'
         test_yaml_regexp "/tests/0/threads/$i/messages/0/data" '[0-9a-f ]+'


### PR DESCRIPTION
Remove the -vvv option that was causing a print of the inner loop count as the first message, instead of the data

```yaml
      messages:
      - { level: info, text: 'I> inner loop count for thread 0 = 0' }
      - level: info
        text: 'same'
        data:
         30 31 32 33  34 35 36 37  38 39 30 31  32 33 34 35   36 37 38 39  30 31 32 33  34 35 36 37  38 39 30 31
         32 33 34 35  36 37 38 39  30 31 32 33  34 35 36 37   38 39 30 31  32 33 34 35  36 37 38 39  30 31 32 33
         34 35 36
```