### PR TITLE
FW/FreeBSD: delegate the common cpu_affinity.cpp to the Linux version

### DIFF
--- a/framework/sysdeps/freebsd/cpu_affinity.cpp
+++ b/framework/sysdeps/freebsd/cpu_affinity.cpp
@@ -3,37 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <topology.h>
-
+#include <pthread.h>
 #include <pthread_np.h>
-#include <sys/cpuset.h>
 
-static_assert(sizeof(cpuset_t) >= sizeof(LogicalProcessorSet));
-
-LogicalProcessorSet ambient_logical_processor_set()
-{
-    LogicalProcessorSet result;
-    if (cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_PID, -1, sizeof(result.array),
-                           reinterpret_cast<cpuset_t *>(result.array)) != 0)
-        result.clear();
-    return result;
-}
-
-bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
+static void set_thread_name(const char *thread_name)
 {
     if (thread_name)
         pthread_set_name_np(pthread_self(), thread_name);
-    if (n == LogicalProcessor(-1))
-        return true;            // don't change affinity
-
-    cpuset_t cpu_set;
-    CPU_ZERO(&cpu_set);
-    CPU_SET(int(n), &cpu_set);
-
-    if (cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(cpu_set), &cpu_set)) {
-        perror("cpuset_setaffinity");
-        return false;
-    }
-    return true;
 }
 
+// FreeBSD's libc has a "fake Linux" API wrapper for us!
+// https://github.com/freebsd/freebsd-src/blob/main/lib/libc/gen/sched_getaffinity.c
+// https://github.com/freebsd/freebsd-src/blob/main/lib/libc/gen/sched_setaffinity.c
+#include "../linux/cpu_affinity.cpp"

--- a/framework/sysdeps/linux/cpu_affinity.cpp
+++ b/framework/sysdeps/linux/cpu_affinity.cpp
@@ -7,9 +7,18 @@
 
 #include <sched.h>
 #include <stdio.h>
-#include <sys/prctl.h>
 
 static_assert(CPU_SETSIZE >= LogicalProcessorSet::Size);
+
+#ifdef __linux__
+#include <sys/prctl.h>
+
+static void set_thread_name(const char *thread_name)
+{
+    if (thread_name)
+        prctl(PR_SET_NAME, thread_name);
+}
+#endif
 
 LogicalProcessorSet ambient_logical_processor_set()
 {
@@ -21,8 +30,7 @@ LogicalProcessorSet ambient_logical_processor_set()
 
 bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
 {
-    if (thread_name)
-        prctl(PR_SET_NAME, thread_name);
+    set_thread_name(thread_name);
     if (n == LogicalProcessor(-1))
         return true;            // don't change affinity
 


### PR DESCRIPTION
The two OSes have very similar API, so keep the implementation in one place. I even wrote wrapper functions, but it turns out they weren't needed because the FreeBSD libc provides the wrappers for us, including translating the ERANGE error of "insufficient buffer" for `cpuset_getaffinity()` to Linux's EINVAL for `sched_getaffinity()`.

https://github.com/freebsd/freebsd-src/blob/main/lib/libc/gen/sched_getaffinity.c
https://github.com/freebsd/freebsd-src/blob/main/lib/libc/gen/sched_setaffinity.c
