### PR TITLE
ifs: add a preinit function to set the minimum duration

### DIFF
--- a/tests/ifs/ifs.c
+++ b/tests/ifs/ifs.c
@@ -275,6 +275,17 @@ static int scan_run(struct test *test, int cpu)
         return EXIT_SUCCESS;
 }
 
+static int scan_preinit(struct test *test)
+{
+    /*
+     * Intel documentation says that each core can take up to 200 ms to run.
+     * Note num_cpus() counts logical processors, so this may overestimate the
+     * number of cores.
+     */
+    test->minimum_duration = num_cpus() * 200;
+    return EXIT_SUCCESS;
+}
+
 static int scan_saf_init(struct test *test)
 {
     ifs_test_t *data = (ifs_test_t *) malloc(sizeof(ifs_test_t));
@@ -294,6 +305,7 @@ static int scan_array_init(struct test *test)
 }
 
 DECLARE_TEST(ifs, "Intel In-Field Scan (IFS) hardware selftest")
+    .test_preinit = scan_preinit,
     .test_init = scan_saf_init,
     .test_run = scan_run,
     .desired_duration = -1,
@@ -303,6 +315,7 @@ DECLARE_TEST(ifs, "Intel In-Field Scan (IFS) hardware selftest")
 END_DECLARE_TEST
 
 DECLARE_TEST(ifs_array_bist, "Array BIST: Intel In-Field Scan (IFS) hardware selftest for cache and registers")
+    .test_preinit = scan_preinit,
     .test_init = scan_array_init,
     .test_run = scan_run,
     .desired_duration = -1,


### PR DESCRIPTION
Because this test is sequential, its runtime is proportional to the number of cores being tested. The time for each Scan test is at most 200 ms (per Intel documentation). This will cause the test's target time to be set at a minimum to this value, which then will inform the test's timeout.

We're not bothering to try and find the exact number of cores that are going to be tested, so we may overestimate the minimum duration by half.

This will make a difference for a system with more than 225 logical processors because the formula in `test_timeout()` will go above the 5-minute default:

```c++
    ShortDuration result = regular_duration * 5 + 30s;
    if (result < 300s)
        result = 300s;
```