### PR TITLE
FW/child_debug: multiply the buffer size by the number of slices

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -427,6 +427,7 @@ static bool create_crash_pipe(int xsave_size)
     // set the buffer sizes
     xsave_size += sizeof(CrashContext::Fixed) + sizeof(CrashContext::mc);
     xsave_size += 256;      // add some headroom; the Linux kernel subtracts 32
+    xsave_size *= sApp->shmem->main_thread_count;
     xsave_size = ROUND_UP_TO(xsave_size, 1024U);
 
     int rcvbuf;


### PR DESCRIPTION
Otherwise the second or further child that crashed could end up not being able to report it:
```
7543: 0.000043834 sendmsg(4,{...},MSG_NOSIGNAL) = 3032 (0xbd8)
37544: 0.000013963 sendmsg(4,{...},MSG_NOSIGNAL) ERR#55 'No buffer space available'
37540: 0.000017625 recvmsg(3,{...},0) = 3032 (0xbd8)
37540: 0.000008499 recvmsg(3,0x820cfb7b0,0)      ERR#35 'Resource temporarily unavailable'
```