### PR TITLE
CI/Bats: fix detection of Windows when running *on* Windows

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -295,7 +295,7 @@ tap_negative_check() {
     test_yaml_regexp "/version" '.*'
 
     local os=`uname -sr`
-    if [[ "$SANDSTONE" = "wine "* ]]; then
+    if [[ "$SANDSTONE" = "wine "* ]] || [[ "$os" = MINGW* ]]; then
         os=`wine cmd /c ver | sed -n "s/\r$//;s/.*Windows /Windows v/p"`
     fi
     [[ "${yamldump[/os]}" = "$os"* ]]


### PR DESCRIPTION
```
$ uname -sr
MINGW64_NT-10.0-22621 3.4.6.x86_64
$ cmd \ /c ver

Microsoft Windows [Version 10.0.22621.2134]
```