### PR TITLE
FW: add the --max-cores-per-slice and the beginnings of slicing

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -346,7 +346,7 @@ tap_negative_check() {
     # Don't use sandstone_selftest because we don't want -n$MAX_PROC
     VALIDATION=dump
     declare -A yamldump
-    run_sandstone_yaml -vvv --max-test-loop-count=1 --selftests -e selftest_timedpass
+    run_sandstone_yaml -vvv --max-test-loop-count=1 --no-slicing --selftests -e selftest_timedpass
 
     test_yaml_numeric "/tests/0/threads@len" "value == $nproc / 2 + 1"
     for ((i = 0; i < nproc/2; ++i)); do

--- a/bats/yamltest.py
+++ b/bats/yamltest.py
@@ -43,10 +43,8 @@ def validate_message(name, message):
 
 def validate_thread(name, thr):
     n = thr['thread']
-    if n != 'main' and not type(n) is int:
-        fail('found unknown thread "{}" for test {}'.format(n, name))
 
-    if n != 'main':
+    if type(n) is int:
         #thr['id']['logical'] # waiting on Windows
         thr['id']['package']
         thr['id']['core']
@@ -56,6 +54,8 @@ def validate_thread(name, thr):
         thr['id']['stepping']
         thr['id']['microcode']
         thr['id']['ppin']
+    elif not n.startswith('main'):
+        fail('found unknown thread "{}" for test {}'.format(n, name))
 
     if 'loop-count' in thr:
         loop_count = thr['loop-count']

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1810,7 +1810,12 @@ void KeyValuePairLogger::print(int tc)
 void KeyValuePairLogger::print_thread_header(int fd, int cpu, const char *prefix)
 {
     if (cpu < 0) {
-        writeln(file_log_fd, timestamp_prefix, "_messages_mainthread = \\");
+        cpu = ~cpu;
+        if (cpu == 0)
+            writeln(file_log_fd, timestamp_prefix, "_messages_mainthread = \\");
+        else
+            dprintf(file_log_fd, "%s_messages_mainthread_%d = \\\n",
+                    timestamp_prefix.c_str(), cpu);
         return;
     }
 
@@ -2077,7 +2082,11 @@ void TapFormatLogger::print_thread_header(int fd, int cpu, int verbosity)
 {
     maybe_print_yaml_marker(fd);
     if (cpu < 0) {
-        writeln(fd, "  Main thread:");
+        cpu = ~cpu;
+        if (cpu == 0)
+            writeln(fd, "  Main thread:");
+        else
+            dprintf(fd, "  Main thread %d:", cpu);
         return;
     }
 
@@ -2175,7 +2184,11 @@ void YamlLogger::print_thread_header(int fd, int cpu, int verbosity)
 {
     maybe_print_messages_header(fd);
     if (cpu < 0) {
-        writeln(fd, indent_spaces(), "  - thread: main");
+        cpu = ~cpu;
+        if (cpu == 0)
+            writeln(fd, indent_spaces(), "  - thread: main");
+        else
+            writeln(fd, indent_spaces(), "  - thread: main ", std::to_string(cpu));
     } else {
         dprintf(fd, "%s  - thread: %d\n", indent_spaces().data(), cpu);
         dprintf(fd, "%s    id: %s\n", indent_spaces().data(), thread_id_header(cpu, verbosity).c_str());

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -487,6 +487,17 @@ inline PerThreadData::Test *SandstoneApplication::test_thread_data(int thread)
     return &test_thread_data_ptr[thread];
 }
 
+template <typename Lambda> static void for_each_main_thread(Lambda &&l)
+{
+    l(sApp->main_thread_data(), -1);
+}
+
+template <typename Lambda> static void for_each_test_thread(Lambda &&l)
+{
+    for (int i = 0; i < num_cpus(); i++)
+        l(sApp->test_thread_data(i), i);
+}
+
 struct AutoClosingFile
 {
     FILE *f = nullptr;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -332,9 +332,15 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
         child_exec_each_test,       // when parent is exec_each_test
     };
 
+    struct SlicePlans {
+        using Slices = std::vector<CpuRange>;
+        std::array<Slices, 1> plans;
+    };
+
     using PerCpuFailures = std::vector<uint64_t>;
     struct SharedMemory;
 
+    SlicePlans slice_plans;
     std::vector<test_data_per_thread> user_thread_data;
     PerThreadData::Main *main_thread_data_ptr;  // points to somewhere in the shmem
     PerThreadData::Test *test_thread_data_ptr;  // points to somewhere in the shmem

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -203,7 +203,7 @@ struct Common
 
 struct alignas(64) Main : Common
 {
-    // nothing yet
+    CpuRange cpu_range;
 };
 
 struct alignas(64) Test : Common
@@ -409,6 +409,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     PerThreadData::Common *thread_data(int thread);
     PerThreadData::Main *main_thread_data() noexcept;
     PerThreadData::Test *test_thread_data(int thread);
+    void select_main_thread(int group);
 
     SandstoneBackgroundScan background_scan;
 
@@ -485,6 +486,13 @@ inline PerThreadData::Test *SandstoneApplication::test_thread_data(int thread)
     assert(thread >= 0);
     assert(thread < sApp->thread_count);
     return &test_thread_data_ptr[thread];
+}
+
+inline void SandstoneApplication::select_main_thread(int group)
+{
+    assert(current_fork_mode() != no_fork || group == 0);
+    main_thread_data_ptr += group;
+    test_thread_data_ptr += main_thread_data_ptr->cpu_range.starting_cpu;
 }
 
 template <typename Lambda> static void for_each_main_thread(Lambda &&l)


### PR DESCRIPTION
This adds the --max-cores-per-slice mode that limits the number of cores available in a given slice. This option can also be used to enable slicing even we heuristically wouldn't do it. It also un-deprecates the--np-slicing option to force the slicing feature to be disabled.

This PR also includes the ability to have multiple main threads (one per slice).