### PR TITLE
FW/child_debug: check SO_SNDBUF instead of SO_RCVBUF

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1423,7 +1423,7 @@ selftest_cpuset_unsorted() {
 
 @test "cpuset=number (inverse order)" {
     # make a list in inverse order
-    local -a cpuset=($($SANDSTONE --dump-cpu-info | tac |
+    local -a cpuset=($($SANDSTONE --dump-cpu-info | sort -rn |
                            awk '/^[0-9]/ { printf "%d,", $1; }'))
     cpuset=${cpuset%,}          # remove last comma
 

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1293,7 +1293,7 @@ crash_context_socket1_common() {
     fi
 
     # Check that gdb can attach to running processes
-    sleep 2m &
+    sleep 120 &
     pid=$!
     if ! gdb -batch -pid $pid -ex kill >/dev/null 2>/dev/null; then
         kill $pid

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -431,7 +431,7 @@ static bool create_crash_pipe(int xsave_size)
 
     int rcvbuf;
     socklen_t size = sizeof(rcvbuf);
-    if (getsockopt(crashpipe[CrashPipeParent], SOL_SOCKET, SO_RCVBUF, &rcvbuf, &size) == 0) {
+    if (getsockopt(crashpipe[CrashPipeParent], SOL_SOCKET, SO_SNDBUF, &rcvbuf, &size) == 0) {
         if (rcvbuf >= xsave_size)
             xsave_size = 0;
     }


### PR DESCRIPTION
On FreeBSD, the SNDBUF is only 2kB by default while the RCVBUF is 16kB, so we need to increase it in order to pass the AVX512 state. We were getting EMSGSIZE when we tried:

```
13804: 0.000012265 sendmsg(4,{NULL,0,[{"\M-l5\0\0\0\0\0\0\0\M-N\M-F)\b\0"...,56},{"\0\0\0\0\0\0\0\0x\a\0\0\0\0\0\0@"...,800},{"\M^?\0\0\0\0\0\0\0\0\0\0\0\0\0\0"...,2176}],3,{},0,0},MSG_NOSIGNAL) ERR#40 'Message too long'
```