### PR TITLE
FW/Win32: add a crash context dumper for Windows

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1415,8 +1415,7 @@ selftest_crash_common() {
         skip "Windows-only test"
     fi
 
-    # I don't know *why* we get this error, but we do
-    selftest_crash_common selftest_fastfail ''  0xC0000409 "Stack buffer overrun"
+    selftest_crash_common selftest_fastfail ''  0xC0000409 "Program self-triggered abnormal termination"
 }
 
 @test "selftest_sigkill" {

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -72,6 +72,7 @@
 #ifdef _WIN32
 #  include <ntstatus.h>
 #  include <windows.h>
+#  include "win32_errorstrings.h"
 #  define dup _dup
 #  define dup2 _dup2
 #  define _PATH_DEVNULL "NUL"
@@ -2015,21 +2016,7 @@ std::string TapFormatLogger::fail_info_details()
     assert(status.result != TestResult::TimedOut);
     assert(status.result != TestResult::Interrupted);
 #ifdef _WIN32
-    switch (status.extra) {
-    case static_cast<unsigned>(STATUS_FAIL_FAST_EXCEPTION):
-        return "Aborted";
-    case STATUS_ACCESS_VIOLATION:
-        return "Access violation";
-    case STATUS_ILLEGAL_INSTRUCTION:
-        return "Illegal instruction";
-    case STATUS_INTEGER_DIVIDE_BY_ZERO:
-        return "Integer division by zero";
-    case STATUS_NO_MEMORY:
-        return "Out of memory condition";
-    case STATUS_STACK_BUFFER_OVERRUN:
-        return "Stack buffer overrun";
-    }
-    return "Unknown";
+    return status_code_to_string(status.extra);
 #else
     return strsignal(status.extra);
 #endif

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1617,6 +1617,8 @@ static void wait_for_children(ChildrenList &children, int *tc, const struct test
     auto single_wait = [&](milliseconds timeout) {
         HANDLE handles[MAXIMUM_WAIT_OBJECTS];
         DWORD nCount = 0;
+        if (sApp->shmem->debug_event)
+            handles[nCount++] = HANDLE(sApp->shmem->debug_event);
         for (auto it = children.handles.begin(); it != children.handles.end() && nCount < MAXIMUM_WAIT_OBJECTS; ++it) {
             HANDLE hnd = HANDLE(*it);
             if (hnd == INVALID_HANDLE_VALUE)
@@ -1635,6 +1637,12 @@ static void wait_for_children(ChildrenList &children, int *tc, const struct test
             return 0;
 
         int idx = result - WAIT_OBJECT_0;
+        if (idx == 0 && sApp->shmem->debug_event) {
+            // one child (or more than one) is crashing
+            debug_crashed_child();
+            return 0;
+        }
+
         HANDLE hExited = handles[idx];
         if (GetExitCodeProcess(hExited, &result) == 0) {
             fprintf(stderr, "%s: GetExitCodeProcess(child = %p) failed: %lx\n",

--- a/framework/sandstone_child_debug_common.h
+++ b/framework/sandstone_child_debug_common.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SANDSTONE_CHILD_DEBUG_COMMON_H
+#define SANDSTONE_CHILD_DEBUG_COMMON_H
+
+#include "sandstone_context_dump.h"
+
+#include <stdint.h>
+
+#ifdef __x86_64__
+#  include "cpu_features.h"
+
+#  include <algorithm>
+#  include <cpuid.h>
+
+// get the size of the context to transfer
+inline int xsave_size_for_bitvector(uint64_t xsave_bv)
+{
+    uint32_t eax, ebx, ecx, edx;
+    int xsave_size = FXSAVE_SIZE;
+    if (!__get_cpuid_count(0xd, 0, &eax, &ebx, &ecx, &edx))
+        return xsave_size;
+
+    // did the bit vector disable any bits that are in CPUID?
+    uint64_t cpuid_bv = eax | uint64_t(edx) << 32;
+    if (cpuid_bv & ~xsave_bv) {
+        // yes, find the end of the highest state that we *are* transferring
+        int bit = 2;
+        uint64_t mask = XSave_Ymm_Hi128;
+        xsave_bv &= ~(XSave_SseState | XSave_X87);  // included in FXSAVE
+        for ( ; xsave_bv; ++bit, mask <<= 1) {
+            if ((xsave_bv & mask) == 0)
+                continue;
+            xsave_bv &= ~mask;
+            __cpuid_count(0xd, bit, eax, ebx, ecx, edx);
+            int size = eax;
+            int offset = ebx;
+            xsave_size = std::max(xsave_size, size + offset);
+        }
+    } else {
+        // no, we'll transfer the entire context
+        xsave_size = ebx;
+    }
+    return xsave_size;
+}
+
+inline int get_xsave_size()
+{
+    return xsave_size_for_bitvector(-1);
+}
+#else
+static int get_xsave_size()
+{
+    return 0;
+}
+#endif // x86_64
+
+#endif // SANDSTONE_CHILD_DEBUG_COMMON_H

--- a/framework/sandstone_context_dump.h
+++ b/framework/sandstone_context_dump.h
@@ -13,8 +13,7 @@
 #if defined(__unix__) || defined(__APPLE__)
 #  include <sys/ucontext.h>
 #else
-// do we want to define something for Windows?
-typedef struct {} mcontext_t;
+typedef struct _CONTEXT mcontext_t;
 #endif  // __unix__
 
 #define FXSAVE_SIZE     0x200

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -471,7 +471,10 @@ struct SandstoneApplication::SharedMemory
     bool log_test_knobs = false;
 
     // child debugging
-#ifndef _WIN32
+#ifdef _WIN32
+    intptr_t debug_event = 0;
+    intptr_t child_debug_socket = -1;
+#else
     int server_debug_socket = -1;
     int child_debug_socket = -1;
 #endif

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -870,6 +870,7 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
     if (ctx.rip != ctx.crash_address)
         message += stdprintf(", CR2 = %p", ctx.crash_address);
     if (ctx.trap_nr >= 0) {
+#ifdef __x86_64__
         static const char trap_names[][4] = {
             "DE", "DB", "NMI", "BP",
             "OF", "BR", "UD", "NM",
@@ -885,6 +886,7 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
 
         message += stdprintf(", trap=%d (%s), error_code = 0x%lx",
                              ctx.trap_nr, trap_name, ctx.error_code);
+#endif
     }
 
     log_message(cpu, SANDSTONE_LOG_ERROR "%s", message.c_str());

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -154,7 +154,11 @@ set pagination off
 set confirm off
 python handle = %#tx; print('ok')
 )";
-static const char gdb_bt_commands[] = R"(printf "Backtrace:"
+static const char gdb_bt_commands[] =
+#ifndef __x86_64__
+        "info registers\n"
+#endif
+        R"(printf "Backtrace:"
 thread apply all bt full
 quit
 )";

--- a/framework/sysdeps/windows/child_debug.cpp
+++ b/framework/sysdeps/windows/child_debug.cpp
@@ -6,6 +6,68 @@
 #include "sandstone.h"
 #include "sandstone_p.h"
 
+#include <windows.h>
+
+#ifndef RtlGenRandom
+#  define RtlGenRandom SystemFunction036
+#endif
+extern "C"
+DECLSPEC_IMPORT BOOLEAN WINAPI RtlGenRandom(PVOID RandomBuffer, ULONG RandomBufferLength);
+
+#define WIN_TEMP_MAX_RETIRES            16
+
+static HANDLE hSlot = INVALID_HANDLE_VALUE;
+
+static bool open_mailslot()
+{
+    static const wchar_t prefix[] = L"\\\\.\\mailslot\\" SANDSTONE_EXECUTABLE_NAME ".";
+    wchar_t name[std::size(prefix) + sizeof(SANDSTONE_STRINGIFY(UINT_MAX))];
+    memcpy(name, prefix, sizeof(prefix));
+
+    for (int i = 0; hSlot == INVALID_HANDLE_VALUE && i < WIN_TEMP_MAX_RETIRES; ++i) {
+        // create a random value in base 36
+        unsigned random;
+        if (!RtlGenRandom(&random, sizeof(random)))
+            continue;
+        _ultow(random, name + std::size(prefix) - 1, 36);
+        hSlot = CreateMailslotW(name, 0, MAILSLOT_WAIT_FOREVER, nullptr);
+    }
+
+    if (hSlot == INVALID_HANDLE_VALUE) {
+        win32_perror("CreateMailslot");
+    } else {
+        // mailslots can't be waited on using WaitForMultipleObjects, so create
+        // an event that the child can use to signal us when it's written
+        // something
+        SECURITY_ATTRIBUTES sa = {};
+        sa.nLength = sizeof(sa);
+        sa.bInheritHandle = true;
+        sa.lpSecurityDescriptor = nullptr;
+        HANDLE hEvent = CreateEventW(&sa, true, false, nullptr);
+        if (!hEvent) {
+            win32_perror("CreateEventW for mailslot");
+            goto close_hslot;
+        }
+
+        // and open a file handle that the child can use to communicate write to
+        HANDLE hFile = CreateFileW(name, GENERIC_WRITE, FILE_SHARE_READ, &sa, OPEN_EXISTING,
+                                   FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (hFile != INVALID_HANDLE_VALUE) {
+            sApp->shmem->debug_event = intptr_t(hEvent);
+            sApp->shmem->child_debug_socket = intptr_t(hFile);
+            return true;
+        }
+        win32_perror("CreateFileW on mailslot");
+        CloseHandle(hEvent);
+    }
+
+close_hslot:
+    CloseHandle(hSlot);
+    hSlot = INVALID_HANDLE_VALUE;
+    return false;
+}
+
+
 void debug_init_child()
 {
 }
@@ -13,7 +75,15 @@ void debug_init_child()
 void debug_init_global(const char *on_hang_arg, const char *on_crash_arg)
 {
     (void) on_hang_arg;
-    (void) on_crash_arg;
+    if (SandstoneConfig::ChildDebugCrashes) {
+        std::string_view arg = on_crash_arg ? on_crash_arg : "context";
+        if (arg == "context" || arg == "context+core" || arg == "core+context") {
+            open_mailslot();
+        } else if (arg != "kill" && arg != "core" && arg != "coredump") {
+            fprintf(stderr, "%s: unknown action for --on-crash: %s\n", program_invocation_name, on_crash_arg);
+            exit(EX_USAGE);
+        }
+    }
 }
 
 void debug_crashed_child(pid_t child)

--- a/framework/sysdeps/windows/tmpfile.c
+++ b/framework/sysdeps/windows/tmpfile.c
@@ -5,6 +5,7 @@
 
 #define _GNU_SOURCE
 #include "sandstone_p.h"
+#include "sandstone_config.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -78,4 +79,3 @@ int open_memfd(enum MemfdCloexecFlag flag)
 
     return -1;
 }
-

--- a/framework/sysdeps/windows/win32_errorstrings.h
+++ b/framework/sysdeps/windows/win32_errorstrings.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SANDSTONE_WIN32_ERRORSTRING_h
+#define SANDSTONE_WIN32_ERRORSTRING_h
+
+#include <windows.h>
+
+inline const char *status_code_to_string(DWORD code)
+{
+    // This list is not exhaustive. It mostly comes from:
+    // https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-exception_record
+
+    switch (code) {
+    case 0xC0000602:    // STATUS_FAIL_FAST_EXCEPTION
+        return "Aborted";
+    case STATUS_ACCESS_VIOLATION:
+        return "Access violation";
+    case STATUS_ARRAY_BOUNDS_EXCEEDED:
+        return "Array bounds exceeded";
+    case STATUS_BREAKPOINT:
+        return "Breakpoint";
+    case STATUS_DATATYPE_MISALIGNMENT:
+        return "Data type misalignment";
+    case STATUS_FLOAT_DENORMAL_OPERAND:
+        return "Floating-pointe denormal";
+    case STATUS_FLOAT_DIVIDE_BY_ZERO:
+        return "Floating-point division by zero";
+    case STATUS_FLOAT_INEXACT_RESULT:
+        return "Floating-point inexact result";
+    case STATUS_FLOAT_INVALID_OPERATION:
+        return "Floating-point invalid operation";
+    case STATUS_FLOAT_OVERFLOW:
+        return "Floating-point overflow";
+    case STATUS_FLOAT_STACK_CHECK:
+        return "Floating-point stack overflow";
+    case STATUS_FLOAT_UNDERFLOW:
+        return "Floating-point underflow";
+    case STATUS_ILLEGAL_INSTRUCTION:
+    case STATUS_PRIVILEGED_INSTRUCTION:
+        return "Illegal instruction";
+    case STATUS_IN_PAGE_ERROR:
+        return "Paging violation";
+    case STATUS_INTEGER_DIVIDE_BY_ZERO:
+        return "Integer division by zero";
+    case STATUS_NO_MEMORY:
+        return "Out of memory condition";
+    case STATUS_STACK_BUFFER_OVERRUN:
+        return "Program self-triggered abnormal termination";
+    case STATUS_STACK_OVERFLOW:
+        return "Stack overflow";
+    }
+
+    return "???";
+}
+
+#endif // SANDSTONE_WIN32_ERRORSTRING_h


### PR DESCRIPTION
Fixes #314.

Now we're getting:
```yaml
   - level: info
      text: |1
       Registers:
        rax   = 0x000000000000002a (42)
        rbx   = 0x0000000000000000 (0)
        rcx   = 0x000000000000feed
        rdx   = 0x0000000000c0ffee
        rsi   = 0x000002a23c9873e0
        rdi   = 0x00000000dfef324d
        rbp   = 0x000000e6ed5ffc10
        rsp   = 0x000000e6ed5ffb90
        r8    = 0x00000000dfef324d
        r9    = 0x000002a23c9873e0
        r10   = 0x0000000000000011 (17)
        r11   = 0x000000e6ed5ffcc0
        r12   = 0x0000000000000000 (0)
        r13   = 0x0000000000000000 (0)
        r14   = 0x0000000000000000 (0)
        r15   = 0x0000000000000000 (0)
        rip   = 0x00007ff6043e9896
        flags = 0x00010246 [ PF ZF IF RF ]
        fs    = 0x53
        gs    = 0x2b
        fcw   = 0x37f
        fsw   = 0x3000 [ top=6 ]
        ftw   = 0xc0
        st(0) = 4000c90fdaa22168c235 (0xc.90fdaa22168c235p-2)
        st(1) = 3fff8000000000000000 (0x8p-3)
        st(2) = 00000000000000000000 (0x0p+0)
        st(3) = 00000000000000000000 (0x0p+0)
        st(4) = 00000000000000000000 (0x0p+0)
        st(5) = 00000000000000000000 (0x0p+0)
        st(6) = 00000000000000000000 (0x0p+0)
        st(7) = 00000000000000000000 (0x0p+0)
        mxcsr = 0x00001f80 [ IM DM ZM OM UM PM RC=nearest ]
        ymm0  = 0000000000000000:0000000000000000 3ff0000000000000:3cb0000000000000
        ymm1  = ffffffffffffffff:ffffffffffffffff ffffffffffffffff:ffffffffffffffff
        ymm2  = 0000000000000000:0000000000000000 7ff8000000000000:fff0000000000000
        ymm3  = 0000000000000000:0000000000000000 00c0ffeedeadbeef:0000feed0000002a
        ymm4  = 0000000000000000:0000000000000000 3f80000000000000:bfc000007f800000
        ymm5  = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm6  = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm7  = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm8  = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm9  = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm10 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm11 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm12 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm13 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm14 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
        ymm15 = 0000000000000000:0000000000000000 0000000000000000:0000000000000000
```

which matches expectations:
* `rax` contains 42 (from `"a" (42)`)
* `rcx` contains 0xfeed (from `"c" (0xfeed)`)
* `rdx` contains 0xc0ffee (from `"d" (0xc0ffee)`)
* `st(0)` contains `acosl(-1)` (pi)
* `st(1)` contains 1.0
* MXCSR is 0x1f80
* `ymm0` contains `_mm_set_pd(1, std::numeric_limits<double>::epsilon())`
* `ymm1` contains `_mm_set1_epi32(-1)` extended to all 256 bits
* `ymm2` contains `_mm_setpd(quiet_NaN, -infinity)`
* `ymm3` contains `_mm_setr_epi32(42, 0xfeed, 0xdeadbeef, 0xc0ffee)`
* `ymm4` contains `_mm_set_ps(1, 0, -1.5, infinity)`
