### PR TITLE
FW/SharedMemory: remove hardcoded limit on MAX_THREADS

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1027,7 +1027,16 @@ static void attach_shmem(int fd)
 {
     assert(sApp->current_fork_mode() == SandstoneApplication::child_exec_each_test);
 
-    int size = ROUND_UP_TO_PAGE(sizeof(SandstoneApplication::SharedMemory));
+    size_t size;
+    if (struct stat st; fstat(fd, &st) >= 0) {
+        size = st.st_size;
+        assert(size == ROUND_UP_TO_PAGE(size));
+    } else {
+        fprintf(stderr, "internal error: could not get the size of shared memory (fd = %d): %m\n",
+                fd);
+        exit(EX_IOERR);
+    }
+
     void *base = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (base == MAP_FAILED) {
         perror("internal error: could not map the shared memory file to memory");

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1076,6 +1076,14 @@ static void attach_shmem(int fd)
     sApp->main_thread_data()->thread_state.exchange(thread_not_started, std::memory_order_acquire);
 }
 
+static void protect_shmem()
+{
+    size_t protected_len = sApp->shmem->thread_data_offset;
+    assert(protected_len == ROUND_UP_TO_PAGE(protected_len) &&
+            "SharedMemory::main_thread_data is not page-aligned");
+    mprotect(sApp->shmem, protected_len, PROT_READ);
+}
+
 __attribute__((weak, noclone, noinline)) void print_application_banner()
 {
 }
@@ -1477,6 +1485,7 @@ static ChildExitStatus wait_for_child(int ffd, intptr_t child, int *tc, const st
 static TestResult child_run(/*nonconst*/ struct test *test)
 {
     if (sApp->current_fork_mode() != SandstoneApplication::no_fork) {
+        protect_shmem();
         pin_to_logical_processor(LogicalProcessor(-1), "control");
         signals_init_child();
         debug_init_child();

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -988,8 +988,20 @@ static LogicalProcessorSet init_cpus()
     return result;
 }
 
+static void attach_shmem_internal()
+{
+    assert(sApp->shmem->thread_data_offset);
+
+    auto ptr = reinterpret_cast<unsigned char *>(sApp->shmem);
+    ptr += sApp->shmem->thread_data_offset;
+    sApp->main_thread_data_ptr = reinterpret_cast<PerThreadData::Main *>(ptr);
+    ptr += sizeof(*sApp->main_thread_data_ptr);
+    sApp->test_thread_data_ptr = reinterpret_cast<PerThreadData::Test *>(ptr);
+}
+
 static void init_shmem()
 {
+    using namespace PerThreadData;
     static_assert(sizeof(PerThreadData::Main) == 64,
             "PerThreadData::Main size grew, please check if it was intended");
     static_assert(sizeof(PerThreadData::Test) == 64,
@@ -1000,8 +1012,13 @@ static void init_shmem()
     LogicalProcessorSet enabled_cpus = init_cpus();
     assert(num_cpus());
 
-    size_t size = sizeof(PerThreadData::Test) * num_cpus() + sizeof(SandstoneApplication::SharedMemory);
-    size = ROUND_UP_TO_PAGE(size);
+    unsigned per_thread_size = sizeof(PerThreadData::Main);
+    per_thread_size = ROUND_UP_TO(per_thread_size, alignof(PerThreadData::Test));
+    per_thread_size += sizeof(PerThreadData::Test) * num_cpus();
+    per_thread_size = ROUND_UP_TO_PAGE(per_thread_size);
+
+    unsigned thread_data_offset = ROUND_UP_TO_PAGE(sizeof(SandstoneApplication::SharedMemory));
+    size_t size = thread_data_offset + per_thread_size;
 
     // our child (if we have one) will inherit this file descriptor
     int fd = open_memfd(MemfdInheritOnExec);
@@ -1018,7 +1035,9 @@ static void init_shmem()
 
     sApp->shmemfd = fd;
     sApp->shmem = new (base) SandstoneApplication::SharedMemory;
+    sApp->shmem->thread_data_offset = thread_data_offset;
     sApp->shmem->enabled_cpus = enabled_cpus;
+    attach_shmem_internal();
 }
 
 static void commit_shmem()
@@ -1051,9 +1070,10 @@ static void attach_shmem(int fd)
 
     close(fd);
     sApp->shmem = static_cast<SandstoneApplication::SharedMemory *>(base);
+    attach_shmem_internal();
 
     // barrier with the parent process
-    sApp->shmem->main_thread_data.thread_state.exchange(thread_not_started, std::memory_order_acquire);
+    sApp->main_thread_data()->thread_state.exchange(thread_not_started, std::memory_order_acquire);
 }
 
 __attribute__((weak, noclone, noinline)) void print_application_banner()

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -449,6 +449,8 @@ struct SandstoneApplication::SharedMemory
 
     LogicalProcessorSet enabled_cpus;
 
+    alignas(64) struct cpu_info cpu_info[];         // C99 Flexible Array Member
+
 #if 0
     // in/out per-thread data allocated dynamically;
     // layout is:

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -447,7 +447,7 @@ struct SandstoneApplication::SharedMemory
 
     // in/out per-thread data
     PerThreadData::Main main_thread_data;
-    PerThreadData::Test per_thread[MAX_THREADS];
+    PerThreadData::Test per_thread[];          // C99 Flexible Array Member
 };
 
 inline SandstoneApplication *_sApp() noexcept

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -447,8 +447,7 @@ struct SandstoneApplication::SharedMemory
     int child_debug_socket = -1;
 #endif
 
-    LogicalProcessorSet enabled_cpus;
-
+    int total_cpu_count = 0;
     alignas(64) struct cpu_info cpu_info[];         // C99 Flexible Array Member
 
 #if 0

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -670,8 +670,7 @@ void apply_cpuset_param(char *param)
     std::vector<struct cpu_info> new_cpu_info;
     int total_matches = 0;
 
-    LogicalProcessorSet &result = sApp->shmem->enabled_cpus;
-    result.clear();
+    LogicalProcessorSet result = {};
     new_cpu_info.reserve(old_cpu_info.size());
 
     for (char *arg = strtok(param, ","); arg; arg = strtok(nullptr, ",")) {

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -784,11 +784,8 @@ void apply_cpuset_param(char *param)
 
 static void init_topology_internal(const LogicalProcessorSet &enabled_cpus)
 {
-    sApp->thread_count = enabled_cpus.count();
-    assert(sApp->thread_count);
-
-    delete[] cpu_info;
-    cpu_info = new struct cpu_info[sApp->thread_count];
+    assert(sApp->thread_count == enabled_cpus.count());
+    cpu_info = sApp->shmem->cpu_info;
 
     if (SandstoneConfig::Debug) {
         static auto mock_topology = create_mock_topology(getenv("SANDSTONE_MOCK_TOPOLOGY"));
@@ -909,8 +906,7 @@ void init_topology(const LogicalProcessorSet &enabled_cpus)
 void restrict_topology(CpuRange range)
 {
     assert(range.starting_cpu + range.cpu_count <= sApp->thread_count);
-    std::move(cpu_info + range.starting_cpu, cpu_info + range.starting_cpu + range.cpu_count,
-              cpu_info);
+    cpu_info = sApp->shmem->cpu_info + range.starting_cpu;
     sApp->thread_count = range.cpu_count;
 
     cached_topology() = build_topology();


### PR DESCRIPTION
This moves the `cpu_info` array into the shared memory segment as a dynamically-sized C99 Flexible Array Member. That way, the children processes (in exec mode) won't have to re-inspect the system again to find the topology.

In order to insert it, we moved the per-thread data to a dynamic offset in the segment, aligned to a page. This layout will change again, once we support multiple main threads. But the advantage of making it dynamic is that we don't have to depend on `MAX_THREADS` any more, thereby we remove the second-to-last instance of this use (see #317 for the last).

This moves the `enabled_cpus` bitset off the shared memory segment, as we don't need it any more.