### PR TITLE
FW/child_debug: restore debug_hung_child() in case of hung children

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1645,6 +1645,7 @@ static void wait_for_children(ChildrenList &children, int *tc, const struct test
         for (size_t i = 0; i < children.handles.size(); ++i) {
             auto child = children.handles[i];
             if (child) {
+                debug_hung_child(child);
 #ifdef _WIN32
                 log_message(-int(i) - 1, SANDSTONE_LOG_ERROR "Child %td did not exit, using TerminateProcess()", child);
                 TerminateProcess(HANDLE(child), EXIT_TIMEOUT);

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -1083,7 +1083,7 @@ void debug_crashed_child()
 
 void debug_hung_child(pid_t child)
 {
-    if (!SandstoneConfig::ChildDebugHangs)
+    if (!SandstoneConfig::ChildDebugHangs || on_hang_action == kill_on_hang)
         return;
 
     char buf[std::numeric_limits<pid_t>::digits10 + 2];


### PR DESCRIPTION
Lost in commit 37cb3e5404eea2847c5da5fe576be0268282b8ee.