### PR TITLE
FW/Logging: check the message counter before fstat()ing the log file

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -573,7 +573,7 @@ selftest_pass() {
        skip "Not supported"
     fi
     declare -A yamldump
-    sandstone_selftest -vvv -e selftest_logs_options
+    sandstone_selftest -vvv --max-messages=0 -e selftest_logs_options
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/result" pass
@@ -582,7 +582,7 @@ selftest_pass() {
     test_yaml_absent "/tests/0/test-options"
 
     # but there should be if we set something
-    sandstone_selftest -vvv -e selftest_logs_options -O dummy=dummy
+    sandstone_selftest -vvv --max-messages=0 -e selftest_logs_options -O dummy=dummy
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/result" pass
@@ -593,7 +593,7 @@ selftest_pass() {
     test_yaml_numeric "/tests/0/threads/0/messages@len" "value == 1"
     test_yaml_regexp "/tests/0/threads/0/messages/0/text" '.*StringValue = DefaultValue'
 
-    sandstone_selftest -vvv -e selftest_logs_options \
+    sandstone_selftest -vvv --max-messages=0 -e selftest_logs_options \
                        -O selftest_logs_options.NullStringValue=0x1 \
                        -O selftest_logs_options.UIntValue=0x1 \
                        -O selftest_logs_options.IntValue=0x1001

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2369,12 +2369,15 @@ void YamlLogger::print()
 
     logging_flush();
 
-    struct mmap_region main_mmap = mmap_file(sApp->main_thread_data()->log_fd);
-    if (main_mmap.size && sApp->shmem->log_test_knobs) {
-        int count = print_test_knobs(file_log_fd, main_mmap);
-        if (count && real_stdout_fd != file_log_fd
-                && sApp->shmem->verbosity >= UsedKnobValueLoggingLevel)
-            print_test_knobs(real_stdout_fd, main_mmap);
+    if (sApp->shmem->log_test_knobs) {
+        struct mmap_region main_mmap = mmap_file(sApp->main_thread_data()->log_fd);
+        if (main_mmap.size) {
+            int count = print_test_knobs(file_log_fd, main_mmap);
+            if (count && real_stdout_fd != file_log_fd
+                    && sApp->shmem->verbosity >= UsedKnobValueLoggingLevel)
+                print_test_knobs(real_stdout_fd, main_mmap);
+            munmap_file(main_mmap);
+        }
     }
 
     // print the thread messages

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1086,6 +1086,7 @@ void logging_finish()
 LoggingStream logging_user_messages_stream(int thread_num, int level)
 {
     LoggingStream stream(sApp->thread_data(thread_num)->log_fd);
+    sApp->thread_data(thread_num)->messages_logged.fetch_add(1, std::memory_order_relaxed);
     uint8_t code = message_code(UserMessages, level);
     stream.write(code);
     return stream;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1478,7 +1478,6 @@ static TestResult child_run(/*nonconst*/ struct test *test)
             break;
         }
 
-        logging_flush();
         run_threads(test);
 
         if (sApp->shmem->use_strict_runtime && wallclock_deadline_has_expired(sApp->endtime)){


### PR DESCRIPTION
This allows us to avoid a system call per thread, per test. However fast those system calls are (and they are fast on Linux), they add up. Here's a benchmark of the runtime of 1000 x selftest_skip in microseconds, divided by the number of threads that would have been started, with the cost of 1 of them subtracted:

| # threads  |   Before   |   After    |
| ---------: | ---------: | ---------: |
|         24 |       1.92 |       0.65 |
|         48 |       1.60 |       0.62 |
|         96 |       1.50 |       0.98 |
|        192 |       1.48 |       0.70 |

That would seem to indicate the cost of this system call is between 0.5 and 1.2 µs. The gain on Windows may be considerably bigger.

This can also be seen with selftest_pass under the same conditions, though the cost of starting the threads dwarfs the gain:

| # threads  |   Before   |   After    |
| ---------: | ---------: | ---------: |
|         24 |      37.37 |      36.94 |
|         48 |      34.06 |      33.60 |
|         96 |      32.96 |      32.56 |
|        192 |      39.78 |      38.31 |

Finally, for selftest_logs, to show that this isn't causing a meaningful regression when the test does log:

| # threads  |   Before   |   After    |
| ---------: | ---------: | ---------: |
|         24 |      50.47 |      49.85 |
|         48 |      44.95 |      44.76 |
|         96 |      42.84 |      42.94 |
|        192 |      49.12 |      49.71 |

That's between 99.7 and 101.2%.

Note: 192 threads means both sockets / NUMA domains were tested.
