### PR TITLE
FW/Win32/child_debug: don't stop execution on non-system exceptions

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -410,6 +410,16 @@ selftest_pass() {
     [[ ${yamldump[/tests]} != *selftest_pass_low_quality* ]]
 }
 
+@test "selftest_cxxthrowcatch" {
+    # Note: we want to test with the crash handler enabled (--on-crash)
+    declare -A yamldump
+    sandstone_selftest --on-crash=context -e selftest_cxxthrowcatch
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/test" selftest_cxxthrowcatch
+    test_yaml_regexp "/tests/0/result" pass
+}
+
 @test "selftest_skip" {
     declare -A yamldump
     sandstone_selftest -e selftest_skip

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -56,6 +56,8 @@ using uint128_t = __uint128_t;
 
 struct SelftestException : std::exception
 {
+    int cpu;
+    SelftestException(int cpu = -1) : cpu(cpu) {}
     const char *what() const noexcept override
     {
         return "OpenDCDiag C++ selftest exception";
@@ -188,6 +190,16 @@ static int selftest_logs_random_init(struct test *test)
 static int selftest_logs_random_run(struct test *test, int cpu)
 {
     return selftest_logs_random_init(test);
+}
+
+static int selftest_cxxthrowcatch_run(struct test *test, int cpu)
+{
+    try {
+        throw SelftestException(cpu);
+    } catch (SelftestException &e) {
+        memcmp_or_fail(&e.cpu, &cpu, 1);
+        return EXIT_SUCCESS;
+    }
 }
 
 static int selftest_skip_init(struct test *test)
@@ -937,6 +949,13 @@ static struct test selftests_array[] = {
     .description = "Logs some random numbers",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_run = selftest_logs_random_run,
+    .desired_duration = -1,
+},
+{
+    .id = "selftest_cxxthrowcatch",
+.description = "Throws and catches a C++ exception",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_run = selftest_cxxthrowcatch_run,
     .desired_duration = -1,
 },
 {

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -945,7 +945,7 @@ void debug_init_global(const char *on_hang_arg, const char *on_crash_arg)
             exit(EX_USAGE);
         }
 
-        if (SandstoneConfig::ChildBacktrace && on_crash_action & backtrace_on_hang) {
+        if (SandstoneConfig::ChildBacktrace && on_crash_action & attach_gdb_on_crash) {
             if (gdb_available == -1)
                 gdb_available = check_gdb_available();
             if (!gdb_available) {


### PR DESCRIPTION
This can happen when exceptions are thrown for other reasons, in particular that of C++ exceptions. Both GCC and MSVC use the SEH mechanism to handle their exceptions. We didn't catch this before because the most self-tests are run with --on-crash=core, so the vectored exception handler wasn't installed.

Before:
```yaml
- test: selftest_cxxthrowcatch
  result: crash
  result-details: { crashed: true, core-dump: false, code: 0x20474343, reason: '???' }
  fail: { cpu-mask: 'X', time-to-fail: null, seed: 'AES:1d1726ac3d4d55dd78077b0a6de46d10e2e8d953c2b2aa2287f884f5921b92ef'}
  time-at-end:   { elapsed:     21.343, now: !!timestamp '2023-11-23T23:55:02Z' }
  test-runtime: 19.280
  threads:
  - thread: 0
    id: { logical-group:  0, logical:  0, package: 0, core: 0, thread: 0 }
    messages:
    - { level: error, text: 'E> Received exception 0x20474343 (???), RIP = 0x7ffd7324565c, parameters [1cd428c88a0]' }
```

0x20474343 is "GCC", see [1] and [2].

Now:
```yaml
tests:
- test: selftest_cxxthrowcatch
  result: pass
  time-at-end:   { elapsed:     22.560, now: !!timestamp '2023-11-23T23:55:48Z' }
  test-runtime: 20.128
```

[1] https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=libgcc/unwind-seh.c;hb=HEAD
[2] https://github.com/llvm/llvm-project/blob/main/libunwind/src/Unwind-seh.cpp