### PR TITLE
FW: fix initialize_smi_counts() when not running over the full system

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -811,7 +811,7 @@ static void initialize_smi_counts()
     sApp->smi_counts_start.resize(num_cpus());
     sApp->smi_counts_start[0] = *v;
     for (int i = 1; i < num_cpus(); i++)
-        sApp->smi_counts_start[cpu_info[i].cpu_number] = sApp->count_smi_events(cpu_info[i].cpu_number).value_or(0);
+        sApp->smi_counts_start[i] = sApp->count_smi_events(cpu_info[i].cpu_number).value_or(0);
 }
 
 static void cleanup_internal(const struct test *test)


### PR DESCRIPTION
Because then we may run on an OS logical processor whose number is greater than the number of threads we're running on (e.g., --cpuset=1 will trigger this). This also fixes the reporting in `smi_count_run()`, which expected the array to be indexed by the internal thread number.

Found by ASan in the internal CI (which runs ASan as root on bare hardware):
```
==67==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000000970 at pc 0x55de9aa88dbe bp 0x7fffce5b6080 sp 0x7fffce5b6078
WRITE of size 8 at 0x603000000970 thread T0
    #0 0x55de9aa88dbd in initialize_smi_counts ../opendcdiag/framework/sandstone.cpp:825
    #1 0x55de9aa88dbd in main ../opendcdiag/framework/sandstone.cpp:3704
    #2 0x7f745a5a7b49 in __libc_start_call_main (/lib64/libc.so.6+0x27b49) (BuildId: 245240a31888ad5c11bbc55b18e02d87388f59a9)
    #3 0x7f745a5a7c0a in __libc_start_main_alias_2 (/lib64/libc.so.6+0x27c0a) (BuildId: 245240a31888ad5c11bbc55b18e02d87388f59a9)
    #4 0x55de9aa9b644 in _start

0x603000000970 is located 736 bytes after 32-byte region [0x603000000670,0x603000000690)
allocated by thread T0 here:
    #0 0x7f745aeb3778 in operator new(unsigned long) (/usr/local/lib64/libasan.so.8+0xda778) (BuildId: 7575ba3f185be32f1b25b3eba3743f94c99844e8)
    #1 0x55de9ab0f418 in std::__new_allocator<unsigned long>::allocate(unsigned long, void const*) /usr/local/include/c++/13/bits/new_allocator.h:147
    #2 0x55de9ab0f418 in std::allocator<unsigned long>::allocate(unsigned long) /usr/local/include/c++/13/bits/allocator.h:198
    #3 0x55de9ab0f418 in std::allocator_traits<std::allocator<unsigned long> >::allocate(std::allocator<unsigned long>&, unsigned long) /usr/local/include/c++/13/bits/alloc_traits.h:482
    #4 0x55de9ab0f418 in std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_M_allocate(unsigned long) /usr/local/include/c++/13/bits/stl_vector.h:378
    #5 0x55de9ab0f418 in std::vector<unsigned long, std::allocator<unsigned long> >::_M_default_append(unsigned long) /usr/local/include/c++/13/bits/vector.tcc:663
    #6 0x55de9aa878a1 in std::vector<unsigned long, std::allocator<unsigned long> >::resize(unsigned long) /usr/local/include/c++/13/bits/stl_vector.h:1011
    #7 0x55de9aa878a1 in initialize_smi_counts ../opendcdiag/framework/sandstone.cpp:822
    #8 0x55de9aa878a1 in main ../opendcdiag/framework/sandstone.cpp:3704
    #9 0x7f745a5a7b49 in __libc_start_call_main (/lib64/libc.so.6+0x27b49) (BuildId: 245240a31888ad5c11bbc55b18e02d87388f59a9)
    #10 0x7f745a5a7c0a in __libc_start_main_alias_2 (/lib64/libc.so.6+0x27c0a) (BuildId: 245240a31888ad5c11bbc55b18e02d87388f59a9)
    #11 0x55de9aa9b644 in _start
```
