### PR TITLE
CI/Bats: use mktempfile in testenv.bash

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -4,15 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 load ../testenv
 
-mktempfile() {
-    # find a temporary directory for us
-    local tmpdir=$BATS_TEST_TMPDIR
-    tmpdir=${tmpdir-$BATS_TMPDIR}
-    tmpdir=${tmpdir-$TMPDIR}
-    tmpdir=${tmpdir-/tmp}
-    TMPDIR=$tmpdir mktemp --tmpdir "$@"
-}
-
 sandstone_selftest() {
     VALIDATION=dump
     run_sandstone_yaml -n$MAX_PROC --disable=mce_check --no-triage --selftests --timeout=20s --retest-on-failure=0 -Y2 "$@"

--- a/bats/testenv.bash
+++ b/bats/testenv.bash
@@ -54,6 +54,15 @@ function setup_sandstone()
     fi
 }
 
+function mktempfile() {
+    # find a temporary directory for us
+    local tmpdir=$BATS_TEST_TMPDIR
+    tmpdir=${tmpdir-$BATS_TMPDIR}
+    tmpdir=${tmpdir-$TMPDIR}
+    tmpdir=${tmpdir-/tmp}
+    TMPDIR=$tmpdir mktemp --tmpdir "$@"
+}
+
 function run_sandstone_yaml_post()
 {
     # any test may override
@@ -66,7 +75,7 @@ function run_sandstone_yaml()
     [[ " $* " == *" --selftests "* ]] || is_selftest=0
 
     # bats' "run" function would help, but it fails on older bats...
-    local yamlfile=`mktemp output-XXXXXX.yaml`
+    local yamlfile=`mktempfile output-XXXXXX.yaml`
     local command="$SANDSTONE -Y -o - \"\$@\" >&3; echo \$?"
     if [[ -n "$TASKSET" ]]; then
         command="taskset ${TASKSET} $command"


### PR DESCRIPTION
That function enforces creating the file in a temporary dir, unlike mktemp command.