### PR TITLE
FW: make LogicalProcessorSet dynamically-sized

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -220,8 +220,6 @@ struct test mce_test = {
 // ever gets freed and we don't care -- the application is exiting anyway)
 static TestrunSelector *test_selector;
 
-static_assert(LogicalProcessorSet::Size >= MAX_THREADS, "CPU_SETSIZE is too small on this platform");
-
 static void find_thyself(char *argv0)
 {
 #ifndef __GLIBC__

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -225,7 +225,6 @@ static void apply_mock_topology(const std::vector<struct cpu_info> &mock_topolog
     for (int i = 0, curr_cpu = 0; i < count; ++i, ++curr_cpu) {
         while (!enabled_cpus.is_set(LogicalProcessor(curr_cpu))) {
             ++curr_cpu;
-            assert(curr_cpu != MAX_THREADS);
         }
 
         cpu_info[i] = mock_topology[curr_cpu];
@@ -802,7 +801,6 @@ static void init_topology_internal(const LogicalProcessorSet &enabled_cpus)
             auto lp = LogicalProcessor(curr_cpu);
             while (!enabled_cpus.is_set(lp)) {
                 lp = LogicalProcessor(++curr_cpu);
-                assert(curr_cpu != MAX_THREADS);
             }
 
             pin_to_logical_processor(lp);

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -70,18 +70,21 @@ class LogicalProcessorSet
 {
     // a possibly non-contiguous range
 public:
-#if defined(__linux__) || defined(_WIN32)
-    static constexpr int Size = 1024;
-#else
-    static constexpr int Size = 256;
-#endif
-
     using Word = unsigned long long;
     static constexpr int ProcessorsPerWord = CHAR_BIT * sizeof(Word);
-    Word array[Size / ProcessorsPerWord];
+    static constexpr int MinSize = 1024;
+    std::vector<Word> array;
+
+    LogicalProcessorSet() noexcept = default;
+    LogicalProcessorSet(int minimumSize)
+    {
+        ensureSize(minimumSize - 1);
+    }
 
     void clear()
     { *this = LogicalProcessorSet{}; }
+    size_t size_bytes() const
+    { return unsigned(array.size()) * sizeof(Word); }
 
     void set(LogicalProcessor n)
     { wordFor(n) |= bitFor(n); }
@@ -129,13 +132,28 @@ public:
     }
 
 private:
-
+    void ensureSize(int n)
+    {
+        static_assert((MinSize % ProcessorsPerWord) == 0);
+        static constexpr size_t MinSizeCount = MinSize / ProcessorsPerWord;
+        size_t idx = size_t(n) / ProcessorsPerWord;
+        if (idx >= array.size())
+            array.resize(std::max(idx + 1, MinSizeCount));
+    }
     Word &wordFor(LogicalProcessor n)
-    { return array[int(n) / ProcessorsPerWord]; }
-    const Word &wordFor(LogicalProcessor n) const
-    { return array[int(n) / ProcessorsPerWord]; }
+    {
+        ensureSize(int(n));
+        return array[int(n) / ProcessorsPerWord];
+    }
+    Word wordFor(LogicalProcessor n) const noexcept
+    {
+        int idx = int(n) / ProcessorsPerWord;
+        return idx < array.size() ? array[idx] : 0;
+    }
     static constexpr Word bitFor(LogicalProcessor n)
-    { return 1ULL << (unsigned(n) % ProcessorsPerWord); }
+    {
+        return 1ULL << (unsigned(n) % ProcessorsPerWord);
+    }
 };
 
 LogicalProcessorSet ambient_logical_processor_set();


### PR DESCRIPTION
This allows us to go beyond the 1024 logical processor limit that the tool currently has. That number is very close to what an 8-socket Sapphire Rapids may have (896 for 56 cores per socket, 960 for 60 cores per socket) and is exceeded for servers with more than 8 sockets.

Plus, update the `ambient_logical_processor_set()` for Linux and FreeBSD not to use a variable sized to `CPU_SETSIZE` (1024), but instead also allocate dynamically (on the stack).

Last `MAX_THREADS` user bites the dust! 
