### PR TITLE
FW: remove the useless code allocating random memory in run_one_test()

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1921,9 +1921,8 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
                 || (runtime >= sApp->current_test_duration))
             goto out;
 
-        // For improved randomization of addresses, we are going to do a random
-        // malloc between 0 and 4095 bytes. This also advances the random seed.
-        random_allocation.reset(new char[rand() & 4095]);
+        // Advance the random seed.
+        random_advance_seed();
     }
 
     /* now we process retries */


### PR DESCRIPTION
This code is running in the main thread and allocates less than a page, so it is served from the main thread's heap. That means this doesn't affect the stacks or heaps of any of the test threads, nor will it affect memory allocated by the tests' init() functions as that is also run in a separate thread since 4248649b550477eb299efcdbfd35be85bbb11657.

See #333 for a better solution for stacks.