### PR TITLE
FW/cpuid: get the details from Leaf 7, subleaf 1, EDX register

### DIFF
--- a/framework/cpuid_internal.h
+++ b/framework/cpuid_internal.h
@@ -166,8 +166,10 @@ static uint64_t detect_cpu()
         features |= parse_register(Leaf07_00ECX, ecx);
         features |= parse_register(Leaf07_00EDX, edx);
 
-        __cpuid_count(7, 1, eax, ebx, ecx, edx);
-        features |= parse_register(Leaf07_01EAX, eax);
+        if (eax) {
+            __cpuid_count(7, 1, eax, ebx, ecx, edx);
+            features |= parse_register(Leaf07_01EAX, eax);
+        }
     }
     if (max_level >= 13) {
         __cpuid_count(13, 1, eax, ebx, ecx, edx);

--- a/framework/cpuid_internal.h
+++ b/framework/cpuid_internal.h
@@ -169,6 +169,7 @@ static uint64_t detect_cpu()
         if (eax) {
             __cpuid_count(7, 1, eax, ebx, ecx, edx);
             features |= parse_register(Leaf07_01EAX, eax);
+            features |= parse_register(Leaf07_01EDX, edx);
         }
     }
     if (max_level >= 13) {


### PR DESCRIPTION
We need to check if subleaf 0 told us that subleaf 1 is enabled, instead of relying on the registers being set to zero. Apparently, Sandy Bridge was buggy (see https://gcc.gnu.org/pipermail/gcc-patches/2023-August/626618.html and https://reviews.llvm.org/D156963).

Then enable extracting from register EDX there.