### PR TITLE
FW/child_debug: context-dumping and backtrace work with -f exec mode too

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1300,7 +1300,7 @@ static ChildExitStatus wait_for_child(int ffd, intptr_t child, int *tc, const st
     struct forkfd_info info;
     struct pollfd pfd[] = {
         { .fd = ffd, .events = POLLIN },
-        { .fd = int(debug_child_watch()), .events = POLLIN }
+        { .fd = int(sApp->shmem->server_debug_socket), .events = POLLIN }
     };
 
     auto do_wait = [&](Duration timeout) {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -95,7 +95,6 @@ void cpu_specific_init(void);
 /* child_debug.cpp */
 void debug_init_child(void);
 void debug_init_global(const char *on_hang_arg, const char *on_crash_arg);
-intptr_t debug_child_watch(void);
 void debug_crashed_child();
 void debug_hung_child(pid_t child);
 
@@ -446,6 +445,11 @@ struct SandstoneApplication::SharedMemory
     OutputFormat output_format = DefaultOutputFormat;
     uint8_t output_yaml_indent = 0;
     bool log_test_knobs = false;
+
+#ifndef _WIN32
+    int server_debug_socket = -1;
+    int child_debug_socket = -1;
+#endif
 
     LogicalProcessorSet enabled_cpus;
 

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -1005,8 +1005,6 @@ void debug_init_child()
         for (int signum : { SIGILL, SIGABRT, SIGFPE, SIGBUS, SIGSEGV }) {
             sigaction(signum, &action, nullptr);
         }
-        if (sApp->current_fork_mode() != SandstoneApplication::exec_each_test)
-            sigaction(SIGTRAP, &action, nullptr);
     }
 }
 

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -993,18 +993,16 @@ void debug_init_global(const char *on_hang_arg, const char *on_crash_arg)
 
 void debug_init_child()
 {
-    if (!SandstoneConfig::ChildDebug)
+    if (!SandstoneConfig::ChildDebugCrashes || sApp->shmem->server_debug_socket == -1)
         return;
 
-    if (SandstoneConfig::ChildBacktrace && on_crash_action & (context_on_crash | attach_gdb_on_crash)) {
-        struct sigaction action = {};
-        sigemptyset(&action.sa_mask);
-        action.sa_sigaction = child_crash_handler;
-        action.sa_flags = SA_NODEFER;       // allow recursive signalling, so the child can raise()
-        action.sa_flags |= SA_SIGINFO;
-        for (int signum : { SIGILL, SIGABRT, SIGFPE, SIGBUS, SIGSEGV }) {
-            sigaction(signum, &action, nullptr);
-        }
+    struct sigaction action = {};
+    sigemptyset(&action.sa_mask);
+    action.sa_sigaction = child_crash_handler;
+    action.sa_flags = SA_NODEFER;       // allow recursive signalling, so the child can raise()
+    action.sa_flags |= SA_SIGINFO;
+    for (int signum : { SIGILL, SIGABRT, SIGFPE, SIGBUS, SIGSEGV }) {
+        sigaction(signum, &action, nullptr);
     }
 }
 


### PR DESCRIPTION
All the infrastructure was there, missing only:
* placing the file descriptors in the shared memory segment
* getting the size of the XSAVE are in the child side
