### PR TITLE
CI/Bats: fix test_yaml_regexp

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -60,7 +60,7 @@ test_yaml_numeric() {
 test_yaml_regexp() {
     local value
     extract_from_yaml "$1"
-    if python3 -c "rx = r'''$2'''" -c 'import re,sys;exit(re.fullmatch(rx, sys.argv[2], re.S) is None)'; then
+    if printf "%s" "$value" | grep --line-regexp -Eq -e "$2"; then
         return 0
     fi
     printf "Regexp match failed:\n"

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -86,7 +86,7 @@ test_fail_socket1() {
     fi
 
     # only one socket should have had problems
-    test_yaml_regexp "/tests/0/fail/cpu-mask" 'None|\.:X(:\.)*'
+    test_yaml_regexp "/tests/0/fail/cpu-mask" 'None|\.+:\.*X[.X]*(:.+)?'
 }
 
 @test "time parse negative" {


### PR DESCRIPTION
Commit 12f2f41b29f67527a0e5d3e4d1315d0efd12863b replaced grep with Python because FreeBSD doesn't have GNU grep, so it doesn't have --perl- regexp. However, I made two big blunders with the Python usage: first, the Python interpreter does not accept multiple `-c` arguments, and second I forgot to pass `"$value"` to it to match what we had extracted.

Effectively, this made all test_yaml_regexp pass, regardless of whether it matched anything or not.

