### PR TITLE
FW/Unix: fix handling of signals in wait_for_children()

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1658,8 +1658,6 @@ static void wait_for_children(ChildrenList &children, int *tc, const struct test
         --children_left;
         return 0;
     };
-    (void) tc;
-    (void) test;
 #else
 #  error "What platform is this?"
 #endif


### PR DESCRIPTION
The rewrite in commit 37cb3e5404eea2847c5da5fe576be0268282b8ee for wait_for_children() accidentally broke the handling of interruptions by signals on Unix systems, which exists to ensure all the processes get interrupted if the parent process is.

Handling of SIGHUP and SIGTERM was easy, since single_wait() was already returning the correct signal number, but wait_for_all_children() wasn't acting on it. Handling of SIGINT required remembering we had been interrupted once.

Fixes #429.