### PR TITLE
FW/Topology: fix running in GitHub's updated CI

### DIFF
--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -394,7 +394,7 @@ static bool fill_topo_cpuid(struct cpu_info *info)
         subleaf++;
     } while (1);
     info->package_id = d >> pkg_shift;
-    return true;
+    return info->core_id != -1;
 }
 
 static bool fill_ucode_msr(struct cpu_info *info)


### PR DESCRIPTION
GitHub's updated CI added AMD CPUs, which don't appear to support getting the topology information using CPUID 0xb (x2API) - https://wiki.osdev.org/Detecting_CPU_Topology_(80x86) confirms:
>  *INTEL: CPUID eax=0x0000000B*
> For Intel CPUs (and not AMD), this CPUID function tells you [...]

So this implements a software fallback for both Linux and Windows. The Linux fallback already existed, but wasn't getting triggered because we assumed `fill_topo_cpuid()` would always succeed.

There's now a new Windows implementation using [`GetLogicalProcessorInformationEx`](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex). We won't get the correct core numbers on Intel CPUs using this, but it's better than nothing.

On my Alder Lake workstation (8+4), this prints:
```
# CPU   PkgID   CoreID  ThrdID  Microcode       PPIN
0       0       0       0       0x2c
1       0       0       1       0x2c
2       0       1       0       0x2c
3       0       1       1       0x2c
4       0       2       0       0x2c
5       0       2       1       0x2c
6       0       3       0       0x2c
7       0       3       1       0x2c
8       0       4       0       0x2c
9       0       4       1       0x2c
10      0       5       0       0x2c
11      0       5       1       0x2c
12      0       6       0       0x2c
13      0       6       1       0x2c
14      0       7       0       0x2c
15      0       7       1       0x2c
16      0       8       0       0x2c
17      0       9       0       0x2c
18      0       10      0       0x2c
19      0       11      0       0x2c
```

Instead of the more correct:
```
# CPU   PkgID   CoreID  ThrdID  Microcode       PPIN
0       0       0       0       0x2c
1       0       0       1       0x2c
2       0       4       0       0x2c
3       0       4       1       0x2c
4       0       8       0       0x2c
5       0       8       1       0x2c
6       0       12      0       0x2c
7       0       12      1       0x2c
8       0       16      0       0x2c
9       0       16      1       0x2c
10      0       20      0       0x2c
11      0       20      1       0x2c
12      0       24      0       0x2c
13      0       24      1       0x2c
14      0       28      0       0x2c
15      0       28      1       0x2c
16      0       36      0       0x2c
17      0       37      0       0x2c
18      0       38      0       0x2c
19      0       39      0       0x2c
```
