### PR TITLE
FW/ContextDump: fix printing of XSAVE state when none was present

### DIFF
--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -465,6 +465,9 @@ void dump_xsave(FILE *f, const void *xsave_area, size_t xsave_size, int xsave_du
 
         if (xsave_bv & ~xgetbv0)
             return;     // bit vector contains invalid bits
+    } else {
+        // only the legacy state
+        mask = XSaveBits(mask & (XSave_X87 | XSave_SseState));
     }
 
     if (mask & XSave_X87)


### PR DESCRIPTION
It was just garbage we were printing, because the `mask` variable had the original value of -1 that indicated what we'd like printed, not what we had available to print.

This has been there for a long time, but I think that it was only with commit fe984441511792bbd2e206f2e872f16d80e9dd1c (PR #357) that it got triggered. I began seeing this on our real SNB and HSW machines:

```
    zmm0  = 0000000000000003:0000000000004e20 0acc9940a947333e:3a262354f539e18f
```

Obviously there's no ZMM register prior to SKX, so the situation above was impossible. Note also that, despite the name, it printed only 256 bits. I also couldn't reproduce on my HSW or SKL laptops, nor my CFL NUC, until I tried a release binary. Then I noticed that the buffer transferred from the XSAVE buffer was only 512 bytes (the FXSAVE header):

```
(gdb) p ctx.xsave_buffer
$4 = {_M_ptr = 0x7fffffffdb70 "\177\003", _M_extent = {_M_extent_value = 512}}
```

Confirmed with strace:
```
[pid 128249] --- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=0x2dc} ---
[pid 128248] sendmsg(4, {msg_name=NULL, msg_namelen=0, msg_iov=[
  {iov_base=..., iov_len=48},
  {iov_base=..., iov_len=184},
  {iov_base=..., iov_len=512}], msg_iovlen=3, msg_controllen=0, msg_flags=0}, MSG_NOSIGNAL) = 744
```