### PR TITLE
FW/Topology: deprecate the --schedule-by option and enforce it

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -304,8 +304,11 @@ tap_negative_check() {
 
     test_yaml_numeric "/tests/0/threads@len" "value == $nproc / 2 + 1"
     for ((i = 0; i < nproc/2; ++i)); do
-        test_yaml_numeric "/cpu-info/$i/logical" "value == $i * 2"
+        test_yaml_numeric "/cpu-info/$i/logical" "(value % 2) == 0"
     done
+
+    # Verify there are no more CPUs:
+    [[ "${yamldump[/cpu-info/$i/logical]-unset}" = unset ]]
 }
 
 selftest_pass() {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3200,16 +3200,6 @@ int main(int argc, char **argv)
             if (sApp->shmem->max_messages_per_thread <= 0)
                 sApp->shmem->max_messages_per_thread = INT_MAX;
             break;
-        case schedule_by_option:
-            if (strcmp(optarg, "thread") == 0) {
-                sApp->schedule_by = SandstoneApplication::ScheduleBy::Thread;
-            } else if (strcmp(optarg, "core") == 0) {
-                sApp->schedule_by = SandstoneApplication::ScheduleBy::Core;
-            } else {
-                fprintf(stderr, "%s: unknown option for schedule-by: %s\n", argv[0], optarg);
-                return EX_USAGE;
-            }
-            break;
 
         case version_option:
             logging_print_version();
@@ -3255,6 +3245,7 @@ int main(int argc, char **argv)
         case mem_sample_time_option:
         case mem_samples_per_log_option:
         case no_mem_sampling_option:
+        case schedule_by_option:
             warn_deprecated_opt(argv[optind]);
             break;
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -352,7 +352,6 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
 
     bool fatal_skips = false;
 
-    ScheduleBy schedule_by = ScheduleBy::Thread;
     ForkMode fork_mode =
 #ifdef _WIN32
             exec_each_test;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -318,11 +318,6 @@ private:
 
 struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>
 {
-    enum class ScheduleBy : int8_t {
-        Thread,
-        Core
-    };
-
     enum class OutputFormat : int8_t {
         no_output   = 0,
         tap,

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -818,8 +818,7 @@ static void init_topology_internal(const LogicalProcessorSet &enabled_cpus)
 
 static Topology build_topology()
 {
-    if (sApp->schedule_by == SandstoneApplication::ScheduleBy::Core)
-        reorder_cpus();
+    reorder_cpus();
 
     std::vector<Topology::Package> packages;
 


### PR DESCRIPTION
This is needed because we need our internal threads to be grouped together and we definitely want to run the same child on both logical processors. This does not affect Windows or FreeBSD, because those already sorted the logical processors this way, and it's how the ACPI numbering worked. Raymond Chen even had a [blog post](https://devblogs.microsoft.com/oldnewthing/20230620-00/?p=108358) about this a couple of weeks ago.

[ChangeLog][Framework] The sorting order for logical processors on Linux has changed. Previously, the tool kept the order provided by the OS, but now it will group all cores together, side-by-side. This change is noticeable when the framework prints warnings and errors from the tests: users who may be parsing the output of the tool must be aware that "thread 1" is likely no longer "Linux logical processor 1". This change does not affect Windows nor systems without hyperthreading.
