### PR TITLE
FW/sandstone_ssl: Drop OpenSSL 1.1 support

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -90,11 +90,18 @@ framework_files = files(
     'topology.cpp',
 )
 
-crypto_dep = dependency('libcrypto',
+if framework_config.get('SANDSTONE_SSL_BUILD') == 1
+  # Look for libcrypto
+  crypto_dep = dependency('libcrypto',
+                        version: '>= 3.0',
                         required: false,
                         static: get_option('ssl_link_type') == 'static')
-if crypto_dep.found() and framework_config.get('SANDSTONE_SSL_BUILD') == 1
-    framework_files += ['sandstone_ssl.cpp']
+  if crypto_dep.found()
+      framework_files += ['sandstone_ssl.cpp']
+  else
+      # If we cannot find libcrypto, disable SSL build
+      framework_config.set10('SANDSTONE_SSL_BUILD', 0)
+  endif
 endif
 
 if get_option('selftests')

--- a/framework/sandstone_ssl.cpp
+++ b/framework/sandstone_ssl.cpp
@@ -48,16 +48,10 @@ void sandstone_ssl_init()
 #else
     void *libcrypto;
 
-    // Try open openssl 1.1
-    libcrypto = dlopen("libcrypto.so.1.1", RTLD_NOW);
+    // Try open openssl 3
+    libcrypto = dlopen("libcrypto.so.3", RTLD_NOW);
 
-    // If previous not avialble, try open openssl 3.0
-    if (!libcrypto)
-    {
-        libcrypto = dlopen("libcrypto.so.3", RTLD_NOW);
-    }
-
-    // When none available, don't continue
+    // If not available, don't continue
     if (!libcrypto) {
         return;
     }


### PR DESCRIPTION
OpenSSL 1.1 is about to EOL this September, so we are no longer supporting it.

Support for OpenSSL 3.0 remain unchanged.