### PR TITLE
FW/Logging: performance improvement: don't copy strings

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1978,7 +1978,7 @@ std::string TapFormatLogger::fail_info_details()
     if (!should_print_fail_info())
         return result;
 
-    auto add_value = [&result](std::string s, char separator) {
+    auto add_value = [&result](const std::string &s, char separator) {
         if (s.empty()) {
             result += "null";
         } else if (!separator) {


### PR DESCRIPTION
The `add_value` lambda was receiving a `std::string` by value, which was inefficient because it copied the string.