### PR TITLE
FW: add num_packages() API.

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -974,6 +974,10 @@ int num_cpus()
     return sApp->thread_count;
 }
 
+int num_packages() {
+    return Topology::topology().packages.size();
+}
+
 static LogicalProcessorSet init_cpus()
 {
     LogicalProcessorSet result = ambient_logical_processor_set();

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -613,6 +613,10 @@ extern struct cpu_info *cpu_info;
 /// restricts the number of CPUs sandstone can see.
 int num_cpus() __attribute__((pure));
 
+/// Returns the number of physical CPU packages (a.k.a. sockets) available to a
+/// test.
+int num_packages() __attribute__((pure));
+
 #ifdef __cplusplus
 }
 inline int cpu_info::cpu() const


### PR DESCRIPTION
This is useful API for the tests that manage the topology of their execution, i.e. group threads by CPU packages (sockets).