### PR TITLE
FW: increase the --retest-on-failure maximum to 128

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2160,7 +2160,7 @@ static void analyze_test_failures(int tc, const struct test *test, int fail_coun
                 int nthreads = 0;
                 fail_pattern = 0;
                 for (const Topology::Thread &thr : core->threads) {
-                    uint64_t this_pattern = per_cpu_failures[thr.cpu()];
+                    auto this_pattern = per_cpu_failures[thr.cpu()];
                     if (this_pattern == 0)
                         all_threads_failed_once = false;
                     if (++nthreads == 1) {
@@ -2212,11 +2212,12 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
     }
     auto mark_up_per_cpu_fail = [&per_cpu_fails, &fail_count](int i) {
         ++fail_count;
-        if (i >= 64)
-            return;     // we only have 64 bits
+        if (i >= SandstoneApplication::MaxRetestCount)
+            return;
         for_each_test_thread([&](PerThreadData::Test *data, int i) {
+            using U = SandstoneApplication::PerCpuFailures::value_type;
             if (data->has_failed())
-                per_cpu_fails[i] |= uint64_t(1) << i;
+                per_cpu_fails[i] |= U(1) << i;
         });
     };
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -354,7 +354,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
         std::array<Slices, 2> plans;
     };
 
-    using PerCpuFailures = std::vector<uint64_t>;
+    using PerCpuFailures = std::vector<__uint128_t>;
     struct SharedMemory;
 
     SlicePlans slice_plans;
@@ -380,7 +380,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     bool ignore_os_errors = false;
     bool force_test_time = false;
     bool service_background_scan = false;
-    static constexpr int MaxRetestCount = 64;
+    static constexpr int MaxRetestCount = sizeof(PerCpuFailures::value_type) * 8;
     int retest_count = 10;
     int total_retest_count = -2;
     int max_test_count = INT_MAX;

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -338,14 +338,15 @@ static constexpr unsigned maskFromRatio()
     int BitPosition = __builtin_ctzll(Ratio::den);
 
     // because this is constexpr, the following expression will check the range of BitPosition
-    return 1U << (BitPosition - 1);
+    return 1U << BitPosition;
 }
 
 template <typename Ratio>
 static int selftest_randomfail_run(struct test *test, int cpu)
 {
     constexpr unsigned Value = maskFromRatio<Ratio>();
-    return rand() % (Value * sApp->thread_count) ? EXIT_SUCCESS : EXIT_FAILURE;
+    unsigned ratio = (Value * sApp->thread_count);
+    return rand() % ratio ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 template <useconds_t Sleeptime, typename Ratio>


### PR DESCRIPTION
We've had a customer asking to be able to say --retest-on-failure=99 so they can get proper 1% granularity.