### PR TITLE
FW/Topology: make a copy of the argv contents in apply_cpuset_param()

### DIFF
--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -674,7 +674,8 @@ void apply_cpuset_param(char *param)
     LogicalProcessorSet result = {};
     new_cpu_info.reserve(old_cpu_info.size());
 
-    for (char *arg = strtok(param, ","); arg; arg = strtok(nullptr, ",")) {
+    std::string p = param;
+    for (char *arg = strtok(p.data(), ","); arg; arg = strtok(nullptr, ",")) {
         const char *orig_arg = arg;
         auto parse_int = [&arg, orig_arg]() {
             errno = 0;


### PR DESCRIPTION
`strtok()` by necessity must modify the input by adding NULs, and this causes the logging to improperly print parameters with commas.

Previously:
```
$ ./opendcdiag --quick -o - --cpuset c0,c2
command-line: 'opendcdiag --quick -o - --cpuset c0'
```

Now:
```
$ ./opendcdiag --quick -o - --cpuset c0,c2
command-line: 'opendcdiag --quick -o - --cpuset c0,c2'
```