### PR TITLE
simd.conf: update to Instruction Extensions manual release 049, AVX10 and APX

### DIFF
--- a/framework/simd.conf
+++ b/framework/simd.conf
@@ -80,6 +80,9 @@ amx-bf16		Leaf07_00EDX	    22	amx-tile	# AMX Tile multiplication in BFloat16
 avx512fp16		Leaf07_00EDX	    23	avx512f,f16c	# AVX512 16-bit Floating Point
 amx-tile		Leaf07_00EDX	    24		# Advanced Matrix Extensions Tile support
 amx-int8		Leaf07_00EDX	    25	amx-tile	# AMX Tile multiplication for Int8
+sha512			Leaf07_01EAX	    0	avx	# SHA-512 instructions
+#sm3			Leaf07_01EAX	    1	avx	# SM3 instructions
+#sm4			Leaf07_01EAX	    2	avx	# SM4 instructions
 raoint			Leaf07_01EAX	    3		# Remote Atomic Operations, Integer
 avxvnni			Leaf07_01EAX	    4	avx	# AVX (VEX-encoded) versions of the Vector Neural Network Instructions
 avx512bf16		Leaf07_01EAX	    5	avx512f	# AVX512 Brain Float16
@@ -92,14 +95,16 @@ cmpccxadd		Leaf07_01EAX	    6		# CMPccXADD instructions
 amx-fp16		Leaf07_01EAX	    21	amx-tile	# AMX Tile multiplication in FP16
 avxifma			Leaf07_01EAX	    23	avx	# AVX-IFMA instructions
 #lam			Leaf07_01EAX	    26		# Linear Address Masking
+#pbndkb			Leaf07_01EBX	    1		# Total Storage Encryption (TSE) instruction PBNDKB
 avxvnniint8		Leaf07_01EDX	    4	avx	# AVX Vector Neural Network Instructions, Int8
 avxneconvert		Leaf07_01EDX	    5	avx	# AVX Non-Exception BF16/FP16/FP32 Conversion instructions
-amx-complex		Leaf07_01EDX	    8	amx-tile	# AMX Complex Matrix multiplication
+#amx-complex		Leaf07_01EDX	    8	amx-tile	# AMX Complex Matrix multiplication
+avxvnniint16		Leaf07_01EDX	    10	avx	# AVX Vector Neural Network Instruction, Int16
 #prefetchiti		Leaf07_01EDX	    14		# PREFETCHIT0/1 instructions
 #xsaveopt		Leaf13_01EAX	    0		# Optimized XSAVE
-xsavec			Leaf13_01EAX	    1		# XSAVE with Compaction
+#xsavec			Leaf13_01EAX	    1		# XSAVE with Compaction
 #xgetbv1		Leaf13_01EAX	    2		# XGETBV with ECX=1
-xsaves			Leaf13_01EAX	    3		# XSAVE Supervisor mode
+#xsaves			Leaf13_01EAX	    3		# XSAVE Supervisor mode
 #xfd			Leaf13_01EAX	    4		# eXtended Feature Disable MSR
 lzcnt			Leaf80000001hECX    5		# Leading Zero Count
 
@@ -153,15 +158,15 @@ arch=CPX	CLX	avx512bf16
 arch=PLC	SKX	avx512ifma,avx512vbmi #sha
 arch=SNC	PLC	avx512vbmi2,gfni,vaes,vpclmulqdq,avx512vnni,avx512bitalg,avx512vpopcntdq,fsrm #rdpid
 arch=WLC	SNC	shstk,movdiri,movdir64b,ibt,keylocker		# avx512vp2intersect
-arch=GLC	WLC	avx512bf16,avxvnni,cldemote,waitpkg,serialize,uintr	# tsxldtrk
+arch=GLC	WLC	avx512bf16,avxvnni,cldemote,waitpkg,serialize,uintr	# pks,tsxldtrk
 arch=RPC	GLC
 arch=RWC	RPC	prefetchiti
   # Atom line
 arch=SLM	WSM	rdrnd,movbe
 arch=GLM	SLM	fsgsbase,rdseed,lzcnt,xsavec,xsaves
 arch=TNT	GLM	clwb,gfni,cldemote,waitpkg,movdiri,movdir64b
