### PR TITLE
FW: Add new skip categories

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -466,7 +466,11 @@ static const char *char_to_skip_category(int val)
     case SkipCategory(8):
         return "OsNotSupportedSkipCategory";
     case SkipCategory(9):
-        return "ThreadIssueSkipCategory";
+        return "TestResourceIssueSkipCategory";
+    case SkipCategory(10):
+        return "CpuTopologyIssueSkipCategory";
+    case SkipCategory(11):
+        return "OSResourceIssueSkipCategory";
     }
 
     return "NO CATEGORY PRESENT";

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -449,27 +449,27 @@ static uint8_t status_level(char letter)
 static const char *char_to_skip_category(int val)
 {
     switch (val) {
-    case SkipCategory(1):
+    case ResourceIssueSkipCategory:
         return "ResourceIssueSkipCategory";
-    case SkipCategory(2):
+    case CpuNotSupportedSkipCategory:
         return "CpuNotSupportedSkipCategory";
-    case SkipCategory(3):
+    case DeviceNotFoundSkipCategory:
         return "DeviceNotFoundSkipCategory";
-    case SkipCategory(4):
+    case DeviceNotConfiguredSkipCategory:
         return "DeviceNotConfiguredSkipCategory";
-    case SkipCategory(5):
+    case UnknownSkipCategory:
         return "UnknownSkipCategory";
-    case SkipCategory(6):
+    case RuntimeSkipCategory:
         return "RuntimeSkipCategory";
-    case SkipCategory(7):
+    case SelftestSkipCategory:
         return "SelftestSkipCategory";
-    case SkipCategory(8):
+    case OsNotSupportedSkipCategory:
         return "OsNotSupportedSkipCategory";
-    case SkipCategory(9):
+    case TestResourceIssueSkipCategory:
         return "TestResourceIssueSkipCategory";
-    case SkipCategory(10):
+    case CpuTopologyIssueSkipCategory:
         return "CpuTopologyIssueSkipCategory";
-    case SkipCategory(11):
+    case OSResourceIssueSkipCategory:
         return "OSResourceIssueSkipCategory";
     }
 

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -91,7 +91,9 @@ typedef enum SkipCategory {
     RuntimeSkipCategory,
     SelftestSkipCategory,
     OsNotSupportedSkipCategory,
-    ThreadIssueSkipCategory
+    TestResourceIssueSkipCategory,
+    CpuTopologyIssueSkipCategory,
+    OSResourceIssueSkipCategory
 } SkipCategory;
 
 /// logs a skip message to the logfile. log_skip accepts the category to which the skip belongs to

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -246,7 +246,7 @@ static int selftest_log_skip_newline_init(struct test *test)
 
 static int selftest_log_skip_newline_run(struct test *test, int cpu)
 {
-    log_skip(RuntimeSkipCategory, "This message should never be displayed");
+    log_skip(SelftestSkipCategory, "This message should never be displayed");
     return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
The following 3 skip categories are added

TestResourceIssueSkipCategory
CpuTopologyIssueSkipCategory
OSResourceIssueSkipCategory

Removed Category: ThreadIssueSkipCategory

**Please do not merge yet**