### PR TITLE
Option to fail a test in cleanup.

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -452,6 +452,50 @@ selftest_pass() {
     test_yaml_regexp "/tests/0/skip-reason" '.*skip.*'
 }
 
+@test "selftest_skip_cleanup" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_skip_cleanup
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/test" selftest_skip_cleanup
+    test_yaml_regexp "/tests/0/result" skip
+    test_yaml_regexp "/tests/0/skip-category" RuntimeSkipCategory
+    test_yaml_regexp "/tests/0/skip-reason" 'SKIP requested in cleanup'
+}
+
+@test "selftest_oserror_cleanup" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_oserror_cleanup
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/test" selftest_oserror_cleanup
+    test_yaml_regexp "/tests/0/result" skip
+    test_yaml_regexp "/tests/0/skip-category" RuntimeSkipCategory
+    test_yaml_regexp "/tests/0/skip-reason" 'Unexpected OS error in cleanup.*'
+}
+
+@test "selftest_logskip_success_cleanup" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_logskip_success_cleanup
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/test" selftest_logskip_success_cleanup
+    test_yaml_regexp "/tests/0/result" skip
+    test_yaml_regexp "/tests/0/skip-category" SelftestSkipCategory
+    test_yaml_regexp "/tests/0/skip-reason" 'SUCCESS after logskip from cleanup'
+}
+
+@test "selftest_logskip_skip_cleanup" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_logskip_skip_cleanup
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/test" selftest_logskip_skip_cleanup
+    test_yaml_regexp "/tests/0/result" skip
+    test_yaml_regexp "/tests/0/skip-category" SelftestSkipCategory
+    test_yaml_regexp "/tests/0/skip-reason" 'SKIP after logskip from cleanup'
+}
+
 selftest_log_skip_init_socket_common() {
     local slicename=$1
     local testname=$2
@@ -943,6 +987,42 @@ test_list_file_ignores_beta() {
     i=$((-1 + yamldump[/tests/0/threads/0/messages@len]))
     test_yaml_regexp "/tests/0/threads/0/messages/$i/level" error
     test_yaml_regexp "/tests/0/threads/0/messages/$i/text" 'E> Init function failed.*'
+}
+
+@test "selftest_logerror_init" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_logerror_init
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+    i=$((0 + yamldump[/tests/0/threads@len]))
+    [[ "$i" -eq 1 ]]
+    test_yaml_regexp "/tests/0/threads/0/thread" 'main'
+    test_yaml_regexp "/tests/0/threads/0/messages/0/level" error
+    test_yaml_regexp "/tests/0/threads/0/messages/0/text" 'E> Error logged in init.*'
+}
+
+@test "selftest_logerror_cleanup" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_logerror_cleanup
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+    i=$((0 + yamldump[/tests/0/threads@len]))
+    [[ "$i" -eq 1 ]]
+    test_yaml_regexp "/tests/0/threads/0/thread" 'main'
+    test_yaml_regexp "/tests/0/threads/0/messages/1/level" error
+    test_yaml_regexp "/tests/0/threads/0/messages/1/text" 'E> Error logged in cleanup'
+}
+
+@test "selftest_fail_cleanup" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_fail_cleanup
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+    i=$((0 + yamldump[/tests/0/threads@len]))
+    [[ "$i" -eq 1 ]]
+    test_yaml_regexp "/tests/0/threads/0/thread" 'main'
+    test_yaml_regexp "/tests/0/threads/0/messages/1/level" info
+    test_yaml_regexp "/tests/0/threads/0/messages/1/text" 'I> cleanup returns FAIL'
 }
 
 @test "selftest_failinit_socket1 --max-cores-per-slice" {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1782,8 +1782,20 @@ static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
         if (sApp->shmem->use_strict_runtime && wallclock_deadline_has_expired(sApp->endtime)){
             // skip cleanup on the last test when using strict runtime
         } else {
-            if (test->test_cleanup)
-                test->test_cleanup(test);
+            if (test->test_cleanup) {
+                ret = test->test_cleanup(test);
+                if (state == TestResult::Passed) {
+                    if (ret == EXIT_SKIP) {
+                        log_skip(RuntimeSkipCategory, "SKIP requested in cleanup");
+                        state = TestResult::Skipped;
+                    } else if (ret < EXIT_SUCCESS) {
+                        log_skip(RuntimeSkipCategory, "Unexpected OS error in cleanup: %s", strerror(-ret));
+                        state = TestResult::Skipped;
+                    } else if (ret > EXIT_SUCCESS) {
+                        state = TestResult::Failed;
+                    }
+                }
+            }
         }
 
         sApp->test_tests_finish(test);

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -209,6 +209,49 @@ static int selftest_log_skip_init(struct test *test)
     return EXIT_SKIP;
 }
 
