### PR TITLE
Implementation of log_skip on EXIT_SKIP for kvm.c tests

### DIFF
--- a/framework/sysdeps/generic/kvm.c
+++ b/framework/sysdeps/generic/kvm.c
@@ -16,7 +16,7 @@ int kvm_generic_run(struct test *test, int cpu)
 
 int kvm_generic_init(struct test *t)
 {
-    log_info("Virtualization support not implemented on this platform");
+    log_skip(DeviceNotConfiguredSkipCategory, "Virtualization support not implemented on this platform");
     return EXIT_SKIP;
 }
 

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -499,7 +499,7 @@ int kvm_generic_run(struct test *test, int cpu)
             ctx.vm_fd = kvm_generic_create_vm(kvm_fd);
             if (ctx.vm_fd < 0) {
                 if (errno == EBUSY) {
-                    log_info("SKIP reason: cannot create VM: device busy");
+                    log_skip(ResourceIssueSkipCategory, "Cannot create VM: device busy");
                     result = EXIT_SKIP;
                     goto epilogue;
                 }
@@ -630,7 +630,7 @@ int kvm_generic_init(struct test *t)
         goto skip;
     }
     if (!ret) {
-        log_info("KVM_CAP_USER_MEMORY is not available, but required.\n");
+        log_skip(DeviceNotFoundSkipCategory, "KVM_CAP_USER_MEMORY is not available, but required.\n");
         ret = EXIT_SKIP;
         goto skip;
     }


### PR DESCRIPTION
Changes that implement the new style of log_skip in kvm tests in opendcdiag