### PR TITLE
FW: Fix rule-of-five violations

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -550,7 +550,19 @@ template <typename Lambda> static void for_each_test_thread(Lambda &&l)
 struct AutoClosingFile
 {
     FILE *f = nullptr;
+    AutoClosingFile(FILE *f = nullptr) : f(f) {}
     ~AutoClosingFile() { if (f) fclose(f); }
+    AutoClosingFile(const AutoClosingFile &) = delete;
+    AutoClosingFile(AutoClosingFile &&other) : f(other.f) { other.f = nullptr; }
+    AutoClosingFile &operator=(const AutoClosingFile &) = delete;
+    AutoClosingFile &operator=(AutoClosingFile &&other)
+    {
+        if (f)
+            fclose(f);
+        f = other.f;
+        other.f = nullptr;
+        return *this;
+    }
     operator FILE *() const { return f; }
 };
 
@@ -562,10 +574,28 @@ struct Pipe
     int &out()                  { return fds[1]; }
     void close_input()          { do_close(in()); }
     void close_output()         { do_close(out()); }
+    explicit operator bool()    { return in() != -1 || out() != -1; }
+
     Pipe()                      { open(); }
     Pipe(DontCreateFlag)        { }
     ~Pipe()                     { close_input(); close_output(); }
-    explicit operator bool()    { return in() != -1 || out() != -1; }
+    Pipe(const Pipe &) = delete;
+    Pipe &operator=(const Pipe &) = delete;
+    Pipe(Pipe &&other)
+    {
+        fds[0] = other.fds[0];
+        fds[1] = other.fds[1];
+        other.fds[0] = other.fds[1] = -1;
+    }
+    Pipe &operator=(Pipe &&other)
+    {
+        close_input();
+        close_output();
+        fds[0] = other.fds[0];
+        fds[1] = other.fds[1];
+        other.fds[0] = other.fds[1] = -1;
+        return *this;
+    }
 
     int open(int reserved = PIPE_BUF)
     {
@@ -610,6 +640,11 @@ template <typename F> inline auto scopeExit(F &&f)
     struct Scope {
         F f;
         bool dismissed = false;
+        Scope(F &&f) : f(std::move(f)) {}
+        Scope(const Scope &) = delete;
+        Scope(Scope &&) = default;
+        Scope &operator=(const Scope &) = delete;
+        Scope &operator=(Scope &&) = delete;
         ~Scope() { if (!dismissed) f(); }
         void dismiss() { dismissed = true; }
         void run_now() { f(); dismiss(); }


### PR DESCRIPTION
For `AutoClosingFile` and `Pipe`, add the missing copy & move constructor and assignment operators. Nowhere in our code were they used incorrectly, but this helps ensure they never do.

For `scopeExit()::Scope`, just delete them all.
