### PR TITLE
FW/Logging: Remove redundant "SkipCategory"

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -428,7 +428,7 @@ selftest_pass() {
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/test" selftest_skip_minimum_cpu
     test_yaml_regexp "/tests/0/result" skip
-    test_yaml_regexp "/tests/0/skip-category" CpuNotSupportedSkipCategory
+    test_yaml_regexp "/tests/0/skip-category" CpuNotSupported
     test_yaml_regexp "/tests/0/skip-reason" '.*test requires.*'
 }
 
@@ -439,7 +439,7 @@ selftest_pass() {
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/test" selftest_log_skip_init
     test_yaml_regexp "/tests/0/result" skip
-    test_yaml_regexp "/tests/0/skip-category" SelftestSkipCategory
+    test_yaml_regexp "/tests/0/skip-category" Selftest
     test_yaml_regexp "/tests/0/skip-reason" '.*skip.*'
 }
 
@@ -450,7 +450,7 @@ selftest_pass() {
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/test" selftest_skip_cleanup
     test_yaml_regexp "/tests/0/result" skip
-    test_yaml_regexp "/tests/0/skip-category" RuntimeSkipCategory
+    test_yaml_regexp "/tests/0/skip-category" Runtime
     test_yaml_regexp "/tests/0/skip-reason" 'SKIP requested in cleanup'
 }
 
@@ -461,7 +461,7 @@ selftest_pass() {
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/test" selftest_oserror_cleanup
     test_yaml_regexp "/tests/0/result" skip
-    test_yaml_regexp "/tests/0/skip-category" RuntimeSkipCategory
+    test_yaml_regexp "/tests/0/skip-category" Runtime
     test_yaml_regexp "/tests/0/skip-reason" 'Unexpected OS error in cleanup.*'
 }
 
@@ -472,7 +472,7 @@ selftest_pass() {
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/test" selftest_skipmsg_success_cleanup
     test_yaml_regexp "/tests/0/result" skip
-    test_yaml_regexp "/tests/0/skip-category" SelftestSkipCategory
+    test_yaml_regexp "/tests/0/skip-category" Selftest
     test_yaml_regexp "/tests/0/skip-reason" 'SUCCESS after skipmsg from cleanup'
 }
 
@@ -483,7 +483,7 @@ selftest_pass() {
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/test" selftest_skipmsg_skip_cleanup
     test_yaml_regexp "/tests/0/result" skip
-    test_yaml_regexp "/tests/0/skip-category" SelftestSkipCategory
+    test_yaml_regexp "/tests/0/skip-category" Selftest
     test_yaml_regexp "/tests/0/skip-reason" 'SKIP after skipmsg from cleanup'
 }
 
