### PR TITLE
FW/Topology: fix the use of --cpuset out of order

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1262,12 +1262,12 @@ function selftest_cpuset() {
     shift 4
 
     declare -A yamldump
-    sandstone_selftest -vvv -e selftest_pass "$@"
+    sandstone_selftest -vvv -e selftest_skip "$@"
     [[ "$status" -eq 0 ]]
-    test_yaml_numeric "/tests/0/threads/1/id/logical" "value == $expected_logical"
-    test_yaml_numeric "/tests/0/threads/1/id/package" "value == $expected_package"
-    test_yaml_numeric "/tests/0/threads/1/id/core" "value == $expected_core"
-    test_yaml_numeric "/tests/0/threads/1/id/thread" "value == $expected_thread"
+    test_yaml_numeric "/cpu-info/0/logical" "value == $expected_logical"
+    test_yaml_numeric "/cpu-info/0/package" "value == $expected_package"
+    test_yaml_numeric "/cpu-info/0/core" "value == $expected_core"
+    test_yaml_numeric "/cpu-info/0/thread" "value == $expected_thread"
 }
 
 @test "cpuset=number (first)" {

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1296,6 +1296,41 @@ function selftest_cpuset() {
         --cpuset=p${cpuinfo[1]}c${cpuinfo[2]}t${cpuinfo[3]}
 }
 
+selftest_cpuset_unsorted() {
+    local MAX_PROC=`nproc`
+    local cpuset=$1
+    shift
+    declare -A yamldump
+    sandstone_selftest -e selftest_skip --cpuset="$cpuset"
+    [[ "$status" -eq 0 ]]
+
+    # Get all the processor numbers
+    i=0
+    for expected_logical in `$SANDSTONE --dump-cpu-info | awk '/^[0-9]/ { print $1; }'`; do
+        test_yaml_numeric "/cpu-info/$i/logical" "value == $expected_logical"
+        i=$((i + 1))
+    done
+}
+
+@test "cpuset=number (inverse order)" {
+    # make a list in inverse order
+    local -a cpuset=($($SANDSTONE --dump-cpu-info | tac |
+                           awk '/^[0-9]/ { printf "%d,", $1; }'))
+    cpuset=${cpuset%,}          # remove last comma
+
+    selftest_cpuset_unsorted "$cpuset" "${cpuinfo[@]}"
+}
+
+@test "cpuset=number (inverse sorted order)" {
+    # sort the CPU list by package, then core then thread
+    # This differs from the above on Linux, on hyperthreaded machines
+    local -a cpuset=($($SANDSTONE --dump-cpu-info | sort -rnk2,3 |
+                           awk '/^[0-9]/ { printf "%d,", $1; }'))
+    cpuset=${cpuset%,}          # remove last comma
+
+    selftest_cpuset_unsorted "$cpuset" "${cpuinfo[@]}"
+}
+
 # Confirm that we are roughly using the threads we said we would
 @test "thread usage" {
     local -a cpuset=(`$SANDSTONE --dump-cpu-info | awk '/^[0-9]/ { print $1 }'`)

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -155,7 +155,7 @@ static linux_cpu_info &proc_cpuinfo()
 }
 #endif
 
-static void reorder_cpus()
+static bool cpu_compare(const struct cpu_info &cpu1, const struct cpu_info &cpu2)
 {
     static auto cpu_tuple = [](const struct cpu_info &c) {
         uint64_t h = (uint64_t(c.package_id) << 32) +
@@ -165,9 +165,11 @@ static void reorder_cpus()
         return std::make_tuple(h, l);
     };
 
-    auto cpu_compare = [](const struct cpu_info &cpu1, const struct cpu_info &cpu2) {
-        return cpu_tuple(cpu1) < cpu_tuple(cpu2);
-    };
+    return cpu_tuple(cpu1) < cpu_tuple(cpu2);
+};
+
+static void reorder_cpus()
+{
     std::sort(cpu_info, cpu_info + num_cpus(), cpu_compare);
 }
 
@@ -697,7 +699,8 @@ void apply_cpuset_param(char *param)
             LogicalProcessor lp = LogicalProcessor(cpu.cpu_number);
             if (!result.is_set(lp)) {
                 result.set(lp);
-                new_cpu_info.push_back(cpu);
+                auto it = std::lower_bound(new_cpu_info.begin(), new_cpu_info.end(), cpu, cpu_compare);
+                new_cpu_info.insert(it, cpu);
                 ++total_matches;
             }
         };


### PR DESCRIPTION
Commit 5027ab76b4614e8d42a48487ae463c4935dfdeea (PR #327) made apply_cpuset_param() create a new array of `cpu_info`, but we didn't ensure it was sorted like it needed to be.

I could just call `reorder_cpus()` again, but everyone knows that `std::sort` is asymptotically O(n log n), while inserting while keeping the list sorted is O(log n) (though we're iterating over n elements, so the whole function is still O(n log n); oh well).