### PR TITLE
FW/Win32: implement pin_to_logical_processors()

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -243,16 +243,7 @@ static const char *path_to_exe()
 static void perror_for_mmap(const char *msg)
 {
 #ifdef _WIN32
-    DWORD dwFlags = FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS |
-            FORMAT_MESSAGE_ARGUMENT_ARRAY | FORMAT_MESSAGE_ALLOCATE_BUFFER;
-    LPCVOID lpSource = nullptr;
-    DWORD dwMessageId = GetLastError();
-    DWORD dwLanguageId = 0;
-    LPSTR lpBuffer = nullptr;
-    DWORD nSize = 0;
-    FormatMessage(dwFlags, lpSource, dwMessageId, dwLanguageId, (LPTSTR)&lpBuffer, nSize, nullptr);
-    fprintf(stderr, "%s: %s\n", msg, lpBuffer);
-    LocalFree(lpBuffer);
+    win32_perror(msg);
 #else
     perror(msg);
 #endif

--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -58,11 +58,15 @@ bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
 
     HANDLE hThread = GetCurrentThread();
     if (!SetThreadGroupAffinity(hThread, &groupAffinity, nullptr)) {
-        // failed
+        win32_perror("SetThreadGroupAffinity");
         return false;
     }
 
-    return SetThreadIdealProcessorEx(hThread, &processorNumber, nullptr) == 0;
+    if (SetThreadIdealProcessorEx(hThread, &processorNumber, nullptr) == 0) {
+        win32_perror("SetThreadIdealProcessorEx");
+        return false;
+    }
+    return true;
 }
 
 bool pin_to_logical_processors(CpuRange range, const char *thread_name)

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -14,6 +14,7 @@ framework_files += \
         'tmpfile.c',
         'ucrt-mapping.c',
         'unistd.c',
+        'win32_perror.c',
         '../generic/kvm.c',
         '../generic/memfpt.c',
         '../generic/msr.c',

--- a/framework/sysdeps/windows/win32_perror.c
+++ b/framework/sysdeps/windows/win32_perror.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <windows.h>
+
+void win32_perror(const char *msg)
+{
+    DWORD dwFlags = FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS |
+            FORMAT_MESSAGE_ARGUMENT_ARRAY | FORMAT_MESSAGE_ALLOCATE_BUFFER;
+    LPCVOID lpSource = NULL;
+    DWORD dwMessageId = GetLastError();
+    DWORD dwLanguageId = 0;
+    LPSTR lpBuffer = NULL;
+    DWORD nSize = 0;
+    FormatMessage(dwFlags, lpSource, dwMessageId, dwLanguageId, (LPTSTR)&lpBuffer, nSize, NULL);
+    if (msg)
+        fprintf(stderr, "%s: ", msg);
+    fprintf(stderr, "%s\n", lpBuffer);
+    LocalFree(lpBuffer);
+
+    SetLastError(dwMessageId);      /* restore */
+}

--- a/framework/sysdeps/windows/win32_stdlib.h
+++ b/framework/sysdeps/windows/win32_stdlib.h
@@ -30,6 +30,10 @@ int posix_memalign(void **memptr, size_t alignment, size_t size);
 void *aligned_alloc(size_t alignment, size_t size);
 void *valloc(size_t size);
 
+/* not stdlib.h, but injected here because we're lazy;
+ * prints the GetLastError() message instead of errno. */
+void win32_perror(const char *s);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
We're expecting that the child processes are restricted to a single Windows Processor Group, in which case we can ask the OS to set the affinity to that group. This will affect the child process' main thread only, so it's not a big deal if we don't do anything. It's actually more important that we be quick.

Also print the error message from `pin_to_logical_processor()` if there's a failure.