### PR TITLE
FW/Win32: statelessly map LogicalProcessor to PROCESSOR_NUMBER

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -308,6 +308,9 @@ tap_negative_check() {
 
     # just verify these exist
     for ((i = 0; i < MAX_PROC; ++i)); do
+        if $is_windows; then
+            test_yaml_numeric "/cpu-info/$i/logical-group" 'value >= 0'
+        fi
         test_yaml_numeric "/cpu-info/$i/logical" 'value >= 0'
         test_yaml_numeric "/cpu-info/$i/package" 'value >= 0'
         test_yaml_numeric "/cpu-info/$i/core" 'value >= 0'
@@ -1506,9 +1509,6 @@ selftest_cpuset_unsorted() {
 @test "thread usage" {
     local -a cpuset=(`$SANDSTONE --dump-cpu-info | awk '/^[0-9]/ { print $1 }'`)
     nproc=${#cpuset[@]}
-    if $is_windows && ((nproc > 64)); then
-        skip "FIXME: Too many CPUs on Windows"
-    fi
 
     # Don't use sandstone_selftest to avoid -n$MAX_PROC
     VALIDATION=dump

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -161,6 +161,7 @@ static int selftest_logs_getcpu_run(struct test *test, int cpu)
 #if defined(_WIN32)
     PROCESSOR_NUMBER number;
     GetCurrentProcessorNumberEx(&number);
+    // see win32/cpu_affinity.cpp
     cpu_number = number.Group * 64 + number.Number;
 #elif defined(__linux__) || defined(__FreeBSD__)
     cpu_number = sched_getcpu();


### PR DESCRIPTION
Instead of statefully depending on the previous count of members in each group, just store them in the bits of the `LogicalProcessor` variable. This turns the operations that used to be O(n) to O(1).

More importantly, this means we don't depend on stateful data that needed to be initialised. It was only initialised by `ambient_logical_processor_set()`, which the child process stopped calling (probably in commit bbf1ad64067897803fdd612e992aa7c827bf1baa). That was an intentional change, because the child should never need to know the full system's ambient processor set, only what the parent process tells it to care about.

As a side-effect of that, the child process wouldn't have the state initialised, so `processor_group_for()` would always return zero and `processor_in_group()` would return `n` (cast to `BYTE`). That is only correct for systems with a single processor group, which happens to be all the development machines we tested this on. For systems with more than one group, we would fail to map back from `LogicalProcessor` to `PROCESSOR_NUMBER`. Additionally, we'd cause Undefined Behaviour on line:
```c++
     groupAffinity.Mask = KAFFINITY(1) << processorNumber.Number;
```
for logical processors 64 to 255, 320 to 511, etc.