### PR TITLE
CI/Bats: restrict non-fake topologies to threads 0

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -82,7 +82,7 @@ test_fail_socket1() {
         if (( status != 0 )); then
             skip "Test only works with Debug builds (to mock the topology) or multi-socket systems"
         fi
-        "$@" --cpuset=c0
+        "$@" --cpuset=c0t0,c1t0
     fi
 
     # only one socket should have had problems


### PR DESCRIPTION
Commit 3ce88aad5f0adf0093a54c49f4926c6bf4c95132 (PR #404) fixed the regexp but I only tested debug builds, for which we were enforcing the topology to single-threaded. When run on real machines, sometimes it's the thread 1 that crashes first.

So we need to restrict to only threads 0 to get an "X".