### PR TITLE
FW: fix build with Clang

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -554,7 +554,7 @@ template <typename F> inline auto scopeExit(F &&f)
         void dismiss() { dismissed = true; }
         void run_now() { f(); dismiss(); }
     };
-    return Scope(std::forward<F>(f));
+    return Scope{ std::forward<F>(f) };
 }
 
 static_assert(std::is_trivially_copyable_v<SandstoneApplication::SharedMemory>);


### PR DESCRIPTION
```
sandstone_p.h:557:12: error: no matching conversion for functional-style cast from '(lambda at ../framework/ sandstone.cpp:913:30)' to 'Scope'
```