### PR TITLE
FW/test-tests: fix race condition in checking the main thread(s)

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1025,6 +1025,7 @@ static void init_shmem()
     sApp->shmemfd = fd;
     sApp->shmem = new (base) SandstoneApplication::SharedMemory;
     sApp->shmem->thread_data_offset = thread_data_offset;
+    sApp->shmem->main_process_pid = getpid();
 }
 
 static void commit_shmem()


### PR DESCRIPTION
We were using for_each_main_thread() in the child process, which is wrong, because we run one child per slice, so there's only one main thread. This was causing some slices in the test-tests mode to conclude the test had failed, not because the test had, but because one of the other slices had marked the test's test as failed.

```yaml
  threads:
  - thread: main
    messages:
    - { level: info, text: 'I> Test memory use: (6076 - 2996) / 4 = 770 kB' }
  - thread: main 1
    messages:
    - { level: info, text: 'I> Test memory use: (6068 - 2868) / 4 = 800 kB' }
    - { level: error, text: 'E> Test ran shorter than expected: 24.472 ms (desired 1000.000 ms, min 750.000 ms)' }
    - { level: info, text: 'I> Inner loop average duration: 5.038 ms' }
  - thread: 4
    id: { logical: 2, package: 0, core: 2, thread: 0, family: 6, model: 0x8c, stepping: 1, microcode: 0xac, ppin: null }
    loop-count: 4
    messages:
    - { level: debug, text: 'd> Sampled iteration timings: 9.058 ms, 5.476 ms, 4.944 ms, 4.303 ms' }
```

Note no threads 0 through 3 and no timing information, but that slice 1 has an error.

Drive-by rename some variables from "group" to "slice".
