### PR TITLE
FW/InterruptMonitor: improve counting of SMI events

### DIFF
--- a/framework/interrupt_monitor.hpp
+++ b/framework/interrupt_monitor.hpp
@@ -8,6 +8,7 @@
 #include <sandstone.h>
 #include <stdint.h>
 #include <numeric>      // for std::accummulate
+#include <optional>
 #include <vector>
 
 class InterruptMonitor
@@ -36,11 +37,12 @@ public:
     uint64_t count_thermal_events() const
     { return get_total_interrupt_counts(Thermal); }
 
-    uint64_t count_smi_events(int cpu) {
+    std::optional<uint64_t> count_smi_events(int cpu)
+    {
         uint64_t msi_count = 0;
         if (read_msr(cpu, MSR_SMI_COUNT, &msi_count))
             return msi_count;
-        return 0;
+        return std::nullopt;
     }
 
     static constexpr bool InterruptMonitorWorks =

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -805,8 +805,12 @@ static void init_internal(const struct test *test)
 
 static void initialize_smi_counts()
 {
-    for (int i = 0; i < num_cpus(); i++)
-        sApp->smi_counts_start[cpu_info[i].cpu_number] = sApp->count_smi_events(cpu_info[i].cpu_number);
+    std::optional<uint64_t> v = sApp->count_smi_events(cpu_info[0].cpu_number);
+    if (!v)
+        return;
+    sApp->smi_counts_start[0] = *v;
+    for (int i = 1; i < num_cpus(); i++)
+        sApp->smi_counts_start[cpu_info[i].cpu_number] = sApp->count_smi_events(cpu_info[i].cpu_number).value_or(0);
 }
 
 static void cleanup_internal(const struct test *test)

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -808,6 +808,7 @@ static void initialize_smi_counts()
     std::optional<uint64_t> v = sApp->count_smi_events(cpu_info[0].cpu_number);
     if (!v)
         return;
+    sApp->smi_counts_start.resize(num_cpus());
     sApp->smi_counts_start[0] = *v;
     for (int i = 1; i < num_cpus(); i++)
         sApp->smi_counts_start[cpu_info[i].cpu_number] = sApp->count_smi_events(cpu_info[i].cpu_number).value_or(0);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -28,7 +28,6 @@
 
 #ifdef __cplusplus
 #include <memory>
-#include <map>
 #include <span>
 
 #include <sandstone_config.h>
@@ -392,7 +391,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     uint64_t last_thermal_event_count;
     uint64_t mce_count_last;
     std::vector<uint32_t> mce_counts_start;
-    std::map<int, uint64_t> smi_counts_start;
+    std::vector<uint64_t> smi_counts_start;
 
     int thread_count;
     ForkMode current_fork_mode() const

--- a/tests/smi_count/smi_count.cpp
+++ b/tests/smi_count/smi_count.cpp
@@ -31,11 +31,13 @@ static int smi_count_run(struct test *test, int cpu)
     if (KEY_EXISTS(sApp->smi_counts_start, real_cpu_number)) {
         auto initial_count = sApp->smi_counts_start[real_cpu_number];
         auto current_count = sApp->count_smi_events(real_cpu_number);
-        uint64_t difference = current_count - initial_count;
+        if (current_count) {
+            uint64_t difference = *current_count - initial_count;
 
-        if (difference) {
-            log_platform_message(SANDSTONE_LOG_INFO "SMI count difference detected: %" PRIu64 " new SMI detected on thread %d cpu_number %d\n",
-                                 difference, cpu, real_cpu_number);
+            if (difference) {
+                log_platform_message(SANDSTONE_LOG_INFO "SMI count difference detected: %" PRIu64 " new SMI detected on thread %d cpu_number %d\n",
+                                     difference, cpu, real_cpu_number);
+            }
         }
     }
     return EXIT_SUCCESS;
@@ -49,4 +51,3 @@ DECLARE_TEST(smi_count, "Counts SMI events")
     .quality_level = TEST_QUALITY_PROD,
 END_DECLARE_TEST
 #endif /* __unix__ */
-

--- a/tests/smi_count/smi_count.cpp
+++ b/tests/smi_count/smi_count.cpp
@@ -20,16 +20,13 @@
 #include <limits.h>
 #include <map>
 
-#define KEY_EXISTS(map, key)  (map.count(key) > 0)
-
 static int smi_count_run(struct test *test, int cpu)
 {
     (void) test;
 
-    int real_cpu_number = cpu_info[cpu].cpu_number;
-
-    if (KEY_EXISTS(sApp->smi_counts_start, real_cpu_number)) {
-        auto initial_count = sApp->smi_counts_start[real_cpu_number];
+    if (sApp->smi_counts_start.size() > cpu) {
+        int real_cpu_number = cpu_info[cpu].cpu_number;
+        auto initial_count = sApp->smi_counts_start[cpu];
         auto current_count = sApp->count_smi_events(real_cpu_number);
         if (current_count) {
             uint64_t difference = *current_count - initial_count;


### PR DESCRIPTION
First, we make `count_smi_events()` return std::optional, so we don't keep trying to get the count after we've already failed once. This won't make much of a difference, with #329 applied.

Second, we replace `std::map` with `std::vector`, which simplifies code. This improves the test runtime of a single, selftest_pass run by 4 ms.