### PR TITLE
FW/Slicing: amend the test heuristic to add a secondary maximum

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -335,6 +335,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     struct SlicePlans {
         static constexpr int MinimumCpusPerSocket = 8;
         static constexpr int DefaultMaxCoresPerSlice = 32;
+        static constexpr int SecondaryMaxCoresPerSlice = DefaultMaxCoresPerSlice * 3 / 4;
         enum Type : int8_t {
             FullSystem = -1,
             IsolateSockets,


### PR DESCRIPTION
Whenever the number of cores in the socket is a multiple of three fourths the target (24 instead of 32), we use this secondary division to avoid having an unbalanced last slice. This makes a 144-core socket like the announced Sierra Forest instead run 6 slices of 24 cores instead of 5 slices of 32 and one final of 16. I don't have any information whether this makes any difference to the performance of the system, but given that it will have one gross of sockets hints that the actual organisation of the cores on the die may have something to do with dozens.

The effect of having an extra child (6 instead of 5) should be negligible and could be compensated by the fact that each child only needs to start 24 threads -- the longest path for that system will be 6+24 = 30 clone() system calls, instead of 5+32 = 37.

This change applies to other multiples of 24 that are larger than 96 but aren't multiples of 96, such as 120, 168, 216, 240, etc. This also means we can hit the Windows WaitForMultipleObjects() limit of 64 children sooner, at 1560 cores (65 * 24, an unlikely topology) or more likely at a grand gross (1728) of cores (12 * 144 = 8 * 216 = 4 * 432 = 2 * 864).

We could repeat this exercise for other multiples of 4 below 32, but I don't see a need for it right now.