### PR TITLE
FW: fix launching threads for the new test schedule methods

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1224,7 +1224,7 @@ static void run_threads(const struct test *test)
     current_test = test;
 
     switch (test->flags & test_schedule_mask) {
-    case test_schedule_default:
+    default:
         run_threads_in_parallel(test, &thread_attr);
         break;
 


### PR DESCRIPTION
I hadn't tested the new flags because I was only using the global override option in the command-line with the unmodified set of tests. Problem arises of a conflict from the new flags added in PR #353 (commit 0f218f5b872a1b1062641ba19c8ebf1c47c92c44) with PR #248 (commit c0d75bffbef27873e7afb4a229ba97ad2faa3558).

Thanks to @dawid-sabat for noticing.