### PR TITLE
FW/Linux: don't keep trying to open the /dev/ MSR nodes if we get EACCES

### DIFF
--- a/framework/sysdeps/linux/msr.c
+++ b/framework/sysdeps/linux/msr.c
@@ -52,9 +52,6 @@ bool read_msr(int cpu, uint32_t msr, uint64_t * value)
     bool ret = false;
     char filename[sizeof "/dev/cpu/2147483647/msr" + 1];
 
-    if (cpu < 0)
-        cpu = thread_num;
-
     try_load_kmod();
 
     sprintf(filename, "/dev/cpu/%i/msr", cpu);
@@ -73,9 +70,6 @@ bool write_msr(int cpu, uint32_t msr, uint64_t value)
     int fd;
     bool ret = false;
     char filename[sizeof "/dev/cpu/2147483647/msr" + 1];
-
-    if (cpu < 0)
-        cpu = thread_num;
 
     try_load_kmod();
 


### PR DESCRIPTION
We can't gain privileges, so the result won't change if we keep trying.

Not retrying means we avoid system calls. It's not a lot, but at 2xNPROC system calls on start, even 0.5µs accumulates. This patch saves 2 ms in start up time.

Before:
```
selftest_pass_low_quality
          0.122776 +- 0.000110 seconds time elapsed  ( +-  0.09% )
selftest_pass
          0.182380 +- 0.000142 seconds time elapsed  ( +-  0.08% )
```
After:
```
selftest_pass_low_quality
         0.1204033 +- 0.0000948 seconds time elapsed  ( +-  0.08% )
selftest_pass
         0.1804157 +- 0.0000790 seconds time elapsed  ( +-  0.04% )
```