### PR TITLE
FW/Win32: fix waiting_for_children() when waiting for multiple children

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1518,8 +1518,6 @@ struct ChildrenList
                 CloseHandle(h);
         }
     }
-
-    std::vector<intptr_t> handles;
 #else
     ~ChildrenList()
     {
@@ -1530,8 +1528,8 @@ struct ChildrenList
     }
 
     std::vector<pollfd> pollfds;
-    std::vector<pid_t> handles;
 #endif
+    std::vector<pid_t> handles;
     std::vector<ChildExitStatus> results;
 
     void add(StartedChild child)


### PR DESCRIPTION
We weren't closing / replacing the handle, so after the first child exited, `WaitForMultipleObjects()` would keep signalling the same child every time. As a consequence, we'd never get the results of the other children, but we'd keep counting children_left down.

`WaitForMultipleObjects` fails with `ERROR_INVALID_HANDLE` if one of the handles is `INVALID_HANDLE_VALUE` (duh!) so we can't use that. We can't repeat the same handle either. The expected solution is to rearrange the array, but instead of that we replace with a dummy, non-signalled handle that will be closed by `~ChildrenList`.

Now this reports properly:
```yaml
  - thread: main
    runtime: 18.816
    messages:
  - thread: main 1
    runtime: 1013.116
    messages:
    - { level: error, text: 'E> Child 384 did not exit, using TerminateProcess()' }
```