### PR TITLE
FW: introduce ShortDuration to store user-configurable times

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -902,7 +902,7 @@ void logging_print_version()
     printf(PROGRAM_VERSION "\n");
 }
 
-void logging_print_header(int argc, char **argv, Duration test_duration, Duration test_timeout)
+void logging_print_header(int argc, char **argv, ShortDuration test_duration, ShortDuration test_timeout)
 {
     if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
         return;                 // short-circuit

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2983,7 +2983,7 @@ int main(int argc, char **argv)
             if (strcmp(optarg, "forever") == 0) {
                 sApp->endtime = MonotonicTimePoint::max();
             } else {
-                sApp->endtime = calculate_wallclock_deadline(string_to_millisecs(optarg), &sApp->starttime);
+                sApp->endtime = sApp->starttime + string_to_millisecs(optarg);
             }
             break;
         case 'v':
@@ -3218,25 +3218,25 @@ int main(int argc, char **argv)
             test_list_randomize = true;
             test_selection_strategy = Repeating;
             sApp->shmem->use_strict_runtime = true;
-            sApp->endtime = calculate_wallclock_deadline(1s, &sApp->starttime);
+            sApp->endtime = sApp->starttime + 1s;
             break;
         case thirty_sec_option:
             test_list_randomize = true;
             test_selection_strategy = Repeating;
             sApp->shmem->use_strict_runtime = true;
-            sApp->endtime = calculate_wallclock_deadline(30s, &sApp->starttime);
+            sApp->endtime = sApp->starttime + 30s;
             break;
         case two_min_option:
             test_list_randomize = true;
             test_selection_strategy = Repeating;
             sApp->shmem->use_strict_runtime = true;
-            sApp->endtime = calculate_wallclock_deadline(2min, &sApp->starttime);
+            sApp->endtime = sApp->starttime + 2min;
             break;
         case five_min_option:
             test_list_randomize = true;
             test_selection_strategy = Repeating;
             sApp->shmem->use_strict_runtime = true;
-            sApp->endtime = calculate_wallclock_deadline(5min, &sApp->starttime);
+            sApp->endtime = sApp->starttime + 5min;
             break;
 
         case max_test_count_option:
@@ -3432,9 +3432,6 @@ int main(int argc, char **argv)
 #endif
 
     logging_print_header(argc, argv, test_duration(), test_timeout(test_duration()));
-
-    if (sApp->starttime.time_since_epoch() == Duration::zero())
-        sApp->starttime = MonotonicTimePoint::clock::now();
 
     // triage process is the best effort to figure out which socket is faulty on
     // a multi-socket system, it's done after the main run and only using the

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -649,7 +649,7 @@ inline void test_the_test_data<true>::test_tests_finish(const struct test *the_t
 #undef maybe_log_error
 }
 
-static Duration test_duration()
+static ShortDuration test_duration()
 {
     /* global (-t) option overrides this all */
     if (sApp->test_time > 0s)
@@ -657,16 +657,16 @@ static Duration test_duration()
     return SandstoneApplication::DefaultTestDuration;
 }
 
-static Duration test_duration(const struct test *test)
+static ShortDuration test_duration(const struct test *test)
 {
     /* Start with the test prefered default time */
-    milliseconds target_duration(test->desired_duration);
-    milliseconds min_duration(test->minimum_duration);
-    milliseconds max_duration(test->maximum_duration);
+    ShortDuration target_duration(test->desired_duration);
+    ShortDuration min_duration(test->minimum_duration);
+    ShortDuration max_duration(test->maximum_duration);
 
     /* apply the global (-t) override */
     if (sApp->test_time.count())
-        target_duration = duration_cast<milliseconds>(sApp->test_time);
+        target_duration = sApp->test_time;
 
     /* fallback to the default if test preference is zero */
     if (target_duration <= 0s)
@@ -686,13 +686,13 @@ static Duration test_duration(const struct test *test)
     return target_duration;
 }
 
-static Duration test_timeout(Duration regular_duration)
+static ShortDuration test_timeout(ShortDuration regular_duration)
 {
     // use the override value if there is one
     if (sApp->max_test_time != Duration::zero())
         return sApp->max_test_time;
 
-    Duration result = regular_duration * 5 + 30s;
+    ShortDuration result = regular_duration * 5 + 30s;
     if (result < 300s)
         result = 300s;
 

--- a/framework/sandstone_chrono.cpp
+++ b/framework/sandstone_chrono.cpp
@@ -11,12 +11,12 @@
 using namespace std;
 using namespace std::chrono;
 
-milliseconds string_to_millisecs(string_view in_string)
+ShortDuration string_to_millisecs(string_view in_string)
 {
     if (in_string.size() == 0)
         return {};
 
-    milliseconds::rep value;
+    ShortDuration::rep value;
     std::from_chars_result r = std::from_chars(in_string.begin(), in_string.end(), value, 10);
     if (r.ec == std::errc{}) {
         string_view suffix = in_string.substr(r.ptr - in_string.data());

--- a/framework/sandstone_chrono.cpp
+++ b/framework/sandstone_chrono.cpp
@@ -11,27 +11,61 @@
 using namespace std;
 using namespace std::chrono;
 
+// like std::chrono::duration_cast, but with overflow checking
+template <typename To, typename Rep, typename Period> static std::optional<To>
+duration_cast_overflow(duration<Rep, Period> from)
+{
+    using ToRep = typename To::rep;
+    using Ratio = std::ratio_divide<Period, typename To::period>;
+    static_assert(Ratio::den == 1, "Unsupported conversion, use std::chrono::duration_cast");
+
+    auto value = ToRep(from.count());
+    if (value != from.count())
+        return std::nullopt;
+    if (__builtin_mul_overflow(value, ToRep(Ratio::num), &value))
+        return std::nullopt;
+    return To(value);
+}
+
 ShortDuration string_to_millisecs(string_view in_string)
 {
     if (in_string.size() == 0)
         return {};
 
+    const char *error_reason = nullptr;
     ShortDuration::rep value;
     std::from_chars_result r = std::from_chars(in_string.begin(), in_string.end(), value, 10);
     if (r.ec == std::errc{}) {
         string_view suffix = in_string.substr(r.ptr - in_string.data());
+        std::optional<ShortDuration> result;
         if (suffix == "ms" || suffix.size() == 0)
-            return std::chrono::milliseconds(value);
-        if (suffix == "s")
-            return std::chrono::seconds(value);
-        if (suffix == "m" || suffix == "min")
-            return std::chrono::minutes(value);
-        if (suffix == "h")
-            return std::chrono::hours(value);
+            result = duration_cast_overflow<ShortDuration>(milliseconds(value));
+        else if (suffix == "s")
+            result = duration_cast_overflow<ShortDuration>(seconds(value));
+        else if (suffix == "m" || suffix == "min")
+            result = duration_cast_overflow<ShortDuration>(minutes(value));
+        else if (suffix == "h")
+            result = duration_cast_overflow<ShortDuration>(hours(value));
+        else
+            error_reason = "unknown time unit";
+
+        if (result)
+            return *result;
+        else if (!error_reason)
+            error_reason = "time out of range";
+    } else if (r.ec == std::errc::result_out_of_range) {
+        error_reason = "time out of range";
+    } else if (r.ec == std::errc::invalid_argument) {
+        error_reason = "could not parse";   // probably not a number!
     }
-    fprintf(stderr, "%s: Invalid time: \"%.*s\"\n", program_invocation_name,
-            int(in_string.size()), in_string.data());
-    exit(EX_USAGE);
+
+    if (error_reason) {
+        fprintf(stderr, "%s: invalid time \"%.*s\": %s\n", program_invocation_name,
+                int(in_string.size()), in_string.data(), error_reason);
+        exit(EX_USAGE);
+    }
+
+    return ShortDuration(value);
 }
 
 string format_duration(std::chrono::nanoseconds ns, FormatDurationOptions opts)

--- a/framework/sandstone_chrono.h
+++ b/framework/sandstone_chrono.h
@@ -25,6 +25,7 @@ static inline int get_monotonic_time_now(struct timespec *tv)
 #include <string>
 
 using Duration = std::chrono::steady_clock::duration;
+using ShortDuration = std::chrono::duration<int, std::milli>;   // +/- 24.85 days
 using MonotonicTimePoint = std::chrono::steady_clock::time_point;
 
 struct coarse_steady_clock : std::chrono::steady_clock
@@ -40,7 +41,7 @@ enum class FormatDurationOptions {
     WithUnit        = 0x01,
 };
 
-std::chrono::milliseconds string_to_millisecs(std::string_view in_string);
+ShortDuration string_to_millisecs(std::string_view in_string);
 std::string format_duration(std::chrono::nanoseconds ns,
                             FormatDurationOptions options = FormatDurationOptions::WithUnit);
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -368,7 +368,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     int max_test_count = INT_MAX;
     int max_test_loop_count = 0;
     int current_iteration_count;        // iterations of the same test (positive for fracture; negative for retest)
-    MonotonicTimePoint starttime;
+    MonotonicTimePoint starttime = MonotonicTimePoint::clock::now();
     MonotonicTimePoint endtime;
     MonotonicTimePoint current_test_starttime;
     static constexpr auto DefaultTestDuration = std::chrono::seconds(1);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -372,10 +372,10 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     MonotonicTimePoint endtime;
     MonotonicTimePoint current_test_starttime;
     static constexpr auto DefaultTestDuration = std::chrono::seconds(1);
-    Duration current_test_duration;
-    Duration test_time = Duration::zero();
-    Duration max_test_time = Duration::zero();
-    Duration delay_between_tests = std::chrono::milliseconds(5);
+    ShortDuration current_test_duration;
+    ShortDuration test_time = {};
+    ShortDuration max_test_time = {};
+    ShortDuration delay_between_tests = std::chrono::milliseconds(5);
 
     std::unique_ptr<RandomEngineWrapper, RandomEngineDeleter> random_engine;
 
@@ -557,7 +557,7 @@ void logging_printf(int level, const char *msg, ...) ATTRIBUTE_PRINTF(2, 3);
 void logging_mark_thread_failed(int thread_num);
 void logging_report_mismatched_data(enum DataType type, const uint8_t *actual, const uint8_t *expected,
                                     size_t size, ptrdiff_t offset, const char *fmt, va_list);
-void logging_print_header(int argc, char **argv, Duration test_duration, Duration test_timeout);
+void logging_print_header(int argc, char **argv, ShortDuration test_duration, ShortDuration test_timeout);
 void logging_print_iteration_start();
 void logging_print_footer();
 void logging_print_triage_results(const std::vector<int> &sockets);


### PR DESCRIPTION
We don't need to store an `int64_t` nanoseconds (± 292 years of range). The range of a plain 32-bit int in milliseconds is enough (± 24.85 days).
