### PR TITLE
FW: add --ignore-unknown-tests option

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -21,9 +21,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#if __has_include(<fnmatch.h>)
-#  include <fnmatch.h>
-#endif
+#include <fnmatch.h>
 #include <getopt.h>
 #include <inttypes.h>
 #include <limits.h>
@@ -2476,14 +2474,10 @@ static NameMatchingStatus test_matches_name(const struct test *test, const char 
     // match test ID exactly
     if (strcmp(name, test->id) == 0)
         return NameMatchesExactly;
-#if __has_include(<fnmatch.h>)
+
     // match test ID as a wildcard
     if (fnmatch(name, test->id, 0) == 0)
         return NameMatches;
-#elif defined(_WIN32)
-    if (PathMatchSpecA(test->id, name))
-        return NameMatches;
-#endif
 
     // does it match one of the groups?
     if (*name == '@') {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -121,6 +121,7 @@ enum {
     fatal_skips_option,
     gdb_server_option,
     ignore_os_errors_option,
+    ignore_unknown_tests_option,
     is_asan_option,
     is_debug_option,
     force_test_time_option,
@@ -1351,6 +1352,8 @@ Common command-line options are:
  --ignore-os-error, --ignore-timeout
      Continue execution of Sandstone even if a test encounters an operating
      system error (this includes tests timing out).
+ --ignore-unknown-tests
+     Ignore unknown tests listed on --enable and --disable.
  -h, --help
      Print help.
  -l, --list
@@ -2981,8 +2984,9 @@ int main(int argc, char **argv)
         { "fatal-skips", no_argument, nullptr, fatal_skips_option },
         { "fork-mode", required_argument, nullptr, 'f' },
         { "help", no_argument, nullptr, 'h' },
-        { "ignore-timeout", no_argument, nullptr, ignore_os_errors_option },
         { "ignore-os-errors", no_argument, nullptr, ignore_os_errors_option },
+        { "ignore-timeout", no_argument, nullptr, ignore_os_errors_option },
+        { "ignore-unknown-tests", no_argument, nullptr, ignore_unknown_tests_option },
         { "list", no_argument, nullptr, 'l' },
         { "list-tests", no_argument, nullptr, raw_list_tests },
         { "list-group-members", required_argument, nullptr, raw_list_group_members },
@@ -3202,6 +3206,9 @@ int main(int argc, char **argv)
 #endif
         case ignore_os_errors_option:
             sApp->ignore_os_errors = true;
+            break;
+        case ignore_unknown_tests_option:
+            sApp->ignore_unknown_tests = true;
             break;
         case is_asan_option:
         case is_debug_option:

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -378,6 +378,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
             fork_each_test;
 #endif
     bool ignore_os_errors = false;
+    bool ignore_unknown_tests = false;
     bool force_test_time = false;
     bool service_background_scan = false;
     static constexpr int MaxRetestCount = sizeof(PerCpuFailures::value_type) * 8;

--- a/framework/sysdeps/windows/fnmatch.c
+++ b/framework/sysdeps/windows/fnmatch.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "fnmatch.h"
+
+#include <assert.h>
+#include <shlwapi.h>
+
+int fnmatch(const char *pattern, const char *name, int flags)
+{
+    assert(flags == 0);
+    (void) flags;
+
+    return PathMatchSpecA(name, pattern) ? 0 : 1;
+}

--- a/framework/sysdeps/windows/fnmatch.h
+++ b/framework/sysdeps/windows/fnmatch.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SANDSTONE_WIN32_FNMATCH_H
+#define SANDSTONE_WIN32_FNMATCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int fnmatch(const char *pattern, const char *name, int flags);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif // SANDSTONE_WIN32_FNMATCH_H

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -7,6 +7,7 @@ framework_files += \
         'child_debug.cpp',
         'cpu_affinity.cpp',
         'fcntl.c',
+        'fnmatch.c',
         'mman.c',
         'resource.cpp',
         'signals.cpp',

--- a/framework/test_selectors/SelectorFactory.cpp
+++ b/framework/test_selectors/SelectorFactory.cpp
@@ -11,14 +11,198 @@
 #include "WeightedNonRepeatingSelector.h"
 #include "WeightedRepeatingSelector.h"
 
-#include <unordered_map>
-#include <vector>
 #include "sandstone.h"
+#include "sandstone_kvm.h"
 #include "sandstone_p.h"
 
-using namespace std;
+#include <vector>
+#include <fnmatch.h>
 
-// TODO: Next steps are to relocate this functionality so this file is nothing but #include statements
+using namespace std;
+extern test mce_test;
+
+enum TestSearchOptions : unsigned {
+    MatchExact      = 0x00,
+    MatchWildcard   = 0x01,
+    MatchGroups     = 0x02,
+};
+static constexpr auto StandardTestMatchOptions = TestSearchOptions(MatchWildcard | MatchGroups);
+
+enum NameMatchingStatus { NameDoesNotMatch = 0, NameMatches, NameMatchesExactly };
+
+static void apply_group_inits(/*nonconst*/ struct test *test)
+{
+    // Create an array with the replacement functions per group and cache.
+    // If the group_init function decides that the group cannot run at all, it
+    // will return a pointer to a replacement function that will in turn cause
+    // the test to fail or skip during test_init().
+
+    std::span<const struct test_group> groups = { &__start_test_group, &__stop_test_group };
+    static auto replacements = [=]() {
+        struct Result {
+            decltype(test_group::group_init) group_init;
+            decltype(test_group::group_init()) replacement;
+        };
+
+        std::vector<Result> replacements(groups.size());
+        size_t i = 0;
+        for ( ; i < replacements.size(); ++i) {
+            replacements[i].group_init = groups[i].group_init;
+            replacements[i].replacement = nullptr;
+        }
+        return replacements;
+    }();
+
+    for (auto ptr = test->groups; *ptr; ++ptr) {
+        for (size_t i = 0; i < groups.size(); ++i) {
+            if (*ptr != &groups.begin()[i])
+                continue;
+            if (replacements[i].group_init && !replacements[i].replacement) {
+                // call the group_init function, only once
+                replacements[i].replacement = replacements[i].group_init();
+                replacements[i].group_init = nullptr;
+            }
+            if (replacements[i].replacement) {
+                test->test_init = replacements[i].replacement;
+                return;
+            }
+        }
+    }
+}
+
+static void prepare_test(/*nonconst*/ struct test *test)
+{
+    if (test->test_preinit) {
+        test->test_preinit(test);
+        test->test_preinit = nullptr;   // don't rerun in case the test is re-added
+    }
+    if (test->groups)
+        apply_group_inits(test);
+
+    if (test->flags & test_type_kvm) {
+        if (!test->test_init) {
+            test->test_init = kvm_generic_init;
+            test->test_run = kvm_generic_run;
+            test->test_cleanup = kvm_generic_cleanup;
+        }
+    }
+}
+
+void add_test(std::vector<struct test *> &test_list, /*nonconst*/ struct test *test)
+{
+    if (test)
+        prepare_test(test);
+    test_list.push_back(test);
+}
+
+static NameMatchingStatus test_matches_name(const struct test *test, const char *name,
+                                            TestSearchOptions options = StandardTestMatchOptions)
+{
+    // match test ID exactly
+    if (strcmp(name, test->id) == 0)
+        return NameMatchesExactly;
+
+    // match test ID as a wildcard
+    if ((options & MatchWildcard) && fnmatch(name, test->id, 0) == 0)
+        return NameMatches;
+
+    // does it match one of the groups?
+    if ((options & MatchGroups) && *name == '@') {
+        for (auto ptr = test->groups; ptr && *ptr; ++ptr) {
+            if (strcmp(name + 1, (*ptr)->id) == 0)
+                return NameMatches;
+        }
+    }
+
+    return NameDoesNotMatch;
+}
+
+static void print_unknown_test(const char *name)
+{
+    fprintf(stderr, "%s: Cannot find test '%s'\n", program_invocation_name, name);
+    exit(EX_USAGE);
+}
+
+void add_tests(std::span<struct test> test_set, std::vector<struct test *> &test_list, const char *name)
+{
+    constexpr auto options = TestSearchOptions(MatchWildcard | MatchGroups);
+    int count = 0;
+    for (struct test &test: test_set) {
+        auto matches = test_matches_name(&test, name, options);
+        if (!matches)
+            continue;
+
+        prepare_test(&test);
+        ++count;
+        if (test.quality_level >= sApp->requested_quality) {
+            add_test(test_list, &test);
+        } else if (test_list.empty()) {
+            // add a dummy entry just so the list isn't empty
+            test_list.push_back(nullptr);
+        }
+    }
+
+    if (count == 0)
+        print_unknown_test(name);
+}
+
+void disable_tests(std::span<struct test> test_set, const char *name)
+{
+    constexpr auto options = TestSearchOptions(MatchWildcard | MatchGroups);
+    int count = 0;
+    for (struct test &test : test_set) {
+        if (test_matches_name(&test, name, options)) {
+            disable_test(&test);
+            ++count;
+        }
+    }
+
+    if (count == 0) {
+        if (!strcmp(name, "mce_check")) {
+            if constexpr (InterruptMonitor::InterruptMonitorWorks)
+                disable_test(&mce_test);
+        } else {
+            print_unknown_test(name);
+        }
+    }
+}
+
+struct test *TestrunSelector::testid_to_test(const char *id, bool silent)
+{
+    for (struct test *test : testinfo) {
+        auto matches = test_matches_name(test, id, MatchExact);
+        if (!matches)
+            continue;
+
+        if (test->quality_level < sApp->requested_quality)
+            return nullptr;
+
+        prepare_test(test);
+        return test;
+    }
+
+    if (!silent)
+        print_unknown_test(id);
+    return nullptr;
+}
+
+void generate_test_list(std::vector<struct test *> &test_list, std::span<struct test> test_set,
+                        int min_quality)
+{
+    if (SandstoneConfig::RestrictedCommandLine || test_list.empty()) {
+        if (!SandstoneConfig::RestrictedCommandLine && sApp->fatal_skips)
+            fprintf(stderr, "# WARNING: --fatal-skips used with full test suite. This will probably fail.\n"
+                            "# You may want to specify a controlled list of tests to run.\n");
+        /* generate test list based on quality levels only */
+        for (struct test &test : test_set) {
+            if (test.quality_level >= min_quality)
+                add_test(test_list, &test);
+        }
+    } else if (test_list.front() == nullptr) {
+        /* remove the dummy entry we added (see add_tests()) */
+        test_list.erase(test_list.begin());
+    }
+}
 
 extern TestrunSelector * setup_test_selector(
         WeightedTestScheme         selectScheme,

--- a/framework/test_selectors/SelectorFactory.h
+++ b/framework/test_selectors/SelectorFactory.h
@@ -6,8 +6,22 @@
 #ifndef __WEIGHTEDTESTRUNSELECTOR_H
 #define __WEIGHTEDTESTRUNSELECTOR_H
 
+#include <span>
+
 // Include base class
 #include "TestrunSelectorBase.h"
+
+inline void disable_test(struct test *test)
+{
+    test->quality_level = TEST_QUALITY_SKIP;
+}
+
+void add_test(std::vector<struct test *> &test_list, /*nonconst*/ struct test *test);
+void add_tests(std::span<struct test> test_set, std::vector<struct test *> &test_list,
+               const char *name);
+void disable_tests(std::span<struct test> test_set, const char *name);
+void generate_test_list(std::vector<struct test *> &test_list, std::span<struct test> test_set,
+                               int min_quality = sApp->requested_quality);
 
 extern TestrunSelector * setup_test_selector(
         WeightedTestScheme         selectScheme,

--- a/framework/test_selectors/TestrunSelectorBase.h
+++ b/framework/test_selectors/TestrunSelectorBase.h
@@ -22,26 +22,11 @@ protected:
     {
     }
 
-    struct test * testid_to_test(const char *id, bool silent)
-    {
-        for (struct test *test: testinfo) {
-            if (strcmp(id, test->id) == 0) {
-                // check the quality level
-                if (test->quality_level >= sApp->requested_quality)
-                    return test;
-
-                // silently skip if the requested quality is too high
-                return nullptr;
-            }
-        }
-        if (!silent) {
-            fprintf(stderr, "\nERROR: Attempt to specify non-existent test id [%s] in list file\n", id);
-            exit(EX_USAGE);
-        }
-        return nullptr;
-    }
+    // in sandstone.cpp
+    struct test * testid_to_test(const char *id, bool silent);
 
 public:
+
     virtual ~TestrunSelector() = default;
     virtual struct test * get_next_test() = 0;
     virtual void reset_selector() {};

--- a/meson.build
+++ b/meson.build
@@ -279,6 +279,7 @@ executable(
         '-march=haswell',
         debug_c_flags,
         default_cpp_warn,
+	'-USANDSTONE',
     ],
     build_by_default : false,
     native : true,


### PR DESCRIPTION
Centralises the handling from test files and command-line, and fixes the missing preinit and group initialisation from test files.

[ChangeLog][Framework] Added the --ignore-unknown-tests option, to ignore unknown tests in the --enable and --disable options.
