### PR TITLE
FW/child_debug/Linux: fix transferring the context without AMX

### DIFF
--- a/framework/amx_common.h
+++ b/framework/amx_common.h
@@ -13,6 +13,8 @@
 
 #if __clang_major__ > 10 || defined(_tile_loadd)
 #  define ATTRIBUTE_AMX_TARGET(x)  __attribute__((target(x)))
+#elif __GNUC__ >= 12
+#  define ATTRIBUTE_AMX_TARGET(x)
 #else
 #  define ATTRIBUTE_AMX_TARGET(x)
 

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -27,13 +27,6 @@
 #endif // _WIN32
 #include "sandstone_p.h"
 
-#include "sandstone_tests.h"
-#include "SelectorFactory.h"
-#include "WeightedRepeatingSelector.h"
-#include "WeightedNonRepeatingSelector.h"
-#include "PrioritizedSelector.h"
-#include "TestrunSelectorBase.h"
-
 #include <exception>
 #include <unordered_map>
 
@@ -1245,4 +1238,5 @@ FOREACH_DATATYPE(DATACOMPARE_TEST)
 #endif // __linux__
 };
 
+extern const std::span<struct test> selftests;
 const std::span<struct test> selftests = { std::begin(selftests_array), std::end(selftests_array) };

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -20,6 +20,7 @@
 #include <sys/ioctl.h>
 #endif
 
+#include "amx_common.h"
 #include "sandstone.h"
 #ifndef _WIN32
 #include "sandstone_asm.h"
@@ -457,6 +458,17 @@ static void cause_sigill()
         }
     }
 #endif
+    if (cpu_has_feature(cpu_feature_amx_tile)) {
+        // init the AMX state
+        alignas(64) static struct amx_tileconfig cfg = {
+            .palette = 1,
+            .start_row = 0,
+            .colsb = { 64 },
+            .rows = { 1 },
+        };
+        asm ("ldtilecfg %0" : : "m" (cfg));
+        asm ("tileloadd (%0, %1, 1), %%tmm0" : : "r" (&cfg), "r" (ptrdiff_t(1)));
+    }
 
     // make sure there are no function calls between the instruction above and the one below
 


### PR DESCRIPTION
On Linux, the AMX state is not saved to the stack if it is in INIT state, so as to avoid possibly overflowing user-provided stacks with the size of the AMX tiles. This meant the kernel saved much less than `xsave_size` to the stack.

This has been a latent problem, but only became visible after we changed the tests' stacks in commit 81914bdde76fe75006f8354c58083fe3848c5abd (PR #333):

```
sendmsg(4, {msg_name=NULL, msg_namelen=0, msg_iov=[{iov_base=..., iov_len=11008}], msg_iovlen=3, msg_controllen=0, msg_flags=0}, MSG_NOSIGNAL) = -1 EFAULT (Bad address)
```

Up until last week, I'd have implemented by simply getting the highest bit in the XSTATE_BV and asking for its offset and size. That is now incorrect, after the APX specification[1] was published, because APX is feature number 19 but is not the one located furthest out. Therefore, we must iterate over all bits set to get the right size.

[1] https://cdrdv2.intel.com/v1/dl/getContent/784266