-arch=GRT	SKL	avxvnni,gfni,vaes,vpclmulqdq,serialize,shstk,cldemote,movdiri,movdir64b,ibt,waitpkg,keylocker # rdpid
-arch=CMT	GRT	cmpccxadd,avxifma,avxneconvert,avxvnniint8
+arch=GRT	SKL	avxvnni,gfni,vaes,vpclmulqdq,serialize,shstk,cldemote,movdiri,movdir64b,ibt,waitpkg,keylocker # pks,rdpid
+arch=CMT	GRT	cmpccxadd,lam,avxifma,avxneconvert,avxvnniint8,uintr
   # Xeon Phi line
 #arch=KNL	SKL		avx512f,avx512er,avx512pf,avx512cd
 #arch=KNM	KNL		avx5124fmaps,avx5124vnniw,avx512vpopcntdq
@@ -173,12 +178,12 @@ arch=ADL	GRT
 arch=RPL	GRT
 arch=MTL	CMT
 arch=ARL	CMT
-arch=LNL	CMT
+arch=LNL	CMT	avxvnniint16,pbndkb	# sha512,sm3,sm4
 arch=ICX	SNC	pconfig
-arch=SPR	GLC	pconfig,amx-tile,amx-bf16,amx-int8
+arch=SPR	GLC	pconfig,amx-tile,amx-bf16,amx-int8	# enqcmd
 arch=EMR	SPR
-arch=GNR	GLC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16,amx-complex
-arch=SRF	CMT	cmpccxadd,avxifma,avxneconvert,avxvnniint8
+arch=GNR	GLC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16	# amx-complex
+arch=SRF	CMT	cmpccxadd,avxifma,avxneconvert,avxvnniint8	# enqcmd
 arch=GRR	SRF	raoint
 arch=CWF	SRF
   # Longer names

--- a/framework/simd.conf
+++ b/framework/simd.conf
@@ -102,6 +102,7 @@ avxneconvert		Leaf07_01EDX	    5	avx	# AVX Non-Exception BF16/FP16/FP32 Conversi
 avxvnniint16		Leaf07_01EDX	    10	avx	# AVX Vector Neural Network Instruction, Int16
 #prefetchiti		Leaf07_01EDX	    14		# PREFETCHIT0/1 instructions
 #avx10			Leaf07_01EDX	    19	avx	# AVX10 Converged Vector ISA
+#apx-f			Leaf07_01EDX	    21		# Advanced Performance Extensions
 #xsaveopt		Leaf13_01EAX	    0		# Optimized XSAVE
 #xsavec			Leaf13_01EAX	    1		# XSAVE with Compaction
 #xgetbv1		Leaf13_01EAX	    2		# XGETBV with ECX=1
@@ -136,6 +137,7 @@ xsave=UintrState	0x4000			uintr	# User Interrupts
 xsave=HwpState		0x10000				# Hardware P-State
 xsave=Xtilecfg		0x20000				# AMX: XTILECFG register
 xsave=Xtiledata		0x40000				# AMX: data in the tiles
+xsave=ApxState		0x80000			apx	# APX Extended GPRs
 xsave=AvxState		SseState|Ymm_Hi128	avx,avx512f
 xsave=MPXState		Bndregs|Bndcsr		mpx
 xsave=Avx512State	AvxState|OpMask|Zmm_Hi256|Hi16_Zmm	avx512f

--- a/framework/simd.conf
+++ b/framework/simd.conf
@@ -101,11 +101,16 @@ avxneconvert		Leaf07_01EDX	    5	avx	# AVX Non-Exception BF16/FP16/FP32 Conversi
 #amx-complex		Leaf07_01EDX	    8	amx-tile	# AMX Complex Matrix multiplication
 avxvnniint16		Leaf07_01EDX	    10	avx	# AVX Vector Neural Network Instruction, Int16
 #prefetchiti		Leaf07_01EDX	    14		# PREFETCHIT0/1 instructions
