### PR TITLE
docs/writing_tests.md fix reference to sandstone_test_groups.h

### DIFF
--- a/docs/writing_tests.md
+++ b/docs/writing_tests.md
@@ -733,7 +733,7 @@ group.
 Tests can be members of multiple groups. The DECLARE_TEST_GROUPS
 macro accepts a comma-separated list of group pointers. The groups
 themselves are defined in
-[sandstone_test_groups_p.h](../framework/sandstone_test_groups_p.h).
+[sandstone_test_groups.h](../framework/sandstone_test_groups.h).
 To add a new group, modify this file.
 
 ### Skipping tests


### PR DESCRIPTION
The reference is valid until commit 441b845185937d9abf439f1391d5302b860e4b96, this commit changes the reference to point to
`framework/sandstone_test_groups.h` instead, turning the reference link valid again.