### PR TITLE
FW/Logging: fix alignment for the cpu-info array for more than 999 CPUs

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -267,6 +267,8 @@ static auto thread_core_spacing()
             ++result.logical;
         if (max_logical_id > 99)
             ++result.logical;
+        if (max_logical_id > 999)
+            ++result.logical;
         if (max_core_id > 9)
             ++result.core;
         if (max_core_id > 99)


### PR DESCRIPTION
For 8-socket systems we're already close to that limit, with Sapphire Rapids having up to 60 cores (and our competition already has more than that). And it turns out that systems bigger than 8 sockets do exist.

Turns out I was too short-sighted back in 2021:

```
commit 07d00a01c879106c5a5604a15ec6b9a28ebbf7bc
Author: Thiago Macieira <thiago.macieira@intel.com>
Date:   Mon Apr 5 13:51:55 2021 -0700

    FW/logging/YAML: align the logical and core numbers

    Just because I can.

    Code may need adaptation if we ever run into a system with more than 9
    sockets (12 or 16S?).
```