### PR TITLE
FW: add proper test slice planning

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -333,8 +333,15 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     };
 
     struct SlicePlans {
+        static constexpr int MinimumCpusPerSocket = 8;
+        static constexpr int DefaultMaxCoresPerSlice = 32;
+        enum Type : int8_t {
+            FullSystem = -1,
+            IsolateSockets,
+            Heuristic,
+        };
         using Slices = std::vector<CpuRange>;
-        std::array<Slices, 1> plans;
+        std::array<Slices, 2> plans;
     };
 
     using PerCpuFailures = std::vector<uint64_t>;

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -226,7 +226,7 @@ void CrashContext::send(int sockfd, siginfo_t *si, void *ucontext)
     CrashContext::Fixed fixed = {
         .crash_address = si->si_addr,
         .rip = si->si_addr,
-        .thread_num = ::thread_num,
+        .thread_num = ::thread_num + sApp->main_thread_data()->cpu_range.starting_cpu,
         .signum = si->si_signo,
         .signal_code = si->si_code,
     };


### PR DESCRIPTION
This concludes the main development of the "socket separation" feature, by finally implementing parallel-slicing by default for all tests. There are still some clean-ups and minor tweaks that may go in.

For example, the formula as implemented in this commit probably deserves some attention. For a CPU like the 144-core Sierra Forest, the ideal plan would be 6 slices of 24 cores, but the formula calculates 5 slices (4x32 and one of 16).

The logging output may still change too.