### PR TITLE
FW/Skip reasons: Add DummySkipCategory to skip reasons

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -328,6 +328,15 @@ selftest_pass() {
     done
 }
 
+@test "selftest_dummy_skip_run_even_threads" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_dummy_skip_run_even_threads
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/test" selftest_dummy_skip_run_even_threads
+    test_yaml_regexp "/tests/0/result" pass
+}
+
 @test "selftest_log_skip_newline" {
     declare -A yamldump
     sandstone_selftest -e selftest_log_skip_newline

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -462,6 +462,8 @@ static const char *char_to_skip_category(int val)
         return "OsNotSupportedSkipCategory";
     case SkipCategory(9):
         return "ThreadIssueSkipCategory";
+    case SkipCategory(10):
+        return "DummySkipCategory";
     }
 
     return "NO CATEGORY PRESENT";
@@ -1249,7 +1251,7 @@ void log_platform_message(const char *fmt, ...)
 #undef log_message_skip
 void log_message_skip(int thread_num, SkipCategory category, const char *fmt, ...)
 {
-    if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
+    if (current_output_format() == SandstoneApplication::OutputFormat::no_output || category == DummySkipCategory)
         return;
 
     va_list va;

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -96,7 +96,9 @@ typedef enum SkipCategory {
     RuntimeSkipCategory,
     SelftestSkipCategory,
     OsNotSupportedSkipCategory,
-    ThreadIssueSkipCategory
+    ThreadIssueSkipCategory,
+    // Use this category if you are skipping on majority of the cores and don't want to clog your log with skip messages.
+    DummySkipCategory  
 } SkipCategory;
 
 /// logs a skip message to the logfile. log_skip accepts the category to which the skip belongs to

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -213,6 +213,15 @@ static int selftest_log_skip_run_even_threads(struct test *test, int cpu)
     return EXIT_SUCCESS;
 }
 
+static int selftest_dummy_skip_run_even_threads(struct test *test, int cpu)
+{
+    if (cpu % 2 == 0) {
+        log_skip(DummySkipCategory, "Dummy Skip");
+        return EXIT_SKIP;
+    }
+    return EXIT_SUCCESS;
+}
+
 static int selftest_log_skip_newline_init(struct test *test)
 {
     log_skip(SelftestSkipCategory, "This is a skip in init \nwith a new line.\nWill it work?");
@@ -851,6 +860,13 @@ static struct test selftests_array[] = {
     .description = "This test will test the log_skip feature in the run function where only even numbered threads skip",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_run = selftest_log_skip_run_even_threads,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_dummy_skip_run_even_threads",
+    .description = "This test will test the dummy_skip feature in the run function where only even numbered threads skip",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_run = selftest_dummy_skip_run_even_threads,
     .desired_duration = -1,
 },
 {


### PR DESCRIPTION
This category can be used when majority of the cores skip a test. When this skip category is used, Sandstone will not log any skip messages. This is equivalent to the case when all cores run the test and the test exits without skips.

One of the use cases for this are the accelerator tests where only a handful of cores run the accelerator tests and others skip. By default all cores will log their defualt/user defined skip messages, the final log looks messy. With the changes in this commit, when this skip category is used, Sandstone will not log the default/user defined skip log message.

Before these changes.

```
test: simple_add
  time-at-start: { elapsed:   1183.377, now: !!timestamp '2023-08-01T04:33:24Z' }
  result: pass
  time-at-end:   { elapsed:   1193.377, now: !!timestamp '2023-08-01T04:33:24Z' }
  test-runtime: 9.056
  threads:
  - thread: 0
    id: { logical:  0, package: 0, core:  0, thread: 0, family: 6, model: 0x55, stepping: 6, microcode: 0x400320a, ppin: null }
    messages:
    - { level: skip, text: 'Os not supported category' }
  - thread: 2
    id: { logical:  2, package: 0, core:  2, thread: 0, family: 6, model: 0x55, stepping: 6, microcode: 0x400320a, ppin: null }
    messages:
    - { level: skip, text: 'Os not supported category' }
```
After these changes.

```
- test: simple_add
  time-at-start: { elapsed:    993.370, now: !!timestamp '2023-08-01T00:05:02Z' }
  result: pass
  time-at-end:   { elapsed:   1010.037, now: !!timestamp '2023-08-01T00:05:02Z' }
  test-runtime: 16.848
- test: simple_add
  time-at-start: { elapsed:   1023.371, now: !!timestamp '2023-08-01T00:05:02Z' }
  result: pass
  time-at-end:   { elapsed:   1043.371, now: !!timestamp '2023-08-01T00:05:02Z' }
  test-runtime: 19.000
- test: simple_add
  time-at-start: { elapsed:   1053.372, now: !!timestamp '2023-08-01T00:05:02Z' }
  result: pass
  time-at-end:   { elapsed:   1073.373, now: !!timestamp '2023-08-01T00:05:02Z' }
  test-runtime: 18.406
```