### PR TITLE
Remove ResourceIssueSkipCategory and replace its usages.

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -452,8 +452,6 @@ static uint8_t status_level(char letter)
 static const char *char_to_skip_category(int val)
 {
     switch (val) {
-    case ResourceIssueSkipCategory:
-        return "ResourceIssue";
     case CpuNotSupportedSkipCategory:
         return "CpuNotSupported";
     case DeviceNotFoundSkipCategory:

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -84,17 +84,16 @@ extern "C" {
 
 // skip categories
 typedef enum SkipCategory {
-    ResourceIssueSkipCategory = 1,
-    CpuNotSupportedSkipCategory,
+    CpuNotSupportedSkipCategory = 1,
+    CpuTopologyIssueSkipCategory,
+    TestResourceIssueSkipCategory,
+    OSResourceIssueSkipCategory,
+    OsNotSupportedSkipCategory,
     DeviceNotFoundSkipCategory,
     DeviceNotConfiguredSkipCategory,
     UnknownSkipCategory,
     RuntimeSkipCategory,
     SelftestSkipCategory,
-    OsNotSupportedSkipCategory,
-    TestResourceIssueSkipCategory,
-    CpuTopologyIssueSkipCategory,
-    OSResourceIssueSkipCategory
 } SkipCategory;
 
 /// logs a skip message to the logfile. log_skip accepts the category to which the skip belongs to

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -169,7 +169,7 @@ static int selftest_logs_getcpu_run(struct test *test, int cpu)
     log_skip(OsNotSupportedSkipCategory, "No API to get the CPU number on this OS");
 #endif
     if (cpu_number == -1)
-        log_skip(ResourceIssueSkipCategory, "OS failed: %m");
+        log_skip(OSResourceIssueSkipCategory, "OS failed: %m");
     log_info("%d", cpu_number);
     return EXIT_SUCCESS;
 }

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -580,7 +580,7 @@ int kvm_generic_run(struct test *test, int cpu)
             ctx.vm_fd = kvm_generic_create_vm(kvm_fd);
             if (ctx.vm_fd < 0) {
                 if (errno == EBUSY) {
-                    log_skip(ResourceIssueSkipCategory, "Cannot create VM: device busy");
+                    log_skip(OSResourceIssueSkipCategory, "Cannot create VM: device busy");
                     result = EXIT_SKIP;
                     goto epilogue;
                 }

--- a/tests/eigen_sparse/eigen_sparse.cpp
+++ b/tests/eigen_sparse/eigen_sparse.cpp
@@ -59,7 +59,7 @@ static int initialize_problem(EigenSparseTestData *d)
         d->A.setFromTriplets(trip.begin(), trip.end());
         d->b = Eigen::VectorXd::Random(n);
     } catch (...) {
-        log_skip(ResourceIssueSkipCategory, "Exception on Eigen code, most probably OOM");
+        log_skip(TestResourceIssueSkipCategory, "Exception on Eigen code, most probably OOM");
         return EXIT_SKIP;
     }
 
@@ -75,7 +75,7 @@ static int eigen_sparse_init(struct test *test) {
     try {
         d->golden = solver.compute(d->A).solve(d->b);
     } catch (...) {
-        log_skip(ResourceIssueSkipCategory, "Exception on Eigen code, most probably OOM");
+        log_skip(TestResourceIssueSkipCategory, "Exception on Eigen code, most probably OOM");
         return EXIT_SKIP;
     }
     if (solver.info() != Eigen::Success) {

--- a/tests/openssl/openssl_sha.cpp
+++ b/tests/openssl/openssl_sha.cpp
@@ -112,7 +112,7 @@ static int ssl_sha_init(struct test* test)
         return EXIT_SUCCESS;
     }
     else {
-        log_skip(ResourceIssueSkipCategory, "OpenSSL library is not available or the current version is not supported");
+        log_skip(TestResourceIssueSkipCategory, "OpenSSL library is not available or the current version is not supported");
         return EXIT_SKIP;
     }
 }


### PR DESCRIPTION
We have decided to split ResourceIssueSkipCategory into, roughly, two: TestResourceIssueSkipCategory and OSResourceIssueSkipCategory. This foments  correct usages of the categories by the test writers as well as helps analyzing the logs. The usages of ResourceIssueSkipCategory were removed as well as the category itself. Since it existed ever so briefly, there's no need to make it a non-breaking change.