### PR TITLE
FW: pre-allocate the stacks' threads

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -90,6 +90,7 @@ framework_files = files(
     'sandstone_chrono.cpp',
     'sandstone_data.cpp',
     'sandstone_test_groups.cpp',
+    'sandstone_thread.cpp',
     'sandstone_utils.cpp',
     'static_vectors.c',
     'test_knobs.cpp',

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -536,6 +536,18 @@ private:
     }
 };
 
+template <typename F> inline auto scopeExit(F &&f)
+{
+    struct Scope {
+        F f;
+        bool dismissed = false;
+        ~Scope() { if (!dismissed) f(); }
+        void dismiss() { dismissed = true; }
+        void run_now() { f(); dismiss(); }
+    };
+    return Scope(std::forward<F>(f));
+}
+
 static_assert(std::is_trivially_copyable_v<SandstoneApplication::SharedMemory>);
 static_assert(std::is_trivially_destructible_v<SandstoneApplication::SharedMemory>);
 

--- a/framework/sandstone_thread.cpp
+++ b/framework/sandstone_thread.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "sandstone_thread.h"
+#include "sandstone_p.h"
+
+#include "gettid.h"
+
+namespace {
+struct SandstoneTestThreadAttributes
+{
+    pthread_attr_t thread_attr;
+    SandstoneTestThreadAttributes()
+    {
+        pthread_attr_init(&thread_attr);
+        pthread_attr_setstacksize(&thread_attr, THREAD_STACK_SIZE);
+    }
+    ~SandstoneTestThreadAttributes()
+    {
+        pthread_attr_destroy(&thread_attr);
+    }
+    SandstoneTestThreadAttributes(const SandstoneTestThreadAttributes &) = delete;
+    SandstoneTestThreadAttributes &operator=(const SandstoneTestThreadAttributes &) = delete;
+};
+} // unnamed namespace
+
+[[maybe_unused]] static bool check_run_from_correct_thread()
+{
+#ifdef __linux__
+    // only tested for Linux
+    return getpid() == gettid();
+#else
+    return true;
+#endif
+}
+
+void SandstoneTestThread::start(RunnerFunction *f, int cpu)
+{
+    assert(check_run_from_correct_thread());
+
+    static SandstoneTestThreadAttributes thread_attributes;
+    auto runner = +[](void *ptr) {
+        auto self = static_cast<SandstoneTestThread *>(ptr);
+        ::thread_num = self->thread_num;
+        return reinterpret_cast<void *>(self->target(self->thread_num));
+    };
+
+    thread_num = cpu;
+    target = f;
+    pthread_create(&thread, &thread_attributes.thread_attr, runner, this);
+}
+
+uintptr_t SandstoneTestThread::join()
+{
+    void *result;
+    pthread_join(thread, &result);
+    return uintptr_t(result);
+}

--- a/framework/sandstone_thread.cpp
+++ b/framework/sandstone_thread.cpp
@@ -8,14 +8,20 @@
 
 #include "gettid.h"
 
+#include <sys/mman.h>
+
 namespace {
 struct SandstoneTestThreadAttributes
 {
+    static constexpr size_t GuardSize = 8192;
     pthread_attr_t thread_attr;
+    unsigned char *stacks_block;
     SandstoneTestThreadAttributes()
+        : stacks_block(allocate_stack_block())
     {
         pthread_attr_init(&thread_attr);
         pthread_attr_setstacksize(&thread_attr, THREAD_STACK_SIZE);
+
     }
     ~SandstoneTestThreadAttributes()
     {
@@ -23,8 +29,47 @@ struct SandstoneTestThreadAttributes
     }
     SandstoneTestThreadAttributes(const SandstoneTestThreadAttributes &) = delete;
     SandstoneTestThreadAttributes &operator=(const SandstoneTestThreadAttributes &) = delete;
+
+    static unsigned char *allocate_stack_block();
+    void update_with_stack_for(int cpu);
 };
 } // unnamed namespace