+#avx10			Leaf07_01EDX	    19	avx	# AVX10 Converged Vector ISA
 #xsaveopt		Leaf13_01EAX	    0		# Optimized XSAVE
 #xsavec			Leaf13_01EAX	    1		# XSAVE with Compaction
 #xgetbv1		Leaf13_01EAX	    2		# XGETBV with ECX=1
 #xsaves			Leaf13_01EAX	    3		# XSAVE Supervisor mode
 #xfd			Leaf13_01EAX	    4		# eXtended Feature Disable MSR
+#avx10_version		Leaf24_00ECX	    0-7		# AVX10 version number
+#avx10_128		Leaf24_00ECX	    16		# 128-bit AVX10
+#avx10_256		Leaf24_00ECX	    17		# 256-bit AVX10
+#avx10_512		Leaf24_00ECX	    18		# 512-bit AVX10
 lzcnt			Leaf80000001hECX    5		# Leading Zero Count
 
 # XSAVE states
@@ -160,7 +165,7 @@ arch=SNC	PLC	avx512vbmi2,gfni,vaes,vpclmulqdq,avx512vnni,avx512bitalg,avx512vpop
 arch=WLC	SNC	shstk,movdiri,movdir64b,ibt,keylocker		# avx512vp2intersect
 arch=GLC	WLC	avx512bf16,avxvnni,cldemote,waitpkg,serialize,uintr	# pks,tsxldtrk
 arch=RPC	GLC
-arch=RWC	RPC	prefetchiti
+arch=RWC	RPC	avx10,prefetchiti
   # Atom line
 arch=SLM	WSM	rdrnd,movbe
 arch=GLM	SLM	fsgsbase,rdseed,lzcnt,xsavec,xsaves
@@ -182,7 +187,7 @@ arch=LNL	CMT	avxvnniint16,pbndkb	# sha512,sm3,sm4
 arch=ICX	SNC	pconfig
 arch=SPR	GLC	pconfig,amx-tile,amx-bf16,amx-int8	# enqcmd
 arch=EMR	SPR
-arch=GNR	GLC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16	# amx-complex
+arch=GNR	RWC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16	# amx-complex
 arch=SRF	CMT	cmpccxadd,avxifma,avxneconvert,avxvnniint8	# enqcmd
 arch=GRR	SRF	raoint
 arch=CWF	SRF


### PR DESCRIPTION
New instruction sets in the 049 release:
* avxvnniint16, for Arrow Lake S (ARL-S) and Lunar Lake (LNL)
* sha512, ditto
* sm3 and sm4, ditto
* pbndkb, for Lunar Lake (LNL)

Updated instruction sets in this release:
* amx-complex, to Granite Rapids-D (so marked optional for GNR)
* enqcmd, added to Sierra Forest and Grand Ridge
* serialize, ditto
* avxvnni, ditto
* pks, added to Alder Lake (ADL)
* lam, added to SRF, GRR, ARL and LNL
* cmpccxadd, added to Arrow Lake (ARL) and Lunar Lake (LNL)
* avxifma, ditto
* avxneconvert, ditto
* avxvnniint8, ditto

Like the sha, aes and pclmulqdq instructions before, I'm leaving the SHA512 and SM3/SM4 extensions as optional. I've left `enqcmd` optional for Sapphire Rapids, Sierra Forest and Grand Ridge, since that instruction is used to communicating with off-core accelerators. I've also left the `pks` extension optional because it appears to be OS-controlled (my Alder Lake workstation doesn't report it).

The additions to ARL, LNL, SRF and GRR make them all have the same feature sets, meaning they're probably from the Crestmont Atom core and are matched on the P-core "Cove" that the hybrid processor will have (probably the one after RWC but I haven't seen its name announced).

This PR also adds the detection for AVX10 and APX. The APX Foundation bit is easy; AVX10 will require more work, with an update to the perl script generator whenever we actually come to need those bits. In particular, the version number is a number, not a bitfield.