### PR TITLE
FW/ContextDump: fix printing the raw value of the MXCSR

### DIFF
--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -327,7 +327,7 @@ static void print_xmm_register(FILE *f, const xmmreg &ptr)
 static void print_avx_registers(FILE *f, const Fxsave *state, XSaveBits mask)
 {
     // start with the MXCSR
-    fprintf(f, " mxcsr = 0x%08u [ ", state->mxcsr);
+    fprintf(f, " mxcsr = 0x%08x [ ", state->mxcsr);
     print_flag_description(f, state->mxcsr, mxcsr);
     fprintf(f, "RC=%s ]\n", rounding_modes[(state->mxcsr & _MM_ROUND_MASK) / _MM_ROUND_DOWN]);
 


### PR DESCRIPTION
"0x%08u" was wrong. I was trying to figure out why the printed value made no sense:
```
          mxcsr = 0x00008064 [ IM DM ZM OM UM PM RC=nearest ]
```
The raw value did not seem to match the flags it decoded.

Now it does:
```
          mxcsr = 0x00001f80 [ IM DM ZM OM UM PM RC=nearest ]
```