### PR TITLE
FW: add two values for struct test::flags to specify the test's scheduling

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -351,6 +351,14 @@ typedef enum test_flag {
     /// parallel.
     test_schedule_sequential        = 0x02,
 
+    /// Asks the framework to run all the threads for all logical processors in
+    /// one single process.
+    test_schedule_fullsystem        = 0x04,
+
+    /// Asks the framework to run one child process per each socket in the
+    /// system, with all cores.
+    test_schedule_isolate_socket    = 0x06,
+
     /// Tells the --test-tests mode to ignore memory consumption for this test
     test_flag_ignore_memory_use     = 0x0010,
 


### PR DESCRIPTION

This is in addition to `test_schedule_sequential` (added in commit c0d75bffbef27873e7afb4a229ba97ad2faa3558):
* `test_schedule_fullsystem`: equivalent to today's functionality, whereby the framework makes no scheduling decisions and simply gives the entirety of the system under test(*) to the test functions
* `test_schedule_isolate_socket`: makes a simple decision to split the system under test into its component socket processors (a "package") and run one child process per socket

All three options are optional and may not be combined with each other. If none of them are specified -- the default -- the framework will make its own decision (which I'm calling "heuristic mode"). The details of such scheduling are coming in a pull request soon.

This commit does not actually implement anything. It only introduces the flags to facilitate updating the existing tests.