### PR TITLE
FW/Logging: pass ChildExitStatus by const-reference

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1668,7 +1668,7 @@ format_duration(MonotonicTimePoint tp, FormatDurationOptions opts = FormatDurati
 
 static ChildExitStatus find_most_serious_result(std::span<const ChildExitStatus> results)
 {
-    auto comparator = [](ChildExitStatus s1, ChildExitStatus s2) {
+    auto comparator = [](const ChildExitStatus &s1, const ChildExitStatus &s2) {
         return s1.result < s2.result;
     };
     return *std::max_element(results.begin(), results.end(), comparator);
@@ -2006,7 +2006,7 @@ std::string TapFormatLogger::fail_info_details()
     return result;
 }
 
-[[gnu::pure]] static const char *crash_reason(ChildExitStatus status)
+[[gnu::pure]] static const char *crash_reason(const ChildExitStatus &status)
 {
     assert(status.result != TestResult::Passed);
     assert(status.result != TestResult::Skipped);
@@ -2034,7 +2034,7 @@ std::string TapFormatLogger::fail_info_details()
 #endif
 }
 
-[[gnu::pure]] static const char *sysexit_reason(ChildExitStatus status)
+[[gnu::pure]] static const char *sysexit_reason(const ChildExitStatus &status)
 {
     assert(status.result == TestResult::OperatingSystemError);
     switch (status.extra) {


### PR DESCRIPTION
It used to be a small type (only 8 bytes) before commit b55f5648bcfbc1f1c18e87576a0e039f803831fe. It's still trivial so the compiler is likely to understand no copying is required, but let's help it along.