### PR TITLE
FW/ContextDump: fix printing of the AVX512 state

### DIFF
--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -369,6 +369,7 @@ static void print_avx_registers(FILE *f, const Fxsave *state, XSaveBits mask)
         fputc('\n', f);
     }
     for (int i = 0; hizmmstate && i < 16; ++i) {
+        nameprefix = 'z';
         fprintf(f, " %cmm%-2d = ", nameprefix, i + 16);
         for (int j = std::size(hizmmstate->xmm) - 1; j >= 0; --j)
             print_xmm_register(f, hizmmstate[i].xmm[j]);

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -349,11 +349,11 @@ static void print_avx_registers(FILE *f, const Fxsave *state, XSaveBits mask)
             zmmhstate = reinterpret_cast<const ymmreg *>(base + offset);
     }
     if (mask & XSave_Hi16_Zmm) {
-        if (int offset = xsave_offset(XSave_Zmm_Hi256); offset > Fxsave::size)
+        if (int offset = xsave_offset(XSave_Hi16_Zmm); offset > Fxsave::size)
             hizmmstate = reinterpret_cast<const zmmreg *>(base + offset);
     }
     if (mask & XSave_OpMask) {
-        if (int offset = xsave_offset(XSave_Zmm_Hi256); offset > Fxsave::size)
+        if (int offset = xsave_offset(XSave_OpMask); offset > Fxsave::size)
             opmaskstate = reinterpret_cast<const __mmask64 *>(base + offset);
     }
 


### PR DESCRIPTION
There was a bad copy & paste job in the offset for two of the three components of the state.

In addition, it looks like the two components of the ZMM state can be independently set. I didn't know that was possible, but I am seeing on my Tiger Lake laptop, with the `xsave_bv` field in the XSAVE header set to 0x2a7. That means it has the entire state my system supports except for:
```c++
    XSave_Zmm_Hi256    = 0x0040,            // AVX512: high 256 bits of ZMM0-15
```

```
$ cpuid -1l0xd -s0
CPU:
   XSAVE features (0xd/0):
      XCR0 valid bit field mask               = 0x00000000000002e7
```

What's probably happening is that the VZEROUPPER instruction zeroes the upper 384 bits of the ZMM0-15 registers and moves the Zmm_Hi256 component back to INIT state, but leaves Ymm_Hi128 (the original AVX2 component) set.

On my laptop, it now prints:
```
          ymm14 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
          ymm15 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
          zmm16 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000 0000000000000000:0000000000000000 0000000000000000:0000000000000000
          zmm17 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000 2074736e6f632865:67617373656d5f67 6f6c5f7472657373:612064696f76000a
```