### PR TITLE
Meson: fixes for warnings found in v1.2.0

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -93,7 +93,7 @@ framework_files = files(
 crypto_dep = dependency('libcrypto',
                         required: false,
                         static: get_option('ssl_link_type') == 'static')
-if crypto_dep.found() and framework_config.get('SANDSTONE_SSL_BUILD') == true
+if crypto_dep.found() and framework_config.get('SANDSTONE_SSL_BUILD') == 1
     framework_files += ['sandstone_ssl.cpp']
 endif
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -46,7 +46,7 @@ tests_set_base.add(
     )
 )
 
-if framework_config.get('SANDSTONE_SSL_BUILD') == true
+if framework_config.get('SANDSTONE_SSL_BUILD') == 1
     tests_set_base.add(
         when : crypto_dep,
         if_true: files(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -105,17 +105,13 @@ tests_config_base = tests_set_base.apply(tests_config)
 tests_base_a = static_library(
     'tests_base',
     sources : tests_config_base.sources(),
-    dependencies : tests_config_base.dependencies(),
     build_by_default: false,
     include_directories : [
         tests_common_incdirs,
     ],
     dependencies: [
+        tests_config_base.dependencies(),
         boost_dep,
-        crypto_dep,
-        eigen3_dep,
-        zlib_dep,
-        zstd_dep,
     ],
     c_args : [
         tests_common_c_args,
@@ -160,14 +156,13 @@ if host_machine.cpu_family() == 'x86_64'
     tests_skx_a = static_library(
         'tests_skx',
         sources : tests_config_skx.sources(),
-        dependencies : tests_config_skx.dependencies(),
         build_by_default: false,
         include_directories : [
             tests_common_incdirs,
         ],
         dependencies: [
+            tests_config_skx.dependencies(),
             boost_dep,
-            eigen3_dep,
         ],
         c_args : [
             tests_common_c_args,


### PR DESCRIPTION
```
framework/meson.build:105: DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.2.0': int operations with non-int. It is not commutative and only worked because of leaky Python abstractions.
Configuring sandstone_config.h using configuration
tests/meson.build:106: WARNING: Keyword argument "dependencies" defined multiple times.
WARNING: This will be an error in future Meson releases.
tests/meson.build:161: WARNING: Keyword argument "dependencies" defined multiple times.
WARNING: This will be an error in future Meson releases.
tests/meson.build:49: DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.2.0': int operations with non-int. It is not commutative and only worked because of leaky Python abstractions.
```