### PR TITLE
FW/Win32: Provide C++ operators new and delete

### DIFF
--- a/framework/sysdeps/windows/aligned_alloc.cpp
+++ b/framework/sysdeps/windows/aligned_alloc.cpp
@@ -10,6 +10,9 @@
 #include <string.h>
 
 #include <sandstone_p.h>
+
+#include <new>
+
 #include <windows.h>
 
 #define DEFAULT_ALIGNMENT       2*__alignof(void *)
@@ -127,3 +130,137 @@ char *strndup(const char *str, size_t n)
     return newstr;
 }
 } // extern "C"
+
+// Provide C++ operators new and delete. For each overload, there should be
+// three functions: the operator new, the (old) unsized operator delete and the
+// C++14 sized deallocation. We provide that even if __cpp_sized_deallocation
+// isn't defined.
+
+// regular new and delete
+void *operator new(size_t size)
+{
+    return aligned_alloc(DEFAULT_ALIGNMENT, size);
+}
+
+void operator delete(void *ptr) noexcept
+{
+    free(ptr);
+}
+
+void operator delete(void *ptr, size_t) noexcept
+{
+    free(ptr);
+}
+
+// array new and delete
+void *operator new[](size_t size)
+{
+    return operator new(size);
+}
+
+void operator delete[](void *ptr) noexcept
+{
+    free(ptr);
+}
+
+void operator delete[](void *ptr, size_t) noexcept
+{
+    free(ptr);
+}
+
+// aligning new and delete
+void *operator new(size_t size, std::align_val_t alignment)
+{
+    return aligned_alloc(size_t(alignment), size);
+}
+
+void operator delete(void *ptr, std::align_val_t) noexcept
+{
+    free(ptr);
+}
+
+void operator delete(void *ptr, size_t, std::align_val_t) noexcept
+{
+    free(ptr);
+}
+
+// array, aligning new and delete
+void *operator new[](size_t size, std::align_val_t alignment)
+{
+    return operator new(size, alignment);
+}
+
+void operator delete[](void *ptr, std::align_val_t) noexcept
+{
+    free(ptr);
+}
+
+void operator delete[](void *ptr, size_t, std::align_val_t) noexcept
+{
+    free(ptr);
+}
+
+// nothrow new and delete
+// (the compiler never generates calls to the nothrow delete)
+void *operator new(size_t size, std::nothrow_t) noexcept
+{
+    return operator new(size);
+}
+
+void operator delete(void *ptr, std::nothrow_t) noexcept
+{
+    free(ptr);
+}
+
+void operator delete(void *ptr, size_t, std::nothrow_t) noexcept
+{
+    free(ptr);
+}
+
+// nothrow array new and delete
+void *operator new[](size_t size, std::nothrow_t) noexcept
+{
+    return operator new(size);
+}
+
+void operator delete[](void *ptr, std::nothrow_t) noexcept
+{
+    free(ptr);
+}
+
+void operator delete[](void *ptr, size_t, std::nothrow_t) noexcept
+{
+    free(ptr);
+}
+
+// nothrow aligning new and delete
+void *operator new(size_t size, std::align_val_t alignment, std::nothrow_t) noexcept
+{
+    return operator new(size, alignment);
+}
+
+void operator delete(void *ptr, std::align_val_t, std::nothrow_t) noexcept
+{
+    free(ptr);
+}
+
+void operator delete(void *ptr, size_t, std::align_val_t, std::nothrow_t) noexcept
+{
+    free(ptr);
+}
+
+// nothrow array, aligning new and delete
+void *operator new[](size_t size, std::align_val_t alignment, std::nothrow_t) noexcept
+{
+    return operator new(size, alignment);
+}
+
+void operator delete[](void *ptr, std::align_val_t, std::nothrow_t) noexcept
+{
+    free(ptr);
+}
+
+void operator delete[](void *ptr, size_t, std::align_val_t, std::nothrow_t) noexcept
+{
+    free(ptr);
+}

--- a/framework/sysdeps/windows/aligned_alloc.cpp
+++ b/framework/sysdeps/windows/aligned_alloc.cpp
@@ -113,15 +113,15 @@ void free(void *ptr)
 
 char *strdup(const char *str)
 {
-    char *newstr = malloc(strlen(str) + 1);
-    return memcpy(newstr, str, strlen(str) + 1);
+    auto newstr = static_cast<char *>(malloc(strlen(str) + 1));
+    return static_cast<char *>(memcpy(newstr, str, strlen(str) + 1));
 }
 
 char *strndup(const char *str, size_t n)
 {
     size_t len = strnlen(str, n);
-    char *newstr = malloc(len + 1);
-    newstr = memcpy(newstr, str, len);
+    auto newstr = static_cast<char *>(malloc(len + 1));
+    newstr = static_cast<char *>(memcpy(newstr, str, len));
     newstr[len] = '\0';
     return newstr;
 }

--- a/framework/sysdeps/windows/aligned_alloc.cpp
+++ b/framework/sysdeps/windows/aligned_alloc.cpp
@@ -84,7 +84,7 @@ void *calloc(size_t n, size_t size)
 size_t aligned_msize(void *ptr)
 {
     if (ptr) {
-	return _msize(((void**)ptr)[-1]) - DEFAULT_ALIGNMENT - sizeof(void*) + 1;
+        return _msize(((void**)ptr)[-1]) - DEFAULT_ALIGNMENT - sizeof(void*) + 1;
     }
     return 0;
 }

--- a/framework/sysdeps/windows/aligned_alloc.cpp
+++ b/framework/sysdeps/windows/aligned_alloc.cpp
@@ -32,6 +32,7 @@ static inline void *check_null_pointer(void *ptr)
     return ptr;
 }
 
+extern "C" {
 void *aligned_alloc(size_t alignment, size_t size)
 {
 #ifdef _UCRT
@@ -125,3 +126,4 @@ char *strndup(const char *str, size_t n)
     newstr[len] = '\0';
     return newstr;
 }
+} // extern "C"

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -3,7 +3,7 @@
 
 framework_files += \
     files(
-        'aligned_alloc.c',
+        'aligned_alloc.cpp',
         'child_debug.cpp',
         'cpu_affinity.cpp',
         'fcntl.c',


### PR DESCRIPTION
The ones in libstdc++ do call `malloc` and `aligned_alloc` and other suitable functions we do provide. However, on Windows, that only works if you link statically to libstdc++.a. If you're using libstdc++6.dll, the already-linked DLL will instead go to the runtime (either MSVCRT or UCRT), bypassing our allocating and zeroing functions.

All the functions in this file are the same because we never throw and never return null pointers.
