### PR TITLE
mce_check: fix printing the count of thermal events

### DIFF
--- a/tests/mce_check/mce_check.cpp
+++ b/tests/mce_check/mce_check.cpp
@@ -82,9 +82,9 @@ static int mce_check_run(struct test *test, int cpu)
 
     uint64_t thermal_now = sApp->count_thermal_events();
     if (thermal_now != sApp->last_thermal_event_count) {
-        sApp->last_thermal_event_count = thermal_now;
         log_platform_message(SANDSTONE_LOG_WARNING "Thermal events detected (%zu since start).",
                              size_t(thermal_now - sApp->last_thermal_event_count));
+        sApp->last_thermal_event_count = thermal_now;
     }
 
     return errorcount;


### PR DESCRIPTION
We must update the variable after we've used it. Otherwise, we get:
```
  Main thread:
   - 'W> Platform issue: Thermal events detected (0 since start).'
```
Which is slightly less than fully useful.