### PR TITLE
CI/Bats: don't run the crashing test with ASan

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -194,6 +194,10 @@ tap_negative_check() {
 }
 
 @test "TAP output crash" {
+    if $is_asan; then
+        skip "Crashing tests skipped with ASAN"
+    fi
+
     # not all tests
     local -a crashtests=(selftest_abortinit selftest_abort selftest_sigsegv)
     if $is_windows; then


### PR DESCRIPTION
It's not that don't crash, it's that ASan prints more stuff that we don't want. Found by the internal CI running ASan:
```
not ok 7 TAP output crash
# (in test file 20-selftests.bats, line 220)
#   `tap_negative_check "$test" ' (Killed|Core Dumped):.*'' failed
# bad line: AddressSanitizer:DEADLYSIGNAL
```