### PR TITLE
Selftests names fixed to fix CI issues.

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -474,26 +474,26 @@ selftest_pass() {
     test_yaml_regexp "/tests/0/skip-reason" 'Unexpected OS error in cleanup.*'
 }
 
-@test "selftest_logskip_success_cleanup" {
+@test "selftest_skipmsg_success_cleanup" {
     declare -A yamldump
-    sandstone_selftest -e selftest_logskip_success_cleanup
+    sandstone_selftest -e selftest_skipmsg_success_cleanup
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/exit" pass
-    test_yaml_regexp "/tests/0/test" selftest_logskip_success_cleanup
+    test_yaml_regexp "/tests/0/test" selftest_skipmsg_success_cleanup
     test_yaml_regexp "/tests/0/result" skip
     test_yaml_regexp "/tests/0/skip-category" SelftestSkipCategory
-    test_yaml_regexp "/tests/0/skip-reason" 'SUCCESS after logskip from cleanup'
+    test_yaml_regexp "/tests/0/skip-reason" 'SUCCESS after skipmsg from cleanup'
 }
 
-@test "selftest_logskip_skip_cleanup" {
+@test "selftest_skipmsg_skip_cleanup" {
     declare -A yamldump
-    sandstone_selftest -e selftest_logskip_skip_cleanup
+    sandstone_selftest -e selftest_skipmsg_skip_cleanup
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/exit" pass
-    test_yaml_regexp "/tests/0/test" selftest_logskip_skip_cleanup
+    test_yaml_regexp "/tests/0/test" selftest_skipmsg_skip_cleanup
     test_yaml_regexp "/tests/0/result" skip
     test_yaml_regexp "/tests/0/skip-category" SelftestSkipCategory
-    test_yaml_regexp "/tests/0/skip-reason" 'SKIP after logskip from cleanup'
+    test_yaml_regexp "/tests/0/skip-reason" 'SKIP after skipmsg from cleanup'
 }
 
 selftest_log_skip_init_socket_common() {
@@ -1096,9 +1096,9 @@ test_list_file_ignores_beta() {
     test_yaml_regexp "/tests/0/threads/0/messages/0/text" 'E> Error logged in init.*'
 }
 
-@test "selftest_logerror_cleanup" {
+@test "selftest_errormsg_cleanup" {
     declare -A yamldump
-    sandstone_selftest -e selftest_logerror_cleanup
+    sandstone_selftest -e selftest_errormsg_cleanup
     [[ "$status" -eq 1 ]]
     test_yaml_regexp "/exit" fail
     i=$((0 + yamldump[/tests/0/threads@len]))

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -215,15 +215,15 @@ static int selftest_logerror_init(struct test *test)
     return EXIT_SUCCESS;
 }
 
-static int selftest_logskip_success_cleanup(struct test *test)
+static int selftest_skipmsg_success_cleanup(struct test *test)
 {
-    log_skip(SelftestSkipCategory, "SUCCESS after logskip from cleanup");
+    log_skip(SelftestSkipCategory, "SUCCESS after skipmsg from cleanup");
     return EXIT_SKIP;
 }
 
-static int selftest_logskip_skip_cleanup(struct test *test)
+static int selftest_skipmsg_skip_cleanup(struct test *test)
 {
-    log_skip(SelftestSkipCategory, "SKIP after logskip from cleanup");
+    log_skip(SelftestSkipCategory, "SKIP after skipmsg from cleanup");
     return EXIT_SKIP;
 }
 
@@ -240,7 +240,7 @@ static int selftest_errno_cleanup(struct test *test)
     return -errno;
 }
 
-static int selftest_logerror_success_cleanup(struct test *test)
+static int selftest_errormsg_success_cleanup(struct test *test)
 {
     log_error("Error logged in cleanup");
     return EXIT_SUCCESS;
@@ -1021,21 +1021,21 @@ static struct test selftests_array[] = {
     .desired_duration = -1,
 },
 {
-    .id = "selftest_logskip_success_cleanup",
+    .id = "selftest_skipmsg_success_cleanup",
     .description = "Log skip message with SUCCESS in the cleanup function",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
     .test_init = selftest_logs_random_init,
     .test_run = selftest_pass_run,
-    .test_cleanup = selftest_logskip_success_cleanup,
+    .test_cleanup = selftest_skipmsg_success_cleanup,
     .desired_duration = -1,
 },
 {
-    .id = "selftest_logskip_skip_cleanup",
+    .id = "selftest_skipmsg_skip_cleanup",
     .description = "Log skip message with SKIP in the cleanup function",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
     .test_init = selftest_logs_random_init,
     .test_run = selftest_pass_run,
-    .test_cleanup = selftest_logskip_skip_cleanup,
+    .test_cleanup = selftest_skipmsg_skip_cleanup,
     .desired_duration = -1,
 },
 {
@@ -1236,12 +1236,12 @@ static struct test selftests_array[] = {
     .desired_duration = -1,
 },
 {
-    .id = "selftest_logerror_cleanup",
+    .id = "selftest_errormsg_cleanup",
     .description = "Fails by calling log_error() in the cleanup function",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
     .test_init = selftest_logs_random_init,
     .test_run = selftest_pass_run,
-    .test_cleanup = selftest_logerror_success_cleanup,
+    .test_cleanup = selftest_errormsg_success_cleanup,
     .desired_duration = -1,
 },
 {


### PR DESCRIPTION
Some "false" conflicting names (logskip) of selftests replaced with the ones which not fall into "selftest_logs*" mask.

This is intended to fix integration builds (selftest phase).