### PR TITLE
Change triage default behavior

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1576,7 +1576,7 @@ crash_context_socket1_common() {
 
     # can't use sandstone_selftest because of --no-triage
     VALIDATION=dump
-    run_sandstone_yaml -n$MAX_PROC --disable=mce_check --selftests --timeout=20s --retest-on-failure=0 -Y -e selftest_fail_socket1
+    run_sandstone_yaml -n$MAX_PROC --disable=mce_check --selftests --timeout=20s --retest-on-failure=0 -Y -e selftest_fail_socket1 --triage
 
     # confirm the topology took effect
     for ((i = 0; i < 4; ++i)); do

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -164,6 +164,7 @@ enum {
     test_tests_option,
     timeout_option,
     total_retest_on_failure,
+    triage_option,
     ud_on_failure_option,
     use_builtin_test_list_option,
     vary_frequency,
@@ -3029,6 +3030,7 @@ int main(int argc, char **argv)
         { "mem-samples-per-log", required_argument, nullptr, mem_samples_per_log_option},
         { "no-memory-sampling", no_argument, nullptr, no_mem_sampling_option },
         { "no-slicing", no_argument, nullptr, no_slicing_option },
+        { "triage", no_argument, nullptr, triage_option },
         { "no-triage", no_argument, nullptr, no_triage_option },
         { "on-crash", required_argument, nullptr, on_crash_option },
         { "on-hang", required_argument, nullptr, on_hang_option },
@@ -3256,6 +3258,9 @@ int main(int argc, char **argv)
             break;
         case no_slicing_option:
             max_cores_per_slice = -1;
+            break;
+        case triage_option:
+            do_not_triage = false;
             break;
         case no_triage_option:
             do_not_triage = true;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3091,7 +3091,7 @@ int main(int argc, char **argv)
     int total_skips = 0;
     int thread_count = -1;
     bool fatal_errors = false;
-    bool do_not_triage = false;
+    bool do_not_triage = true;
     const char *on_hang_arg = nullptr;
     const char *on_crash_arg = nullptr;
 


### PR DESCRIPTION
Do not run triage by default. Add an option `--triage` to force the previous behavior.

[ChangeLog][Framework] Change the default behavior to not run triage. Add --triage option to force the previous behavior.
