### PR TITLE
Handling signals between tests

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2611,12 +2611,11 @@ static struct test *get_next_test(int tc)
     return test;
 }
 
-static void wait_delay_between_tests()
+static bool wait_delay_between_tests()
 {
     useconds_t useconds = duration_cast<microseconds>(sApp->delay_between_tests).count();
-
     // make the system call even if delay_between_tests == 0
-    usleep(useconds);
+    return usleep(useconds) == 0;
 }
 
 static int exec_mode_run(int argc, char **argv)
@@ -3056,11 +3055,11 @@ static void background_scan_update_load_threshold(MonotonicTimePoint now)
 }
 
 // Don't run tests unless load is low or it's time to run a test anyway
-static void background_scan_wait()
+static bool background_scan_wait()
 {
     auto as_seconds = [](Duration d) -> int { return duration_cast<seconds>(d).count(); };
 
-    auto do_wait = [](Duration base_wait, Duration variable) {
+    auto do_wait = [](Duration base_wait, Duration variable) -> bool {
         microseconds ubase = duration_cast<microseconds>(base_wait);
         microseconds uvar = duration_cast<microseconds>(variable);
 
@@ -3069,7 +3068,7 @@ static void background_scan_wait()
         auto deviation = duration_cast<microseconds>(uvar * random_factor);
         microseconds sleep_time = ubase + deviation;
 
-        usleep(sleep_time.count());
+        return usleep(sleep_time.count()) == 0;
     };
     using namespace SandstoneBackgroundScanConstants;
 
@@ -3089,14 +3088,18 @@ static void background_scan_wait()
                                              "%d s, waiting %d +/- %d s\n",
                        sApp->background_scan.timestamp.size(), as_seconds(elapsed),
                        as_seconds(expected_start), as_seconds(MinimumDelayBetweenTests));
-        do_wait(expected_start, MinimumDelayBetweenTests);
+        if (!do_wait(expected_start, MinimumDelayBetweenTests)) {
+            return false;
+        }
         goto skip_wait;
     }
 
     logging_printf(LOG_LEVEL_VERBOSE(3), "# Background scan: waiting %d +/- 10%% s\n",
                    as_seconds(MinimumDelayBetweenTests));
     while (1) {
-        do_wait(MinimumDelayBetweenTests, MinimumDelayBetweenTests / 10);
+        if (!do_wait(MinimumDelayBetweenTests, MinimumDelayBetweenTests / 10)) {
+            return false;
+        }
 
 skip_wait:
         now = MonotonicTimePoint::clock::now();
@@ -3125,6 +3128,7 @@ skip_wait:
                        idle_load, sApp->background_scan.load_idle_threshold,
                        as_seconds(MinimumDelayBetweenTests));
     }
+    return true;
 }
 
 extern constexpr const uint64_t minimum_cpu_features = _compilerCpuFeatures;
@@ -3801,10 +3805,17 @@ int main(int argc, char **argv)
             logging_print_iteration_start();
             initialize_smi_counts();  // used by smi_count test
         } else if (lastTestResult != TestResult::Skipped) {
-            if (sApp->service_background_scan)
-                background_scan_wait();
-            else
-                wait_delay_between_tests();
+            if (sApp->service_background_scan) {
+                if (!background_scan_wait()) {
+                    logging_printf(LOG_LEVEL_VERBOSE(2), "# Background scan: waiting between tests interrupted\n");
+                    break;
+                }
+            } else {
+                if (!wait_delay_between_tests()) {
+                    logging_printf(LOG_LEVEL_VERBOSE(2), "# Test execution interrupted between tests\n");
+                    break;
+                }
+            }
         }
 
         // Note temporal coupling here with restarting


### PR DESCRIPTION
If the application is "in between" test execution mode (waits for credits to execute tests), non-fatal signals are handled with usleep() and forces application loop to stop.
Appropriate log is added, the application returns current test execution status (not 'interrupted').