### PR TITLE
FW/Logging: simple refactor and clean-up

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1692,9 +1692,8 @@ static TestResult run_one_test_once(int *tc, const struct test *test)
     }
 
     // print results and find out if the test failed
-    TestResult real_state = logging_print_results(state, tc, test);
-
-    switch (state.result) {
+    TestResult testResult = logging_print_results(state, tc, test);
+    switch (testResult) {
     case TestResult::Passed:
     case TestResult::Skipped:
     case TestResult::Failed:
@@ -1711,7 +1710,7 @@ static TestResult run_one_test_once(int *tc, const struct test *test)
             _exit(logging_close_global(exit_code));
         } else {
             // not a pass either, but won't affect the result
-            real_state = TestResult::Skipped;
+            testResult = TestResult::Skipped;
         }
         break;
 
@@ -1721,7 +1720,7 @@ static TestResult run_one_test_once(int *tc, const struct test *test)
         break;
     }
 
-    return real_state;
+    return testResult;
 }
 
 static void analyze_test_failures(int tc, const struct test *test, int fail_count, int attempt_count,


### PR DESCRIPTION
Lots of changes to apply "Don't Repeat Yourself" and simplify execution, plus at the end make `logging_print_results()` return the full results

Up until this point, it only returned Skipped, Passed, or Failed. Now it will return the full status, with the near-term objective of making it summarise the result from multiple child processes.

This in turn means `run_one_test_once()` can return extended results to run_one_test(). The latter will not, because at the end of the failure analysis it sets to a single condition:

```c++
    /* now we process retries */
    if (fail_count > 0) {
...
        analyze_test_failures(*tc, test, fail_count, iterations, per_cpu_fails);
        state = TestResult::Failed;
    }
```
