### PR TITLE
FW/Logging: add logging_flush() to logging_init()

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1098,6 +1098,8 @@ void logging_init(const struct test *test)
     case SandstoneApplication::OutputFormat::no_output:
         return;                 // short-circuit
     }
+
+    logging_flush();
 }
 
 void logging_init_child_preexec()


### PR DESCRIPTION
This is right after we print the test that is about to start, so is a logical place to flush the log to filesystem.

I noticed this on a defective machine that rebooted because of a test, that the actual log file said a test had finished and passed:
```yaml
  time-at-start: { elapsed: 13592188.000, now: !!timestamp '2023-10-25T02:06:39Z' }
  result: pass
  time-at-end:   { elapsed: 13592280.000, now: !!timestamp '2023-10-25T02:06:39Z' }
  test-runtime: 92.027
```

But the terminal from which I launched the tool (tmux rules!) logged the next test starting:
```yaml
- test: xxxxx
  time-at-start: { elapsed: 13592280.000, now: !!timestamp '2023-10-25T02:06:39Z' }
```