### PR TITLE
FW/child_debug: ensure we drain the queue of crash information

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -1059,10 +1059,12 @@ void debug_crashed_child()
 
     // receive the context
     alignas(16) uint8_t xsave_area[xsave_size];     // Variable Length Array, a.k.a. alloca
-    CrashContext ctx = CrashContext::receive(sApp->shmem->server_debug_socket,
-                                             { xsave_area, size_t(xsave_size) });
+    for (;;) {
+        CrashContext ctx = CrashContext::receive(sApp->shmem->server_debug_socket,
+                                                 { xsave_area, size_t(xsave_size) });
 
-    if (ctx.contents != CrashContext::NoContents) {
+        if (ctx.contents == CrashContext::NoContents)
+            break;
         char buf[std::numeric_limits<pid_t>::digits10 + 2];
         sprintf(buf, "%d", ctx.fixed.pid);
 
@@ -1070,14 +1072,14 @@ void debug_crashed_child()
             attach_gdb(buf);
         else
             print_crash_info(buf, ctx);
-    }
 
-    // release the child
-    auto &thread_state = sApp->main_thread_data()->thread_state;
-    thread_state.load(std::memory_order_acquire);
-    if (on_crash_action != context_on_crash) {
-        thread_state.store(thread_debugged, std::memory_order_relaxed);
-        futex_wake_all(&thread_state);
+        // release the child
+        auto &thread_state = sApp->main_thread_data()->thread_state;
+        thread_state.load(std::memory_order_acquire);
+        if (on_crash_action != context_on_crash) {
+            thread_state.store(thread_debugged, std::memory_order_relaxed);
+            futex_wake_all(&thread_state);
+        }
     }
 }
 


### PR DESCRIPTION
This fixes a race condition, because the draining of the socket depended on the order in which we'd get the SIGCHLD / pidfd activation versus the socket. I hadn't observed this on Linux, but it can happen there two: if the parent process is woken up after two children have crashed, we'd only get the context of one.

If this race condition happened, we'd probably blame the next process as a crash too. While that doesn't detection worse (we've already had a crash), it could complicate debugging of the part.