### PR TITLE
FW/InterruptMonitor: fix parsing /proc/interrupts with offlined CPUs

### DIFF
--- a/framework/sysdeps/linux/interrupt_monitor.cpp
+++ b/framework/sysdeps/linux/interrupt_monitor.cpp
@@ -30,12 +30,12 @@ std::vector<uint32_t> InterruptMonitor::get_interrupt_counts(InterruptType type)
     }();
 
     std::vector<uint32_t> result;
+    if (!f)
+        return result;
 
     char *line = nullptr;
     size_t len = 0;
-    ssize_t nread;
-    if (!f)
-        return result;
+    auto free_line = scopeExit([&] { free(line); });
 
     while (f && (nread = getline(&line, &len, f)) != -1) {
         // Skip any blanks at the start of the line
@@ -57,7 +57,6 @@ std::vector<uint32_t> InterruptMonitor::get_interrupt_counts(InterruptType type)
         }
         break;
     }
-    free(line);
 
     // reset the file pointer for the next time we get called
     fseek(f, 0, SEEK_SET);

--- a/framework/sysdeps/linux/interrupt_monitor.cpp
+++ b/framework/sysdeps/linux/interrupt_monitor.cpp
@@ -6,9 +6,46 @@
 #include <interrupt_monitor.hpp>
 #include <sandstone_p.h>
 
-#include <ctype.h>
-
 constexpr const char * const proc_interrupts_file = "/proc/interrupts";
+
+static bool is_kernel_blank(char c)
+{
+    // kernel only uses spaces for the /proc/interrupts file but we accept tabs
+    return c == ' ' || c == '\t';
+}
+
+static char *skip_to_non_blank(char *ptr)
+{
+    char c;
+    for ( ; (c = *ptr); ++ptr) {
+        if (!is_kernel_blank(c))
+            break;
+    }
+    return ptr;
+}
+
+static std::vector<int> parse_header(char *line, ssize_t nread)
+{
+    // read every CPU number to create the mapping
+    static const char cpu[] = "CPU";
+    std::vector<int> result;
+    if (nread <= 0)
+        return result;
+
+    char *ptr = skip_to_non_blank(line);
+    while (strncmp(ptr, cpu, strlen(cpu)) == 0) {
+        char *endptr;
+        ptr += strlen(cpu);
+        unsigned long n = strtoul(ptr, &endptr, 10);
+        if (n == 0 && ptr == endptr)
+            break;
+
+        result.push_back(n);
+        ptr = skip_to_non_blank(endptr);
+    }
+
+    return result;
+}
 
 // this function reads the interrupts file and returns a list of integers corresponding
 // to the contents of the line that matches the input header prefix, for example "MCE:"
@@ -37,22 +74,34 @@ std::vector<uint32_t> InterruptMonitor::get_interrupt_counts(InterruptType type)
     size_t len = 0;
     auto free_line = scopeExit([&] { free(line); });
 
+    // read the header and create the CPU mapping
+    ssize_t nread = getline(&line, &len, f);
+    std::vector<int> cpu_mapping = parse_header(line, nread);
+    if (cpu_mapping.size() == 0) {
+        // failed to parse the header!
+        fclose(f);
+        f.f = nullptr;
+        return result;
+    }
+
+    // static code analyzers: we trust the kernel
+    result.resize(cpu_mapping.back() + 1);
+
     while (getline(&line, &len, f) != -1) {
         // Skip any blanks at the start of the line
-        char *ptr = line;
-        while (*ptr && isblank(*ptr))
-            ptr++;
+        char *ptr = skip_to_non_blank(line);
         if (strncmp(ptr, hdr, strlen(hdr)) != 0)
             continue;
 
         ptr = ptr + strlen(hdr);
-        while (*ptr != '\0') {
+        for (int i = 0; *ptr != '\0'; ++i) {
             char *endptr;
             errno = 0;
             uint64_t n = strtoull(ptr, &endptr, 10);
             if (n == 0 && ptr == endptr)
                 break;
-            result.push_back(n);
+            // static code analyzers: we trust the kernel
+            result[cpu_mapping[i]] = n;
             ptr = endptr;
         }
         break;

--- a/framework/sysdeps/linux/interrupt_monitor.cpp
+++ b/framework/sysdeps/linux/interrupt_monitor.cpp
@@ -37,7 +37,7 @@ std::vector<uint32_t> InterruptMonitor::get_interrupt_counts(InterruptType type)
     size_t len = 0;
     auto free_line = scopeExit([&] { free(line); });
 
-    while (f && (nread = getline(&line, &len, f)) != -1) {
+    while (getline(&line, &len, f) != -1) {
         // Skip any blanks at the start of the line
         char *ptr = line;
         while (*ptr && isblank(*ptr))


### PR DESCRIPTION

When some CPUs are offlined by the system adminstrator via `/sys/devices/system/cpu/cpuN/online`, the column numbers and CPU numbers in `/proc/interrupts` will no longer match.

For example, if I turn off CPUs 10 to 19 on a 14-core system, the header will be:
```
            CPU0       CPU1       CPU2       CPU3       CPU4       CPU5       CPU6       CPU7       CPU8       CPU9       CPU20      CPU21      CPU22      CPU23      CPU24      CPU25      CPU26      CPU27
```

So we must parse the first line to create tha mapping and we must do so every time we read this file, in case it changed. If it did, the mce_check will likely report an error.

