### PR TITLE
FW: move up the CPUID detection to the parent process

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -423,6 +423,17 @@ selftest_pass() {
     test_yaml_regexp "/tests/0/threads/0/messages/$i/text" '.*skip.*'
 }
 
+@test "selftest_skip_minimum_cpu" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_skip_minimum_cpu
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/test" selftest_skip_minimum_cpu
+    test_yaml_regexp "/tests/0/result" skip
+    test_yaml_regexp "/tests/0/skip-category" CpuNotSupportedSkipCategory
+    test_yaml_regexp "/tests/0/skip-reason" '.*test requires.*'
+}
+
 @test "selftest_log_skip_init" {
     declare -A yamldump
     sandstone_selftest -e selftest_log_skip_init

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -814,6 +814,13 @@ static void init_internal(const struct test *test)
     logging_init(test);
 }
 
+static void init_per_thread_data()
+{
+    auto initer = [](auto *data, int) { data->init(); };
+    for_each_main_thread(initer);
+    for_each_test_thread(initer);
+}
+
 static void initialize_smi_counts()
 {
     std::optional<uint64_t> v = sApp->count_smi_events(cpu_info[0].cpu_number);
@@ -1738,9 +1745,7 @@ static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
         int ret = 0;
         test->per_thread = sApp->user_thread_data.data();
         std::fill_n(test->per_thread, sApp->thread_count, test_data_per_thread{});
-        auto initer = [](auto *data, int) { data->init(); };
-        for_each_main_thread(initer);
-        for_each_test_thread(initer);
+        init_per_thread_data();
 
         sApp->test_tests_init(test);
         if (test->test_init) {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1730,15 +1730,6 @@ static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
         debug_init_child();
     }
 
-    uint64_t required_cpu_features = test->minimum_cpu | test->compiler_minimum_cpu;
-    if (uint64_t missing = required_cpu_features & ~cpu_features) {
-        // for brevity, don't report the bits that the framework itself needs
-        missing &= ~_compilerCpuFeatures;
-        log_skip(CpuNotSupportedSkipCategory, "test requires %s\n", cpu_features_to_string(missing).c_str());
-        (void) missing;
-        return TestResult::Skipped;
-    }
-
     TestResult state = TestResult::Passed;
 
     do {
@@ -2039,7 +2030,18 @@ static void run_one_test_children(ChildrenList &children, int *tc, const struct 
 static TestResult run_one_test_once(int *tc, const struct test *test)
 {
     ChildrenList children;
-    run_one_test_children(children, tc, test);
+    if (uint64_t missing = (test->minimum_cpu | test->compiler_minimum_cpu) & ~cpu_features) {
+        init_per_thread_data();
+
+        // for brevity, don't report the bits that the framework itself needs
+        missing &= ~_compilerCpuFeatures;
+        log_skip(CpuNotSupportedSkipCategory, "test requires %s\n", cpu_features_to_string(missing).c_str());
+        (void) missing;
+
+        children.results.emplace_back(ChildExitStatus{ TestResult::Skipped });
+    } else {
+        run_one_test_children(children, tc, test);
+    }
 
     // print results and find out if the test failed
     TestResult testResult = logging_print_results(children.results, tc, test);

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2002,9 +2002,8 @@ static int slices_for_test(const struct test *test)
     return plan.size();
 }
 
-static TestResult run_one_test_once(int *tc, const struct test *test)
+static void run_one_test_children(ChildrenList &children, int *tc, const struct test *test)
 {
-    ChildrenList children;
     int child_count = slices_for_test(test);
     if (sApp->current_fork_mode() != SandstoneApplication::exec_each_test) {
         assert(sApp->current_fork_mode() != SandstoneApplication::child_exec_each_test
@@ -2035,6 +2034,12 @@ static TestResult run_one_test_once(int *tc, const struct test *test)
 
     /* wait for the children */
     wait_for_children(children, tc, test);
+}
+
+static TestResult run_one_test_once(int *tc, const struct test *test)
+{
+    ChildrenList children;
+    run_one_test_children(children, tc, test);
 
     // print results and find out if the test failed
     TestResult testResult = logging_print_results(children.results, tc, test);

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -887,8 +887,17 @@ static struct test selftests_array[] = {
     .desired_duration = -1,
 },
 {
+    .id = "selftest_skip_minimum_cpu",
+    .description = "Skips by having unsatisfiable .minimum_cpu requirements",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_init = selftest_failinit_init,            // shouldn't get run
+    .test_run = selftest_fail_run,                  // shouldn't get run
+    .minimum_cpu = ~decltype(test::minimum_cpu)(0), // hopefully we won't get run where this passes!
+    .desired_duration = -1,
+},
+{
     .id = "selftest_skip",
-    .description = "Skipped test",
+    .description = "Skips by returning EXIT_SKIP from the init function",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_init = selftest_skip_init,
     .test_run = selftest_skip_run,
@@ -896,7 +905,7 @@ static struct test selftests_array[] = {
 },
 {
     .id = "selftest_log_skip_init",
-    .description = "This test will test the log_skip feature in the init function",
+    .description = "Skips using log_skip() in the init function",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_init = selftest_log_skip_init,
     .test_run = selftest_log_skip_run,
@@ -904,21 +913,21 @@ static struct test selftests_array[] = {
 },
 {
     .id = "selftest_log_skip_run_all_threads",
-    .description = "This test will test the log_skip feature in the run function where all threads skip",
+    .description = "Skips using log_skip() in the run function where all threads skip",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_run = selftest_log_skip_run_all_threads,
     .desired_duration = -1,
 },
 {
     .id = "selftest_log_skip_run_even_threads",
-    .description = "This test will test the log_skip feature in the run function where only even numbered threads skip",
+    .description = "Skips using log_skip() in the run function where only even numbered threads skip",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_run = selftest_log_skip_run_even_threads,
     .desired_duration = -1,
 },
 {
     .id = "selftest_log_skip_newline",
-    .description = "This test will test the log_skip feature in the init function where there are newlines in the message",
+    .description = "Skips using log_skip() in the init function where there are newlines in the message",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_init = selftest_log_skip_newline_init,
     .test_run = selftest_log_skip_newline_run,


### PR DESCRIPTION
This is where it used to be, in the earliest versions of the framework. I moved it to the child on d0edbae7ad0dde41a3a1b2a41ebfc957f16b409f (2021-03-19) in the old repository:
```
    FW: move the per-test check on CPU features and timing into the child

    This means we'll launch a child for tests that will be skipped, thus
    adding a bit of overhead. But it simplifies logging (especially for
    Windows support).
```
Before this, we were getting away with the `FILE *` logging across parent and child on Linux, but that was a ticking time bomb. Therefore, I simplified by moving all the per-thread logging into the child.

Commit 040bc365e8eeddf27b4a4a892dfb2a7a2a5cb912 (#286) removed the `FILE*` -based logging and moreover 8294f1ae3a1cf3503333bace9954af2e6c4b836f (#324) kept the file descriptors open, so we can now easily bring it back up to the parent. This saves us from launching the child processes when we know we're going to skip -- this is important on Windows where starting processes is relatively expensive.
