### PR TITLE
Improve socket-related API

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -956,6 +956,10 @@ int num_cpus()
     return sApp->thread_count;
 }
 
+int num_sockets() {
+    return Topology::topology().packages.size();
+}
+
 static LogicalProcessorSet init_cpus()
 {
     LogicalProcessorSet result = ambient_logical_processor_set();

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -613,6 +613,11 @@ extern struct cpu_info *cpu_info;
 /// restricts the number of CPUs sandstone can see.
 int num_cpus() __attribute__((pure));
 
+/// Returns the number of physical CPU packages (a.k.a. sockets) available to a
+/// test. It is number of packages which contain the logical CPUs available to a
+/// test.
+int num_sockets() __attribute__((pure));
+
 #ifdef __cplusplus
 }
 inline int cpu_info::cpu() const

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -322,6 +322,7 @@ struct cpu_info {
     int thread_id;          ///! Topology info from APIC
     int core_id;            ///! Topology info from APIC
     int package_id;         ///! Topology info from APIC
+    int package_idx;        ///! Package index (0 to number of sockets - 1),
     struct cache_info cache[3]; ///! Cache info from OS
     uint8_t family;         ///! CPU family (usually 6)
     uint8_t stepping;       ///! CPU stepping


### PR DESCRIPTION
This contains, essentially, the following:

* add `num_sockets()` API

   This is useful API for the tests that manage the topology of their
   execution, i.e. group threads by sockets (CPU packages).

* keep track of CPU package/socket index in `struct cpu_info`.

    It allows massive simplification for any test that wants to be
    topology-aware. The test can then do a by-socket bookkeeping by simply
    allocating an array of size num_sockets() and use
    cpu_info[cpu].package_idx as index to access cpu's socket element in
    that array.