### PR TITLE
FW/Topology: fill in the topology before family/model/stepping

### DIFF
--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -806,11 +806,11 @@ static void init_topology_internal(const LogicalProcessorSet &enabled_cpus)
 
             pin_to_logical_processor(lp);
             init_cpu_info(&cpu_info[i], curr_cpu);
+            try_detection<topo_impls>(&cpu_info[i]);
             try_detection<family_impls>(&cpu_info[i]);
             try_detection<ppin_impls>(&cpu_info[i]);
             try_detection<ucode_impls>(&cpu_info[i]);
             try_detection<cache_info_impls>(&cpu_info[i]);
-            try_detection<topo_impls>(&cpu_info[i]);
         }
         return nullptr;
     };


### PR DESCRIPTION
Because otherwise the warning output on mismatch says "package -1".

```
WARNING: Inconsistent CPU information detected. Reference socket 0 is family 0x06, model 0x8f, stepping 0x06
WARNING: CPU 56 on socket -1 differs from socket 0: family 0x06 model 0x8f, stepping 0x08.
```