### PR TITLE
FW/Skip: Add new skip category "TestConfigurationSkipCategory"

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -464,6 +464,8 @@ static const char *char_to_skip_category(int val)
         return "OsNotSupportedSkipCategory";
     case SkipCategory(9):
         return "ThreadIssueSkipCategory";
+    case SkipCategory(10):
+        return "TestConfigurationSkipCategory";
     }
 
     return "NO CATEGORY PRESENT";

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -91,7 +91,8 @@ typedef enum SkipCategory {
     RuntimeSkipCategory,
     SelftestSkipCategory,
     OsNotSupportedSkipCategory,
-    ThreadIssueSkipCategory
+    ThreadIssueSkipCategory,
+    TestConfigurationSkipCategory
 } SkipCategory;
 
 /// logs a skip message to the logfile. log_skip accepts the category to which the skip belongs to


### PR DESCRIPTION
This skip can be used when the test doesn't have enough information/configuration that it needs.

After the changes:

```
result: skip
skip-category: TestConfigurationSkipCategory
skip-reason: 'Not enough information for the test'
```

@eamartin96, @pwlazlyn and @jposwiata requested for this category as their DSA test needs it.