### PR TITLE
Fix --dump-cpu-info detection

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1287,6 +1287,9 @@ static void dump_cpu_info()
             detected = arch.name;
             break;
         }
+        if (sApp->shmem->verbosity > 1)
+            printf("CPU is not %s: missing %s\n", arch.name,
+                   cpu_features_to_string(arch.features & ~cpu_features).c_str());
     }
     printf("Detected CPU: %s; family-model-stepping (hex): %02x-%02x-%02x; CPU features: %s\n",
            detected, cpu_info[0].family, cpu_info[0].model, cpu_info[0].stepping,

--- a/framework/scripts/x86simd_generate.pl
+++ b/framework/scripts/x86simd_generate.pl
@@ -284,7 +284,7 @@ struct X86Architecture
 };
 
 static const struct X86Architecture x86_architectures[] = {|;
-for (sort keys %sorted_archs) {
+for (sort { $b <=> $a } keys %sorted_archs) {
     my $arch = $sorted_archs{$_};
     next if $arch->{base} eq "<>";
     printf "    { cpu_%s, \"%s\" },\n", $arch->{id}, $arch->{prettyname};


### PR DESCRIPTION
This reverts commit 71643880fb56af4f6e8216ac8a25c1caa8c5690c. We don't want natural sorting of the array, we want reverse natural sorting.

The loop in `dump_cpu_info()` depends on the list being sorted from most featureful to least. We could reverse the iteration there but it's easier this way.

Before:
```
$ $objdir/opendcdiag --dump-cpu-info
Detected CPU: Core2; family-model-stepping (hex): 06-8c-01; CPU features: clflush,sse2,pclmul,fma,sse4.2,movbe,popcnt,aes,avx,f16c,rdrnd,fsgsbase,bmi,avx2,bmi2,avx512f,avx512dq,rdseed,adx,avx512ifma,clflushopt,clwb,avx512cd,sha,avx512bw,avx512vl,avx512vbmi,ospke,avx512vbmi2,shstk,gfni,vaes,vpclmulqdq,avx512vnni,avx512bitalg,avx512vpopcntdq,movdiri,movdir64b,ibt,lzcnt
```

Now:
```
$ $objdir/opendcdiag --dump-cpu-info
Detected CPU: Tiger Lake; family-model-stepping (hex): 06-8c-01; CPU features: clflush,sse2,pclmul,fma,sse4.2,movbe,popcnt,aes,avx,f16c,rdrnd,fsgsbase,bmi,avx2,bmi2,avx512f,avx512dq,rdseed,adx,avx512ifma,clflushopt,clwb,avx512cd,sha,avx512bw,avx512vl,avx512vbmi,ospke,avx512vbmi2,shstk,gfni,vaes,vpclmulqdq,avx512vnni,avx512bitalg,avx512vpopcntdq,movdiri,movdir64b,ibt,lzcnt
```
