### PR TITLE
FW: re-add a log_skip if a test init() returns a negative errno

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1769,6 +1769,8 @@ static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
             state = TestResult::Failed;
             break;
         } else if (ret < 0) {
+            if (ret != EXIT_SKIP)
+                log_skip(RuntimeSkipCategory, "Unexpected OS error: %s", strerror(-ret));
             state = TestResult::Skipped;
             break;
         }


### PR DESCRIPTION
Before:
```yaml
  time-at-start: { elapsed:      0.000, now: !!timestamp '2023-09-06T21:09:16Z' }
  result: skip
  skip-category: UnknownSkipCategory
  skip-reason: Unknown, check main thread message for details or use -vv option for more info
  time-at-end:   { elapsed:      0.000, now: !!timestamp '2023-09-06T21:09:16Z' }
```

After:
```yaml
  time-at-start: { elapsed:      0.000, now: !!timestamp '2023-09-06T21:26:25Z' }
  result: skip
  skip-category: RuntimeSkipCategory
  skip-reason: 'Unexpected OS error: Permission denied'
  time-at-end:   { elapsed:      0.000, now: !!timestamp '2023-09-06T21:26:25Z' }
```