+
+#ifndef _WIN32
+unsigned char *SandstoneTestThreadAttributes::allocate_stack_block()
+{
+    size_t size = num_cpus() * (THREAD_STACK_SIZE + GuardSize);
+    void *map = mmap(nullptr, size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (map == MAP_FAILED)
+        return nullptr;
+
+    auto ptr = static_cast<unsigned char *>(map);
+    for (int i = 0; i < num_cpus(); ++i) {
+        ptr += GuardSize;
+        mprotect(ptr, THREAD_STACK_SIZE, PROT_READ | PROT_WRITE);
+        ptr += THREAD_STACK_SIZE;
+    }
+    return ptr;
+}
+
+void SandstoneTestThreadAttributes::update_with_stack_for(int cpu)
+{
+    if (!stacks_block)
+        return;
+    unsigned char *stacktop = stacks_block;
+    stacktop -= (THREAD_STACK_SIZE + GuardSize) * unsigned(cpu);
+    pthread_attr_setstack(&thread_attr, stacktop - THREAD_STACK_SIZE, THREAD_STACK_SIZE);
+}
+#else
+unsigned char *SandstoneTestThreadAttributes::allocate_stack_block()
+{
+    return nullptr;
+}
+void SandstoneTestThreadAttributes::update_with_stack_for(int)
+{
+}
+#endif
+
 
 [[maybe_unused]] static bool check_run_from_correct_thread()
 {
@@ -49,6 +94,7 @@ void SandstoneTestThread::start(RunnerFunction *f, int cpu)
 
     thread_num = cpu;
     target = f;
+    thread_attributes.update_with_stack_for(cpu);
     pthread_create(&thread, &thread_attributes.thread_attr, runner, this);
 }
 

--- a/framework/sandstone_thread.h
+++ b/framework/sandstone_thread.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SANDSTONE_THREAD
+#define SANDSTONE_THREAD
+
+#include <functional>
+
+#include <pthread.h>
+#include <stdint.h>
+
+struct SandstoneTestThread
+{
+    using RunnerFunction = uintptr_t (int);
+    void start(RunnerFunction *, int cpu);
+    uintptr_t join();
+
+    pthread_t thread;
+    RunnerFunction *target;
+    int thread_num;
+};
+
+#endif // SANDSTONE_THREAD

--- a/framework/sysdeps/darwin/gettid.h
+++ b/framework/sysdeps/darwin/gettid.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSDEPS_DARWIN_GETTID_H
+#define SYSDEPS_DARWIN_GETTID_H
+
+#include <pthread.h>
+#include <stdint.h>
+
+typedef uint64_t tid_t;
+
+static inline tid_t gettid()
+{
+    tid_t result;
+    pthread_threadid_np(NULL, &result);
+    return result;
+}
+
+#endif // SYSDEPS_DARWIN_GETTID_H

--- a/framework/sysdeps/freebsd/gettid.h
+++ b/framework/sysdeps/freebsd/gettid.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSDEPS_FREEBSD_GETTID_H
+#define SYSDEPS_FREEBSD_GETTID_H
+
+#include <sys/thr.h>
+
+typedef long tid_t;
+
+static inline tid_t gettid()
+{
+    tid_t result;
+    thr_self(&result);
+    return result;
+}
+
+#endif // SYSDEPS_FREEBSD_GETTID_H

--- a/framework/sysdeps/linux/gettid.h
+++ b/framework/sysdeps/linux/gettid.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSDEPS_LINUX_GETTID_H
+#define SYSDEPS_LINUX_GETTID_H
+
+#include <unistd.h>
+
+typedef pid_t tid_t;
+
+#if (__GLIBC__ * 10000 + __GLIBC_MINOR__) < 20030
+#  include <sys/syscall.h>
+static inline tid_t gettid()
+{
+    return syscall(SYS_gettid);
+}
+#endif
+
+#endif // SYSDEPS_LINUX_GETTID_H

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -12,6 +12,7 @@
 #include "sandstone_iovec.h"
 
 #include "futex.h"
+#include "gettid.h"
 
 #include <initializer_list>
 #include <limits>
@@ -43,13 +44,6 @@
 
 #ifdef __linux__
 #  include <sys/prctl.h>
-#  include <sys/syscall.h>
-
-typedef pid_t tid_t;
-static inline tid_t sys_gettid()
-{
-    return syscall(SYS_gettid);
-}
 
 // can't #include <asm/ucontext.h> because until glibc 2.26 it conflicted with
 // <sys/ucontext.h>, so:
@@ -94,7 +88,7 @@ struct CrashContext
     struct Fixed {
         pid_t pid = getpid();
 #ifdef __linux__
-        tid_t handle = sys_gettid();
+        tid_t handle = gettid();
 #else
         uintptr_t handle = reinterpret_cast<uintptr_t>(pthread_self());
 #endif

--- a/framework/sysdeps/windows/gettid.h
+++ b/framework/sysdeps/windows/gettid.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSDEPS_WIN32_GETTID_H
+#define SYSDEPS_WIN32_GETTID_H
+
+#include <windows.h>
+
+typedef DWORD tid_t;
+
+static inline tid_t gettid()
+{
+    return GetCurrentThreadId();
+}
+
+#endif // SYSDEPS_WIN32_GETTID_H


### PR DESCRIPTION
There are two reasons for this. First, it will allow us to randomise the stack addresses according to the fracture, replacing the code that was in `run_one_test()` and didn't do anything. Second, because it shows a performance improvement:

|  # Threads   | Before (µs)  |  After (µs)  |
|-------------:|-------------:|-------------:|
|            1 |        35950 |        33363 |
|           24 |        53527 |        53386 |
|           48 |        57227 |        55624 |
|           96 |        62519 |        59104 |
|          192 |        74021 |        67249 |

Subtracting the first line from all others:

<table>
<thead>
<tr>
<th rowspan=2># Threads</th>
<th colspan=2>Before (µs)</th>
<th colspan=2>After (µs)</th>
</tr>
<tr>
<th>Total</th>
<th>Per thread</th>
<th>Total</th>
<th>Per thread</th>
</tr>
</thead>
<tbody>
<tr>
<td align="right">23</td>
<td align="right">17576</td>
<td align="right">764</td>
<td align="right">20022</td>
<td align="right">871</td>
</tr>
<tr>
<td align="right">47</td>
<td align="right">21277</td>
<td align="right">453</td>
<td align="right">22261</td>
<td align="right">474</td>
</tr>
<tr>
<td align="right">95</td>
<td align="right">26568</td>
<td align="right">280</td>
<td align="right">25741</td>
<td align="right">271</td>
</tr>
<tr>
<td align="right">191</td>
<td align="right">38071</td>
<td align="right">199</td>
<td align="right">33886</td>
<td align="right">177</td>
</tr>
</tbody>
</table>

Even subtracting the overhead of starting a thread, the marginal cost of starting threads continues to decrease (I'm not sure why, I expected it to increase).

I also benchmarked not having guard pages, but that seems to trigger a perverse optimisation inside the kernel, at least in the machine I tested: it decided to offer 2 MB huge pages, but unfortunately that's slower to allocate.

Pre-faulting the top of the stack for each doesn't seem to help, because `pthread_create()` writes there anyway.
