### PR TITLE
FW/MSR: set errno before the early return

### DIFF
--- a/framework/sysdeps/linux/msr.c
+++ b/framework/sysdeps/linux/msr.c
@@ -54,8 +54,10 @@ bool read_msr(int cpu, uint32_t msr, uint64_t * value)
     bool ret = false;
     char filename[sizeof "/dev/cpu/2147483647/msr" + 1];
 
-    if (atomic_load_explicit(&msr_access_denied, memory_order_relaxed))
+    if (atomic_load_explicit(&msr_access_denied, memory_order_relaxed)) {
+        errno = EACCES;
         return false;
+    }
     try_load_kmod();
 
     sprintf(filename, "/dev/cpu/%i/msr", cpu);
@@ -78,8 +80,10 @@ bool write_msr(int cpu, uint32_t msr, uint64_t value)
     bool ret = false;
     char filename[sizeof "/dev/cpu/2147483647/msr" + 1];
 
-    if (atomic_load_explicit(&msr_access_denied, memory_order_relaxed))
+    if (atomic_load_explicit(&msr_access_denied, memory_order_relaxed)) {
+        errno = EACCES;
         return false;
+    }
     try_load_kmod();
 
     sprintf(filename, "/dev/cpu/%i/msr", cpu);


### PR DESCRIPTION
Commit 12cb9e6491ca61d4d4af08d26bb06c2ff3595013 ("don't keep trying to open the /dev/ MSR nodes if we get EACCES") added the early return, but forgot to set errno.