### PR TITLE
FW/forkfd: add a workaround against the Red Hat buggy 4.18 backport

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1779,10 +1779,8 @@ static StartedChild call_forkfd()
      * https://sourceware.org/bugzilla/show_bug.cgi?id=15368
      * https://yarchive.net/comp/linux/getpid_caching.html
      */
-    enum {
-        PidProperlyUpdated = 2,
-        PidIncorrectlyCached = 1
-    };
+    static constexpr eventfd_t PidProperlyUpdated = 0x646950646f6f47,
+        PidIncorrectlyCached = 0x646950646142;
     static int ffd_extra_flags = -1;
     if (__builtin_expect(ffd_extra_flags < 0, false)) {
         // determine if we need to pass FFD_USE_FORK


### PR DESCRIPTION
See the comment for the description of the problem. Prior to the multi-children rewrite in commit 37cb3e5404eea2847c5da5fe576be0268282b8ee ("FW: rewrite wait_for_child() as wait_for_children()"), the effect of `poll(2)` always returning immediately was that we'd immediately go into `forkfd_wait()`:

```c++
        EINTR_LOOP(ret, forkfd_wait(pfd[0].fd, &info, nullptr));
```

That means the child debugging wouldn't work, but the user would otherwise see no ill effects.

With the rewrite, I added a WNOHANG flag:
```c++
            struct forkfd_info info;
            EINTR_LOOP(ret, forkfd_wait4(pfd.fd, &info, WNOHANG, nullptr));
...
            forkfd_close(pfd.fd);
            pfd.fd = -1;
            pfd.events = 0;
            children.handles[i] = 0;
            children.results[i] = test_result_from_exit_code(info);
```

This causes `waitid(2)` (inside `forkfd_wait4()`) to return immediately with success. That causes garbage data to be copied to the `info` variable. I was fortunate that in my test I got an assertion failure:
```
./opendcdiag/framework/sandstone.cpp:348: ChildExitStatus test_result_from_exit_code(forkfd_info): Assertion `false && "Impossible condition; did we get a CLD_STOPPED??"' failed.
```

Without that, the behaviour would have been completely unpredictable.

Tested on a RHEL 8.6:
```
eventfd2(0, EFD_CLOEXEC)                = 11
eventfd2(0, EFD_CLOEXEC)                = 12
waitid(P_PIDFD, 2147483647, NULL, WNOHANG|WEXITED, NULL) = -1 EBADF (Bad file descriptor)
clone(child_stack=NULL, flags=CLONE_PIDFD|SIGCHLD, parent_tid=[13]) = 25003
poll([{fd=13, events=POLLIN}], 1, 1)    = 1 ([{fd=13, revents=POLLIN}])
write(12, "BadPoll\0", 8)               = 8
close(12)                               = 0
fcntl(13, F_GETFL)                      = 0x2 (flags O_RDWR)
waitid(P_PIDFD, 13, {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=25003, si_uid=0, si_status=127, si_utime=18446744073709551615, si_stime=0}, WEXITED, NULL) = 0
```

https://bugreports.qt.io/browse/QTBUG-100174
https://bugzilla.redhat.com/show_bug.cgi?id=2107643
https://access.redhat.com/errata/RHSA-2022:6460