+static int selftest_logerror_init(struct test *test)
+{
+    log_error("Error logged in init, test is not expected to run any threads");
+    return EXIT_SUCCESS;
+}
+
+static int selftest_logskip_success_cleanup(struct test *test)
+{
+    log_skip(SelftestSkipCategory, "SUCCESS after logskip from cleanup");
+    return EXIT_SKIP;
+}
+
+static int selftest_logskip_skip_cleanup(struct test *test)
+{
+    log_skip(SelftestSkipCategory, "SKIP after logskip from cleanup");
+    return EXIT_SKIP;
+}
+
+static int selftest_skip_cleanup(struct test *test)
+{
+    log_info("SKIP returned silently from cleanup");
+    return EXIT_SKIP;
+}
+
+static int selftest_errno_cleanup(struct test *test)
+{
+    log_info("Unexpected OS error reported from cleanup");
+    errno = ENOMEM;
+    return -errno;
+}
+
+static int selftest_logerror_success_cleanup(struct test *test)
+{
+    log_error("Error logged in cleanup");
+    return EXIT_SUCCESS;
+}
+
+static int selftest_fail_cleanup(struct test *test)
+{
+    log_info("cleanup returns FAIL");
+    return EXIT_FAILURE;
+}
+
 template <int PackageId> static int selftest_log_skip_socket_init(struct test *test)
 {
     if (num_packages() == 1 && cpu_info[0].package_id == PackageId)
@@ -960,6 +1003,42 @@ static struct test selftests_array[] = {
     .desired_duration = -1,
 },
 {
+    .id = "selftest_skip_cleanup",
+    .description = "SKIP in the cleanup function",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logs_random_init,
+    .test_run = selftest_pass_run,
+    .test_cleanup = selftest_skip_cleanup,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_oserror_cleanup",
+    .description = "OS error in the cleanup function",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logs_random_init,
+    .test_run = selftest_pass_run,
+    .test_cleanup = selftest_errno_cleanup,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_logskip_success_cleanup",
+    .description = "Log skip message with SUCCESS in the cleanup function",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logs_random_init,
+    .test_run = selftest_pass_run,
+    .test_cleanup = selftest_logskip_success_cleanup,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_logskip_skip_cleanup",
+    .description = "Log skip message with SKIP in the cleanup function",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logs_random_init,
+    .test_run = selftest_pass_run,
+    .test_cleanup = selftest_logskip_skip_cleanup,
+    .desired_duration = -1,
+},
+{
     .id = "selftest_maybe_skip_750ms",
     .description = "Requests to run for 750 ms (could be skipped)",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
@@ -1117,6 +1196,14 @@ static struct test selftests_array[] = {
     /* Negative tests */
 
 {
+    .id = "selftest_logerror_init",
+    .description = "Fails on error logged in init",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logerror_init,
+    .test_run = selftest_failinit_run,
+    .desired_duration = -1,
+},
+{
     .id = "selftest_fail",
     .description = "Fails by way of returning",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
@@ -1133,10 +1220,28 @@ static struct test selftests_array[] = {
     .desired_duration = -1,
 },
 {
+    .id = "selftest_fail_cleanup",
+    .description = "Fails in the cleanup function",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logs_random_init,
+    .test_run = selftest_pass_run,
+    .test_cleanup = selftest_fail_cleanup,
+    .desired_duration = -1,
+},
+{
     .id = "selftest_logerror",
     .description = "Fails by calling log_error()",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
     .test_run = selftest_logerror_run,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_logerror_cleanup",
+    .description = "Fails by calling log_error() in the cleanup function",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logs_random_init,
+    .test_run = selftest_pass_run,
+    .test_cleanup = selftest_logerror_success_cleanup,
     .desired_duration = -1,
 },
 {


### PR DESCRIPTION
Some tests (e.g. with locks) requires post-run checkin, if anything is inconsistent, test is expected to fail.
Both patterns (logging error(s) and returning non-SUCCESS value) from test_cleanup function are handled properly and report appropriate state in the log. Potential group SKIPs are handled in limited scope.