### PR TITLE
FW/Logging: log the per-slice resource-consumption information

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1069,6 +1069,10 @@ function selftest_logerror_common() {
     test_yaml_regexp "/exit" invalid
     test_yaml_regexp "/tests/0/result" 'timed out'
     test_yaml_numeric "/tests/0/test-runtime" 'value >= 1000'
+    test_yaml_numeric "/tests/0/threads/0/runtime" 'value >= 1000'
+    if ! $is_windows; then
+        test_yaml_regexp "/tests/0/threads/0/resource-usage" '\{.*\}'
+    fi
     for ((i = 1; i <= MAX_PROC; ++i)); do
         test_yaml_regexp "/tests/0/threads/$i/state" failed
         n=$((-1 + yamldump[/tests/0/threads/$i/messages@len]))
@@ -1099,9 +1103,14 @@ selftest_freeze_socket1_common() {
     done
     for ((j = 0; j < i; ++j)); do
         if ((j < i - 1)); then
+            test_yaml_numeric "/tests/0/threads/$j/runtime" 'value > 0'
             test_yaml_absent "/tests/0/threads/$j/messages/0/text"
         else
+            test_yaml_numeric "/tests/0/threads/$j/runtime" 'value > 1000'
             test_yaml_regexp "/tests/0/threads/$j/messages/0/text" '.* Child .* did not exit.*'
+        fi
+        if ! $is_windows; then
+            test_yaml_regexp "/tests/0/threads/$j/resource-usage" '\{.*\}'
         fi
     done
 

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1086,14 +1086,27 @@ function selftest_logerror_common() {
 
 selftest_freeze_socket1_common() {
     declare -A yamldump
-    test_fail_socket1 sandstone_selftest -vvv --on-crash=kill --on-hang=kill -e selftest_freeze_socket1 --timeout=1s
+    test_fail_socket1 sandstone_selftest -vvv --on-crash=kill --on-hang=kill -e selftest_freeze_socket1 --timeout=1s "$@"
     [[ "$status" -eq 2 ]]
     test_yaml_regexp "/exit" invalid
     test_yaml_regexp "/tests/0/result" 'timed out'
     test_yaml_numeric "/tests/0/test-runtime" 'value >= 1000'
 
+    for ((i = 0; i <= yamldump[/tests/0/threads@len]; ++i)); do
+        if [[ "${yamldump[/tests/0/threads/$i/thread]}" != main* ]]; then
+            break
+        fi
+    done
+    for ((j = 0; j < i; ++j)); do
+        if ((j < i - 1)); then
+            test_yaml_absent "/tests/0/threads/$j/messages/0/text"
+        else
+            test_yaml_regexp "/tests/0/threads/$j/messages/0/text" '.* Child .* did not exit.*'
+        fi
+    done
+
     # only one socket should have frozen
-    for ((i = 1; i <= yamldump[/tests/0/threads@len]; ++i)); do
+    for (( ; i <= yamldump[/tests/0/threads@len]; ++i)); do
         if [[ "${yamldump[/tests/0/threads/$i/id/package]}" = 1 ]]; then
             test_yaml_regexp "/tests/0/threads/$i/state" failed
             n=$((-1 + yamldump[/tests/0/threads/$i/messages@len]))

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -120,9 +120,9 @@ public:
 
     const struct test *test;
     MonotonicTimePoint earliest_fail = MonotonicTimePoint::max();
+    std::span<const ChildExitStatus> slices;
     ChildExitStatus childExitStatus;
     TestResult testResult = TestResult::Passed;
-    int slices = 0;
     int pc = 0;
     bool skipInMainThread = false;
 
@@ -1668,9 +1668,9 @@ static ChildExitStatus find_most_serious_result(std::span<const ChildExitStatus>
 
 inline AbstractLogger::AbstractLogger(const struct test *test, std::span<const ChildExitStatus> state_)
     : test(test),
+      slices(state_),
       childExitStatus(find_most_serious_result(state_)),
-      testResult(childExitStatus.result),
-      slices(int(state_.size()))
+      testResult(childExitStatus.result)
 {
     // check that most serious result
     switch (testResult) {
@@ -1872,7 +1872,7 @@ void KeyValuePairLogger::print_thread_messages()
 
         munmap_and_truncate_log(data, r);
     };
-    for_each_main_thread(doprint, slices);
+    for_each_main_thread(doprint, slices.size());
     for_each_test_thread(doprint);
 }
 
@@ -2146,7 +2146,7 @@ void TapFormatLogger::print_thread_messages()
 
         munmap_and_truncate_log(data, r);
     };
-    for_each_main_thread(doprint, slices);
+    for_each_main_thread(doprint, slices.size());
     for_each_test_thread(doprint);
 }
 
@@ -2451,7 +2451,7 @@ void YamlLogger::print()
 
         munmap_and_truncate_log(data, r);
     };
-    for_each_main_thread(doprint, slices);
+    for_each_main_thread(doprint, slices.size());
     for_each_test_thread(doprint);
 
     print_child_stderr_common([](int fd) {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -40,6 +40,10 @@
 #include "interrupt_monitor.hpp"
 #include "thermal_monitor.hpp"
 
+#ifndef _WIN32
+#  include <sys/resource.h>     // for struct rusage
+#endif
+
 #ifndef O_NOSIGPIPE
 #  define O_NOSIGPIPE 0
 #endif
@@ -144,6 +148,11 @@ struct ChildExitStatus
     // for TestKilled and TestCoreDumped, on Unix it's the signal number;
     // on Windows it's an NTSTATUS
     unsigned extra = 0;
+
+    MonotonicTimePoint endtime = {};
+#ifndef _WIN32
+    struct rusage usage = {};
+#endif
 };
 
 struct test_group

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -937,7 +937,8 @@ static struct test selftests_array[] = {
     .description = "Runs for the requested time, but busy-waiting", // or practically so
     .groups = DECLARE_TEST_GROUPS(&group_positive, &group_fail_test_the_test),
     .test_run = selftest_timedpass_run<0>,
-    .desired_duration = 200
+    .desired_duration = 200,
+    .fracture_loop_count = -1,
 },
 {
     .id = "selftest_timedpass_tooshort",


### PR DESCRIPTION
This was very useful for us in the past few days trying to figure out why tests were failing in the CI but only on certain machines. A crude version of this change revealed that all the tests were consuming less than 50% CPU and had a massive amount of kernel time and involuntary context-switches. That is, they were competing for CPU time with something else (a runaway buggy test on one machine, a runaway VSCode in another[1]).

Regular `timedpass_busywait` on a 4-core TGL:
```yaml
- test: selftest_timedpass_busywait
  time-at-start: { elapsed:      0.000, now: !!timestamp '2023-08-31T20:23:30Z' }
  result: pass
  time-at-end:   { elapsed:    200.000, now: !!timestamp '2023-08-31T20:23:30Z' }
  test-runtime: 200.433
  threads:
  - thread: main
    runtime: 200.421
    resource-usage: { utime: 1560.711, stime: 0.000, cpuavg: 778.7, maxrss: 2692, majflt: 0, minflt: 93, voluntary-cs: 28, involutary-cs: 182 }
```

Ditto with --max-cores-per-slice=2:
```yaml
- test: selftest_timedpass_busywait
  state: { seed: 'AES:5d15bf8fab15a4958d36694d5e77159aa2ea407054ea5b6a72c996b2a188ea65', iteration: 0, retry: false }
  time-at-start: { elapsed:      0.000, now: !!timestamp '2023-08-31T20:24:35Z' }
  result: pass
  time-at-end:   { elapsed:    200.000, now: !!timestamp '2023-08-31T20:24:35Z' }
  test-runtime: 200.458
  threads:
  - thread: main
    runtime: 200.441
    resource-usage: { utime: 769.102, stime: 0.000, cpuavg: 383.7, maxrss: 2692, majflt: 1, minflt: 80, voluntary-cs: 17, involutary-cs: 111 }
  - thread: main 1
    runtime: 200.441
    resource-usage: { utime: 788.959, stime: 0.000, cpuavg: 393.6, maxrss: 2564, majflt: 0, minflt: 85, voluntary-cs: 17, involutary-cs: 76 }
```

[1] https://github.com/microsoft/vscode/issues/124230