@@ -520,7 +520,7 @@ selftest_log_skip_init_socket_common() {
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/test" selftest_log_skip_run_all_threads
     test_yaml_regexp "/tests/0/result" skip
-    test_yaml_regexp "/tests/0/skip-category" RuntimeSkipCategory
+    test_yaml_regexp "/tests/0/skip-category" Runtime
     test_yaml_regexp "/tests/0/skip-reason" '.*test_run().*'
     for ((i = 0; i < yamldump[/tests/0/threads@len]; ++i)); do
         test_yaml_regexp "/tests/0/threads/$i/messages/0/level" skip
@@ -548,7 +548,7 @@ selftest_log_skip_init_socket_common() {
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/test" selftest_log_skip_newline
     test_yaml_regexp "/tests/0/result" skip
-    test_yaml_regexp "/tests/0/skip-category" SelftestSkipCategory
+    test_yaml_regexp "/tests/0/skip-category" Selftest
     test_yaml_regexp "/tests/0/skip-reason" $'.*\n.*\n.*'
 }
 

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -449,27 +449,27 @@ static const char *char_to_skip_category(int val)
 {
     switch (val) {
     case ResourceIssueSkipCategory:
-        return "ResourceIssueSkipCategory";
+        return "ResourceIssue";
     case CpuNotSupportedSkipCategory:
-        return "CpuNotSupportedSkipCategory";
+        return "CpuNotSupported";
     case DeviceNotFoundSkipCategory:
-        return "DeviceNotFoundSkipCategory";
+        return "DeviceNotFound";
     case DeviceNotConfiguredSkipCategory:
-        return "DeviceNotConfiguredSkipCategory";
+        return "DeviceNotConfigured";
     case UnknownSkipCategory:
-        return "UnknownSkipCategory";
+        return "Unknown";
     case RuntimeSkipCategory:
-        return "RuntimeSkipCategory";
+        return "Runtime";
     case SelftestSkipCategory:
-        return "SelftestSkipCategory";
+        return "Selftest";
     case OsNotSupportedSkipCategory:
-        return "OsNotSupportedSkipCategory";
+        return "OsNotSupported";
     case TestResourceIssueSkipCategory:
-        return "TestResourceIssueSkipCategory";
+        return "TestResourceIssue";
     case CpuTopologyIssueSkipCategory:
-        return "CpuTopologyIssueSkipCategory";
+        return "CpuTopologyIssue";
     case OSResourceIssueSkipCategory:
-        return "OSResourceIssueSkipCategory";
+        return "OSResourceIssue";
     }
 
     return "NO CATEGORY PRESENT";
@@ -1782,7 +1782,7 @@ void KeyValuePairLogger::print(int tc)
                    testResult == TestResult::Passed ? "pass" : "fail");
 
     if (testResult == TestResult::Skipped && !skipInMainThread) {
-        logging_printf(LOG_LEVEL_QUIET, "%s_skip_category = %s\n", test->id, "RuntimeSkipCategory");
+        logging_printf(LOG_LEVEL_QUIET, "%s_skip_category = %s\n", test->id, "Runtime");
         logging_printf(LOG_LEVEL_QUIET, "%s_skip_reason = %s\n", test->id,
                        "All CPUs skipped while executing 'test_run()' function, check log for details");
     } else if (testResult == TestResult::Skipped) {
@@ -1797,7 +1797,7 @@ void KeyValuePairLogger::print(int tc)
             if (file_log_fd != real_stdout_fd)
                 format_and_print_message(file_log_fd, -1, message, false);
         } else {
-            logging_printf(LOG_LEVEL_QUIET, "%s_skip_category = %s\n", test->id, "UnknownSkipCategory");
+            logging_printf(LOG_LEVEL_QUIET, "%s_skip_category = %s\n", test->id, "Unknown");
             logging_printf(LOG_LEVEL_QUIET, "%s_skip_reason = %s\n", test->id,
                            "Unknown, check main thread message for details or use -vv option for more info");
         }
@@ -1912,10 +1912,10 @@ void TapFormatLogger::print(int tc)
                 extra += "(" + std::string(char_to_skip_category(init_skip_message[0])) +
                         " : " + init_skip_message.substr(1,init_skip_message.size()) + ")";
             else
-                extra += "(UnknownSkipCategory: check main thread message for details or "
+                extra += "(Unknown: check main thread message for details or "
                             "use -vv option for more info)";
         } else {
-            extra += "(RuntimeSkipCategory: All CPUs skipped while executing 'test_run()' "
+            extra += "(Runtime: All CPUs skipped while executing 'test_run()' "
                      "function, check log for details)";
         }
         [[fallthrough]];
@@ -2379,7 +2379,7 @@ void YamlLogger::print_result_line()
     case TestResult::Skipped:
         logging_printf(loglevel, "  result: skip\n");
         if (!skipInMainThread) {
-            logging_printf(loglevel, "  skip-category: %s\n", "RuntimeSkipCategory");
+            logging_printf(loglevel, "  skip-category: %s\n", "Runtime");
             logging_printf(loglevel, "  skip-reason: %s\n",
                            "All CPUs skipped while executing 'test_run()' function, check log "
                            "for details");
@@ -2394,7 +2394,7 @@ void YamlLogger::print_result_line()
                     format_and_print_message(real_stdout_fd, -1, message, false);
                 format_and_print_message(file_log_fd, -1, message, false);
             } else {
-                logging_printf(loglevel, "  skip-category: %s\n", "UnknownSkipCategory");
+                logging_printf(loglevel, "  skip-category: %s\n", "Unknown");
                 logging_printf(loglevel, "  skip-reason: %s\n",
                                "Unknown, check main thread message for details or use -vv "
                                "option for more info");


### PR DESCRIPTION
This will remove redundant suffix "SkipCategory" attached to skip-category message in the log.

Before the change:

```
result: skip
skip-category: CpuNotSupportedSkipCategory
skip-reason: 'test requires amx-tile'
```

After the change:

```
result: skip
skip-category: CpuNotSupported
skip-reason: 'test requires amx-tile'
```