### PR TITLE
FW: remove the struct test::max_threads field

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -502,16 +502,6 @@ struct test {
     ///  0      default (no limit)
     int maximum_duration;
 
-    /// maximum number of threads to assign to the given test. this
-    /// might be useful when the test does not scale well for a very
-    /// big number of cores. 0 (default) means use all available. any
-    /// other value will make the test_run() function to be called
-    /// only for a subset of the overall available threads, not all of
-    /// thread_count. the framework will try to spread out
-    /// package/core usage as much as it can, when this mode is
-    /// activated
-    int max_threads;
-
     /// fracture the test time into smaller runs
     /// Special values:
     ///  <0         never

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -1069,7 +1069,6 @@ static struct test selftests_array[] = {
     .test_init = selftest_logs_init,
     .test_run = selftest_logs_run,
     .desired_duration = -1,
-    .max_threads = 3,
     .quality_level = TEST_QUALITY_PROD,
 },
 {
@@ -1363,7 +1362,6 @@ static struct test selftests_array[] = {
     .groups = DECLARE_TEST_GROUPS(&group_random),
     .test_run = selftest_randomfail_run<std::ratio<1, 2>>,
     .desired_duration = -1,
-    .max_threads = 3,
     .quality_level = TEST_QUALITY_PROD,
 },
 {
@@ -1372,7 +1370,6 @@ static struct test selftests_array[] = {
     .groups = DECLARE_TEST_GROUPS(&group_random),
     .test_run = selftest_randomfail_run<std::ratio<1, 1024>>,
     .desired_duration = -1,
-    .max_threads = 3,
     .quality_level = TEST_QUALITY_PROD,
 },
 {


### PR DESCRIPTION
This field was used by the old "sliding window slicing" functionality of the OpenDCDiag framework, which was removed in commit 8f59e10b04ad82724d3bf2975d827f0aeb1ca022 (PR #271).

It is superseded by the new "parallel slicing" feature, which is enabled by the `test_schedule_*` flags to the `struct test::flags` field (introduced in commit 0f218f5b872a1b1062641ba19c8ebf1c47c92c44 PR #353).