### PR TITLE
FW: move the between-test checks on MCE and thermal events to mce_check

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3309,7 +3309,7 @@ int main(int argc, char **argv)
     if (sApp->shmem->verbosity == -1)
         sApp->shmem->verbosity = (sApp->requested_quality < SandstoneApplication::DefaultQualityLevel) ? 1 : 0;
 
-    if (InterruptMonitor::InterruptMonitorWorks) {
+    if (InterruptMonitor::InterruptMonitorWorks && mce_test.quality_level != TEST_QUALITY_SKIP) {
         sApp->last_thermal_event_count = sApp->count_thermal_events();
         sApp->mce_counts_start = sApp->get_mce_interrupt_counts();
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1404,9 +1404,6 @@ static ChildExitStatus wait_for_child(int ffd, intptr_t child, int *tc, const st
             }
         }
 
-        if (sApp->count_thermal_events() != sApp->last_thermal_event_count)
-            log_platform_message(SANDSTONE_LOG_WARNING "Thermal events detected, timing cannot be trusted.");
-
         return { TestResult::TimedOut };
     }
     return test_result_from_exit_code(info);

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -812,20 +812,6 @@ static void initialize_smi_counts()
 static void cleanup_internal(const struct test *test)
 {
     logging_finish();
-
-    if (InterruptMonitor::InterruptMonitorWorks) {
-        uint64_t mce_now = sApp->count_mce_events();
-        if (sApp->mce_count_last != mce_now) {
-            logging_printf(LOG_LEVEL_QUIET, "# WARNING: Machine check exception detected\n");
-            sApp->mce_count_last = mce_now;
-        }
-
-        uint64_t thermal_now = sApp->count_thermal_events();
-        if (thermal_now != sApp->last_thermal_event_count) {
-            sApp->last_thermal_event_count = thermal_now;
-            logging_printf(LOG_LEVEL_QUIET, "# WARNING: Thermal events detected.\n");
-        }
-    }
 }
 
 template <uint64_t X, uint64_t Y, typename P = int>

--- a/tests/mce_check/mce_check.cpp
+++ b/tests/mce_check/mce_check.cpp
@@ -62,7 +62,8 @@ static int mce_check_run(struct test *test, int cpu)
         assert(cpu < differences.size());
 
         if (differences[i] != 0) {
-            log_message(i, SANDSTONE_LOG_ERROR "MCE detected");
+            log_message(i, SANDSTONE_LOG_ERROR "MCE detected (%u interrupts since start)",
+                        differences[i]);
             differences[i] = 0;
             ++errorcount;
         }
@@ -78,6 +79,14 @@ static int mce_check_run(struct test *test, int cpu)
 
     if (errorcount)
         log_platform_message(SANDSTONE_LOG_ERROR "MCE interrupts detected on %d CPUs", errorcount);
+
+    uint64_t thermal_now = sApp->count_thermal_events();
+    if (thermal_now != sApp->last_thermal_event_count) {
+        sApp->last_thermal_event_count = thermal_now;
+        log_platform_message(SANDSTONE_LOG_WARNING "Thermal events detected (%zu since start).",
+                             size_t(thermal_now - sApp->last_thermal_event_count));
+    }
+
     return errorcount;
 }
 

--- a/tests/mce_check/mce_check.cpp
+++ b/tests/mce_check/mce_check.cpp
@@ -61,10 +61,10 @@ static int mce_check_run(struct test *test, int cpu)
         cpu = cpu_info[i].cpu_number;
         assert(cpu < differences.size());
 
-        if (differences[i] != 0) {
+        if (differences[cpu] != 0) {
             log_message(i, SANDSTONE_LOG_ERROR "MCE detected (%u interrupts since start)",
-                        differences[i]);
-            differences[i] = 0;
+                        differences[cpu]);
+            differences[cpu] = 0;
             ++errorcount;
         }
     }


### PR DESCRIPTION
This removes the parsing of /proc/interrupts on Linux between each test and when the "mce_check" test is run. In any case, the product of those checks was only comments, not properly structured data (because we introduced them for the TAP output format, before we had YAML), which means many tools never caught or stored them at all. Though as a consequence the test running in a child process, its update of the counts won't be committed, so when the test is run again, it'll compare against the original numbers from the tool's start.

The problem with /proc/interrupts is that it increases in size linearly with the number of cores.

This improves start-up time a bit if `--disable=mce_check` is passed. For `perf stat -r500 $objdir/opendcdiag --disable=mce_check --selftests -o - -e selftest_skip`:

| Machine     | Before (ms) | After (ms) |
|-------------|-------------|------------|
| 14c SKX     |       3.94  |      3.46  |
| 2x28c CLX   |      36.40  |     27.83  |
| 2x48c SPR   |     123.86  |     80.00  |

And 1000 runs of `selftest_pass` (not including the start up time above):

| Machine     | Before (ms) | After (ms) |
|-------------|-------------|------------|
| 14c SKX     |       6.83  |      6.52  |
| 2x28c CLX   |      21.45  |     13.91  |
| 2x48c SPR   |      63.73  |     17.23  |

[ChangeLog][mce_check] This test now has a "sticky" behavior: if a problem is found, it is reported every time the test is run, instead of only the first time the problem was detected.
