### PR TITLE
FW/Logging/TAP: ensure there's a space before #

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1947,8 +1947,8 @@ void TapFormatLogger::print(int tc)
 
     std::string tap_line = stdprintf("%s %3i %s", okstring, tc, test->id);
     if (extra.size()) {
-        static constexpr std::string_view separator = "# ";
-        size_t newsize = std::max(tap_line.size(), size_t(32)) + separator.size() + extra.size();
+        static constexpr std::string_view separator = " # ";
+        size_t newsize = std::max(tap_line.size(), size_t(31)) + separator.size() + extra.size();
         tap_line.reserve(newsize);
         if (tap_line.size() < 32)
             tap_line.resize(32, ' ');


### PR DESCRIPTION
Fixes #452. Now:

```
 $ $objdir/opendcdiag --output-format=tap --selftests -e selftest_timedpass_busywait --quick
THIS IS AN UNOPTIMIZED BUILD: DON'T TRUST TEST TIMING!
# opendcdiag --output-format=tap --selftests -e selftest_timedpass_busywait --quick
# opendcdiag-9e64cb24b4d0; Operating system: Linux 6.5.9-1-default, glibc 2.38
ok   1 selftest_timedpass_busywait # (beta test) 
ok   2 mce_check
exit: pass
```