### PR TITLE
[signal handling] Proper handling for TERM/INT signals

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -95,7 +95,7 @@ typedef enum SkipCategory {
 } SkipCategory;
 
 /// logs a skip message to the logfile. log_skip accepts the category to which the skip belongs to
-/// and accepts a constant format string followed by 0 or more arguments that provide data for the 
+/// and accepts a constant format string followed by 0 or more arguments that provide data for the
 /// format string.
 #define log_skip(skip_category, ...)          log_message_skip(thread_num, skip_category, __VA_ARGS__)
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -124,12 +124,12 @@ enum class TestResult : int8_t {
     Skipped = -1,
     Passed,
     Failed,
-    Killed,
     CoreDumped,
     OperatingSystemError,
     OutOfMemory,
     TimedOut,
     Interrupted,
+    Killed,
 };
 
 enum ThreadState : int {


### PR DESCRIPTION
Signal handlers causes application to stop as soon as required (first TERM causes immediate app stop, first INT/Ctrl-C causes warning, second stops the app with status 'Interrupted'). After single INT/Ctrl-C app reports exit status Interrupt (with appropriate exit code).

It fixes https://github.com/opendcdiag/opendcdiag/issues/429