### PR TITLE
FW/Logging: Fix incorrect inspection of slices that didn't run

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -122,6 +122,7 @@ public:
     MonotonicTimePoint earliest_fail = MonotonicTimePoint::max();
     ChildExitStatus childExitStatus;
     TestResult testResult = TestResult::Passed;
+    int slices = 0;
     int pc = 0;
     bool skipInMainThread = false;
 
@@ -1660,7 +1661,10 @@ static ChildExitStatus find_most_serious_result(std::span<const ChildExitStatus>
 }
 
 inline AbstractLogger::AbstractLogger(const struct test *test, std::span<const ChildExitStatus> state_)
-    : test(test), childExitStatus(find_most_serious_result(state_)), testResult(childExitStatus.result)
+    : test(test),
+      childExitStatus(find_most_serious_result(state_)),
+      testResult(childExitStatus.result),
+      slices(int(state_.size()))
 {
     // check that most serious result
     switch (testResult) {
@@ -1862,7 +1866,7 @@ void KeyValuePairLogger::print_thread_messages()
 
         munmap_and_truncate_log(data, r);
     };
-    for_each_main_thread(doprint);
+    for_each_main_thread(doprint, slices);
     for_each_test_thread(doprint);
 }
 
@@ -2136,7 +2140,7 @@ void TapFormatLogger::print_thread_messages()
 
         munmap_and_truncate_log(data, r);
     };
-    for_each_main_thread(doprint);
+    for_each_main_thread(doprint, slices);
     for_each_test_thread(doprint);
 }
 
@@ -2441,7 +2445,7 @@ void YamlLogger::print()
 
         munmap_and_truncate_log(data, r);
     };
-    for_each_main_thread(doprint);
+    for_each_main_thread(doprint, slices);
     for_each_test_thread(doprint);
 
     print_child_stderr_common([](int fd) {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -524,9 +524,9 @@ inline void SandstoneApplication::select_main_thread(int slice)
     test_thread_data_ptr += main_thread_data_ptr->cpu_range.starting_cpu;
 }
 
-template <typename Lambda> static void for_each_main_thread(Lambda &&l)
+template <typename Lambda> static void for_each_main_thread(Lambda &&l, int max_slices = INT_MAX)
 {
-    int count = sApp->is_main_process() ? sApp->shmem->main_thread_count : 1;
+    int count = sApp->is_main_process() ? std::min(sApp->shmem->main_thread_count, max_slices) : 1;
     for (int i = 0; i < count; i++)
         l(sApp->main_thread_data(i), -1 - i);
 }


### PR DESCRIPTION
This was mostly harmless and caused only a logging problem. It went unnoticed because if said slice had been run at least once (and hadn't failed the last time), nothing got printed.

We only initialise the `PerThreadData::Main` structure inside the child, so if there was no child, the block would have been left zeroed. And zero `fail_time` means "failed", causing the loggers to print the headers:

```yaml
- test: ifs
  details: { quality: production, description: "Intel In-Field Scan (IFS) hardware selftest" }
  state: { seed: 'LCG:788160728', iteration: 0, retry: false }
  time-at-start: { elapsed:      0.000, now: !!timestamp '2023-08-17T23:05:19Z' }
  result: skip
  skip-category: ResourceIssueSkipCategory
  skip-reason: 'could not open intel_ifs_0/run_test for writing (not running as root?): Permission denied'
  time-at-end:   { elapsed:      2.000, now: !!timestamp '2023-08-17T23:05:19Z' }
  test-runtime: 1.393
  threads:
  - thread: main
    messages:
  - thread: main 1
    messages:
  - thread: main 2
    messages:
  - thread: main 3
    messages:
- test: mce_check
  details: { quality: production, description: "Machine Check Exceptions/Events count" }
  state: { seed: 'LCG:486211036', iteration: 0, retry: false }
  time-at-start: { elapsed:      2.000, now: !!timestamp '2023-08-17T23:05:19Z' }
  result: pass
  time-at-end:   { elapsed:     51.000, now: !!timestamp '2023-08-17T23:05:19Z' }
  test-runtime: 48.306
  threads:
  - thread: main 1
    messages:
  - thread: main 2
    messages:
  - thread: main 3
    messages:
```

Now:
```yaml
- test: ifs
  details: { quality: production, description: "Intel In-Field Scan (IFS) hardware selftest" }
  state: { seed: 'LCG:420197827', iteration: 0, retry: false }
  time-at-start: { elapsed:      0.000, now: !!timestamp '2023-08-17T23:20:52Z' }
  result: skip
  skip-category: ResourceIssueSkipCategory
  skip-reason: 'could not open intel_ifs_0/run_test for writing (not running as root?): Permission denied'
  time-at-end:   { elapsed:      3.333, now: !!timestamp '2023-08-17T23:20:52Z' }
  test-runtime: 3.459
  threads:
  - thread: main
    messages:
- test: mce_check
  details: { quality: production, description: "Machine Check Exceptions/Events count" }
  state: { seed: 'LCG:386261202', iteration: 0, retry: false }
  time-at-start: { elapsed:      3.333, now: !!timestamp '2023-08-17T23:20:52Z' }
  result: pass
  time-at-end:   { elapsed:     76.664, now: !!timestamp '2023-08-17T23:20:52Z' }
  test-runtime: 74.419
```