### PR TITLE
FW: allow min == max in ParseIntArgument

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2756,7 +2756,7 @@ template <typename Integer = int> struct ParseIntArgument
     {
         assert(name);
         assert(arg);
-        assert(min < max);
+        assert(min <= max);
         assert(Integer(min) == min);
         assert(Integer(max) == max);
 


### PR DESCRIPTION
Otherwise you can't pass -n1 for a 1-thread system.