### PR TITLE
FW/Topology: simplify the Topology class and functions

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1789,10 +1789,8 @@ static void analyze_test_failures(int tc, const struct test *test, int fail_coun
             Topology::Package *pkg = &topology.packages[p];
             for (size_t c = 0; c < pkg->cores.size(); ++c) {
                 Topology::Core *core = &pkg->cores[c];
-                for (const Topology::Thread *thr : core->threads) {
-                    if (!thr)
-                        continue;
-                    if (per_cpu_failures[thr->cpu()] && (pkg_failures[p] == -1)) {
+                for (const Topology::Thread &thr : core->threads) {
+                    if (per_cpu_failures[thr.cpu()] && (pkg_failures[p] == -1)) {
                         last_bad_package = pkg->id;
                         failed_packages++;
                         pkg_failures[p] = pkg->id;
@@ -1820,10 +1818,8 @@ static void analyze_test_failures(int tc, const struct test *test, int fail_coun
                 bool all_threads_failed_equally = true;
                 int nthreads = 0;
                 fail_pattern = 0;
-                for (const Topology::Thread *thr : core->threads) {
-                    if (!thr)
-                        continue;
-                    uint64_t this_pattern = per_cpu_failures[thr->cpu()];
+                for (const Topology::Thread &thr : core->threads) {
+                    uint64_t this_pattern = per_cpu_failures[thr.cpu()];
                     if (this_pattern == 0)
                         all_threads_failed_once = false;
                     if (++nthreads == 1) {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1778,7 +1778,7 @@ static void analyze_test_failures(int tc, const struct test *test, int fail_coun
         // Analysis is not needed if there's only a single package.
         if (topology.packages.size() == 1) {
             logging_printf(LOG_LEVEL_VERBOSE(1), "# - Failures localised to package %d\n",
-                           topology.packages[0].id);
+                           topology.packages[0].id());
             return;
         }
 
@@ -1791,9 +1791,9 @@ static void analyze_test_failures(int tc, const struct test *test, int fail_coun
                 Topology::Core *core = &pkg->cores[c];
                 for (const Topology::Thread &thr : core->threads) {
                     if (per_cpu_failures[thr.cpu()] && (pkg_failures[p] == -1)) {
-                        last_bad_package = pkg->id;
+                        last_bad_package = pkg->id();
                         failed_packages++;
-                        pkg_failures[p] = pkg->id;
+                        pkg_failures[p] = pkg->id();
                     }
                 }
             }
@@ -2326,7 +2326,7 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests)
         return result;                  // shouldn't happen!
 
     if (orig_topo.packages.size() == 1) {
-        result.push_back(orig_topo.packages.front().id);
+        result.push_back(orig_topo.packages.front().id());
         return result;
     }
 
@@ -2368,7 +2368,7 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests)
             result.push_back(disabled_sockets.at(disabled_sockets.size() - 1));
             break;
         }
-        disabled_sockets.push_back(it->id);
+        disabled_sockets.push_back(it->id());
     }
 
     if (ret) { // failed on the last socket as well, so it's the main suspect

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2349,12 +2349,11 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests)
     Topology topo = Topology::topology();
     vector<int> result; // faulty sockets
 
-    auto it = topo.packages.begin();
     if (topo.packages.empty())
         return result;                  // shouldn't happen!
 
     if (topo.packages.size() == 1) {
-        result.push_back(it->id);
+        result.push_back(topo.packages.front().id);
         return result;
     }
 
@@ -2368,7 +2367,7 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests)
     int ret = EXIT_SUCCESS;
     bool ever_failed = false;
     vector<int> disabled_sockets;
-    for (; it != topo.packages.end(); disabled_sockets.push_back(it->id), ++it) {
+    for (auto it = topo.packages.begin(); it != topo.packages.end(); ++it) {
         ret = run_tests_with_retest({ it, topo.packages.end() });
         if (ret) ever_failed = true; /* we've seen a failure */
 
@@ -2377,6 +2376,7 @@ static vector<int> run_triage(vector<const struct test *> &triage_tests)
             result.push_back(disabled_sockets.at(disabled_sockets.size() - 1));
             break;
         }
+        disabled_sockets.push_back(it->id);
     }
 
     if (ret) { // failed on the last socket as well, so it's the main suspect

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -331,6 +331,10 @@ struct cpu_info {
     uint8_t family;         ///! CPU family (usually 6)
     uint8_t stepping;       ///! CPU stepping
     uint16_t model;         ///! CPU model
+
+#ifdef __cplusplus
+    int cpu() const;        ///! Internal CPU number
+#endif
 };
 
 struct test;
@@ -607,6 +611,10 @@ extern struct cpu_info *cpu_info;
 int num_cpus() __attribute__((pure));
 
 #ifdef __cplusplus
+}
+inline int cpu_info::cpu() const
+{
+    return this - ::cpu_info;
 }
 
 constexpr inline test_flags operator|(test_flag f1, test_flag f2)

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -837,8 +837,6 @@ static Topology build_topology()
             return Topology({});
 
         Topology::Package *pkg = &packages.emplace_back();
-        assert(pkg->id == -1);
-        pkg->id = info->package_id;
 
         // scan forward to the end of this package
         Topology::Thread *first = info;
@@ -906,7 +904,7 @@ void update_topology(std::span<const struct cpu_info> new_cpu_info,
         // copy only if matching the socket ID
         auto matching = [=](const struct cpu_info &ci) {
             for (const Topology::Package &p : packages) {
-                if (p.id == ci.package_id)
+                if (p.id() == ci.package_id)
                     return true;
             }
             return false;

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -930,8 +930,10 @@ void init_topology(const LogicalProcessorSet &enabled_cpus)
 void restrict_topology(CpuRange range)
 {
     assert(range.starting_cpu + range.cpu_count <= sApp->thread_count);
-    cpu_info = sApp->shmem->cpu_info + range.starting_cpu;
-    sApp->thread_count = range.cpu_count;
+    auto old_cpu_info = std::exchange(cpu_info, sApp->shmem->cpu_info + range.starting_cpu);
+    int old_thread_count = std::exchange(sApp->thread_count, range.cpu_count);
+    if (old_cpu_info == cpu_info && old_thread_count == sApp->thread_count)
+        return;
 
     cached_topology() = build_topology();
 }

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -858,6 +858,24 @@ const Topology &Topology::topology()
     return cached_topology();
 }
 
+Topology::Data Topology::clone() const
+{
+    Data result;
+    result.all_threads.assign(cpu_info, cpu_info + num_cpus());
+    result.packages = packages;
+
+    // now update all spans to point to the data we carry
+    for (Package &pkg : result.packages) {
+        for (Core &core : pkg.cores) {
+            int starting_cpu = core.threads.front().cpu();
+            int ending_cpu = core.threads.back().cpu();
+            core.threads = { result.all_threads.data() + starting_cpu,
+                             result.all_threads.data() + ending_cpu + 1 };
+        }
+    }
+    return result;
+}
+
 void update_topology(std::span<const struct cpu_info> new_cpu_info,
                      std::span<const Topology::Package> packages)
 {

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -48,6 +48,20 @@ public:
     std::string build_falure_mask(const struct test *test) const;
 
     static const Topology &topology();
+    struct Data;
+    Data clone() const;
+};
+struct Topology::Data
+{
+    // this type is move-only (not copyable)
+    Data() = default;
+    Data(const Data &) = delete;
+    Data(Data &&) = default;
+    Data &operator=(const Data &) = delete;
+    Data &operator=(Data &&) = default;
+
+    std::vector<Package> packages;
+    std::vector<Topology::Thread> all_threads;
 };
 
 enum class LogicalProcessor : int {};

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -25,11 +25,8 @@ class Topology
 {
 public:
     using Thread = struct cpu_info;
-
     struct Core {
-        int id;
-        std::vector<const Thread *> threads;
-        Core() noexcept : id(-1) {}
+        std::span<const Thread> threads;
     };
 
     struct Package {

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -24,18 +24,11 @@ class LogicalProcessorSet;
 class Topology
 {
 public:
-
-    // Thread corresponds to the OS CPU.
-    struct Thread {
-        int id; // thread id within the core (e.g. 0 or 1 for SMT)
-        int cpu; // sandstone internal CPU id, e.g. tests get this identifier
-        int oscpu; // logical CPU id, as reported and recognized by the OS
-        Thread() noexcept : id(-1), cpu(-1), oscpu(-1) {}
-    };
+    using Thread = struct cpu_info;
 
     struct Core {
         int id;
-        std::vector<Thread> threads;
+        std::vector<const Thread *> threads;
         Core() noexcept : id(-1) {}
     };
 

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -30,9 +30,9 @@ public:
     };
 
     struct Package {
-        int id;
         std::vector<Core> cores;
-        Package() noexcept : id(-1) {}
+        int id() const
+        { return cores.size() ? cores.front().threads.front().package_id : -1; }
     };
 
     std::vector<Package> packages;


### PR DESCRIPTION
This simplifies the `Topology` class, from a vector of vector of vectors to a vector of vector of spans: we make the `Topology::Thread` type be exactly the same as the `struct cpu_info` that we'd had since version 1, when everything was still in C. 
The functions are simplified to reduce memory allocations on the child side, which is on the critical path of test running. Benchmarks don't show significant improvement, but it's still there.
