### PR TITLE
FW/Topology & Triage: do less work

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3310,7 +3310,7 @@ int main(int argc, char **argv)
     if (unsigned(thread_count) < unsigned(sApp->thread_count)) {
         sApp->thread_count = thread_count;
         sApp->shmem->enabled_cpus.limit_to(thread_count);
-        restrict_topology(0, thread_count);
+        restrict_topology({ 0, thread_count });
     }
     commit_shmem();
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1077,11 +1077,9 @@ static std::string cpu_features_to_string(uint64_t f)
     return result;
 }
 
-static void dump_cpu_info(const LogicalProcessorSet &enabled_cpus)
+static void dump_cpu_info()
 {
     int i;
-
-    load_cpu_info(enabled_cpus);
 
     // find the best matching CPU
     const char *detected = "<unknown>";
@@ -2285,9 +2283,8 @@ static int exec_mode_run(int argc, char **argv)
         attach_shmem(shmemfd);
     }
 
-    sApp->thread_count = sApp->shmem->enabled_cpus.count();
+    init_topology(sApp->shmem->enabled_cpus);
     sApp->user_thread_data.resize(sApp->thread_count);
-    load_cpu_info(sApp->shmem->enabled_cpus);
 
 #ifndef NO_SELF_TESTS
     if (sApp->shmem->selftest && !SandstoneConfig::RestrictedCommandLine)
@@ -2887,6 +2884,7 @@ int main(int argc, char **argv)
 
     init_shmem();
     sApp->shmem->enabled_cpus = init_cpus();
+    init_topology(sApp->shmem->enabled_cpus);
     while (!SandstoneConfig::RestrictedCommandLine &&
            (opt = simple_getopt(argc, argv, long_options)) != -1) {
         switch (opt) {
@@ -2982,7 +2980,7 @@ int main(int argc, char **argv)
             apply_cpuset_param(optarg);
             break;
         case dump_cpu_info_option:
-            dump_cpu_info(sApp->shmem->enabled_cpus);
+            dump_cpu_info();
             return EXIT_SUCCESS;
         case fatal_skips_option:
             sApp->fatal_skips = true;
@@ -3308,8 +3306,8 @@ int main(int argc, char **argv)
     if (unsigned(thread_count) < unsigned(sApp->thread_count)) {
         sApp->thread_count = thread_count;
         sApp->shmem->enabled_cpus.limit_to(thread_count);
+        restrict_topology(0, thread_count);
     }
-    load_cpu_info(sApp->shmem->enabled_cpus);
     commit_shmem();
 
     signals_init_global();

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2310,13 +2310,14 @@ static int exec_mode_run(int argc, char **argv)
 // generic vector<int> for the future improvements.
 static vector<int> run_triage(vector<const struct test *> &triage_tests)
 {
+    std::vector<struct cpu_info> saved_cpu_info;
     auto run_tests_with_retest = [&](std::span<const Topology::Package> set) {
         SandstoneApplication::PerCpuFailures per_cpu_failures;
         int k = 0;
         int ret = EXIT_SUCCESS;
 
         // all the shady stuff needed to set up to run a test smoothly
-        update_topology(set);
+        update_topology(saved_cpu_info, set);
 
         do {
             int test_count = 1;
@@ -2341,6 +2342,9 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests)
         result.push_back(it->id);
         return result;
     }
+
+    // backup the original CPU info
+    saved_cpu_info.assign(cpu_info, cpu_info + num_cpus());
 
     // backup the original verbosity
     int orig_verbosity = sApp->shmem->verbosity;
@@ -2372,7 +2376,7 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests)
     sApp->shmem->verbosity = orig_verbosity;
 
     // restore original topology
-    update_topology(topo.packages);
+    update_topology(std::move(saved_cpu_info));
 
     return result;
 }

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -896,7 +896,7 @@ void update_topology(std::span<const struct cpu_info> new_cpu_info,
         std::fill_n(end, excess, (struct cpu_info){});
 
     sApp->thread_count = new_thread_count;
-    restrict_topology(0, new_thread_count);
+    restrict_topology({ 0, new_thread_count });
 }
 
 void init_topology(const LogicalProcessorSet &enabled_cpus)
@@ -906,11 +906,12 @@ void init_topology(const LogicalProcessorSet &enabled_cpus)
     cached_topology() = build_topology();
 }
 
-void restrict_topology(int starting_cpu, int cpu_count)
+void restrict_topology(CpuRange range)
 {
-    assert(starting_cpu + cpu_count <= sApp->thread_count);
-    std::move(cpu_info + starting_cpu, cpu_info + starting_cpu + cpu_count, cpu_info);
-    sApp->thread_count = cpu_count - starting_cpu;
+    assert(range.starting_cpu + range.cpu_count <= sApp->thread_count);
+    std::move(cpu_info + range.starting_cpu, cpu_info + range.starting_cpu + range.cpu_count,
+              cpu_info);
+    sApp->thread_count = range.cpu_count;
 
     cached_topology() = build_topology();
 }

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -140,7 +140,8 @@ bool pin_to_logical_processor(LogicalProcessor, const char *thread_name = nullpt
 
 void apply_cpuset_param(char *param);
 void init_topology(const LogicalProcessorSet &enabled_cpus);
-void update_topology(std::span<const Topology::Package> sockets);
+void update_topology(std::span<const struct cpu_info> new_cpu_info,
+                     std::span<const Topology::Package> sockets = {});
 void restrict_topology(int starting_cpu, int cpu_count);
 
 #endif /* INC_TOPOLOGY_H */

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -138,8 +138,9 @@ private:
 LogicalProcessorSet ambient_logical_processor_set();
 bool pin_to_logical_processor(LogicalProcessor, const char *thread_name = nullptr);
 
-void load_cpu_info(/*in*/ const LogicalProcessorSet &enabled_cpus);
 void apply_cpuset_param(char *param);
+void init_topology(const LogicalProcessorSet &enabled_cpus);
 void update_topology(std::span<const Topology::Package> sockets);
+void restrict_topology(int starting_cpu, int cpu_count);
 
 #endif /* INC_TOPOLOGY_H */

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -58,8 +58,17 @@ public:
 };
 
 enum class LogicalProcessor : int {};
+
+struct CpuRange
+{
+    // a contiguous range
+    int starting_cpu;
+    int cpu_count;
+};
+
 class LogicalProcessorSet
 {
+    // a possibly non-contiguous range
 public:
 #if defined(__linux__) || defined(_WIN32)
     static constexpr int Size = 1024;
@@ -142,6 +151,6 @@ void apply_cpuset_param(char *param);
 void init_topology(const LogicalProcessorSet &enabled_cpus);
 void update_topology(std::span<const struct cpu_info> new_cpu_info,
                      std::span<const Topology::Package> sockets = {});
-void restrict_topology(int starting_cpu, int cpu_count);
+void restrict_topology(CpuRange range);
 
 #endif /* INC_TOPOLOGY_H */


### PR DESCRIPTION
This splits `load_cpu_info` into an init and a rebuild function, so we initialise only once, then we can rebuild many times by shrinking what CPUs we observe (except at the end of the triage run, when we restore the state).