### PR TITLE
FW: add cleanup_global() to centralize application exiting

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -675,15 +675,28 @@ int logging_close_global(int exitcode)
 {
     progress_bar_flush();
     if (!SandstoneConfig::NoLogging) {
-        if (exitcode != EXIT_SUCCESS) {
+        if (exitcode != EXIT_SUCCESS)
             logging_print_log_file_name();
-            logging_printf(LOG_LEVEL_QUIET,
-                           exitcode == EXIT_FAILURE ? "exit: fail\n" : "exit: invalid\n");
-        } else if (sApp->shmem->verbosity >= 0) {
-            logging_printf(LOG_LEVEL_QUIET, "exit: pass\n");
-        }
-    }
 
+        const char *exitline = [&] {
+            switch (exitcode) {
+            case EXIT_SUCCESS:
+                if (sApp->shmem->verbosity >= 0)
+                    return "pass";
+                return (const char *)nullptr;
+            case EXIT_FAILURE:
+                return "fail";
+            default:
+                if (exitcode & EXIT_INTERRUPTED)
+                    return "interrupted";
+                [[fallthrough]];
+            case EXIT_INVALID:
+                return "invalid";
+            }
+        }();
+        if (exitline)
+            logging_printf(LOG_LEVEL_QUIET, "exit: %s\n", exitline);
+    }
     if (exitcode == EXIT_SUCCESS && delete_log_on_success) {
         close(file_log_fd);
         remove(sApp->file_log_path.c_str());

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2080,7 +2080,7 @@ static TestResult run_one_test_once(int *tc, const struct test *test)
     case TestResult::OutOfMemory:
         if (!sApp->ignore_os_errors) {
             logging_flush();
-            int exit_code = print_application_footer(2, {});
+            int exit_code = print_application_footer(EXIT_INVALID, {});
             _exit(logging_close_global(exit_code));
         } else {
             // not a pass either, but won't affect the result

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -82,14 +82,6 @@ struct mmap_region
 };
 
 /*
- * Called from sandstone_main() before logging_global_init() and before
- * logging_global_finish(). Feel free to add your own banner or footer. Be
- * careful about corrupting the log output.
- */
-void print_application_banner(void);
-int print_application_footer(int exit_code);
-
-/*
  * Called from sandstone_main(). The default weak implementation performs no
  * checks, they just return. Feel free to implement a strong version elsewhere
  * if you prefer the framework to check for system or CPU criteria.
@@ -689,6 +681,14 @@ void random_init_thread(int thread_num);
 
 /* sandstone.cpp */
 TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::PerCpuFailures &per_cpu_fails);
+
+/*
+ * Called from sandstone_main() before logging_global_init() and before
+ * logging_global_finish(). Feel free to add your own banner or footer. Be
+ * careful about corrupting the log output.
+ */
+void print_application_banner();
+int print_application_footer(int exit_code, SandstoneApplication::PerCpuFailures per_cpu_failures);
 
 #endif
 

--- a/framework/sandstone_utils.h
+++ b/framework/sandstone_utils.h
@@ -30,6 +30,7 @@
 /* Extra codes used by the application only */
 #define EXIT_INVALID        2
 //#define EXIT_ABORTED        3
+#define EXIT_INTERRUPTED    128     /* OR'ed with signal */
 
 // Macro to help create a std::string from variable arguments: @p fmt must be
 // both the printf-style format string and the last argument before the variadic list

--- a/framework/sandstone_utils.h
+++ b/framework/sandstone_utils.h
@@ -27,6 +27,10 @@
 #define EXIT_NOTINSTALLED 5     /* The program is not installed. */
 #define EXIT_MEMORY     204     /* Failed to perform an action due to memory shortage. */
 
+/* Extra codes used by the application only */
+#define EXIT_INVALID        2
+//#define EXIT_ABORTED        3
+
 // Macro to help create a std::string from variable arguments: @p fmt must be
 // both the printf-style format string and the last argument before the variadic list
 #define va_start_and_stdprintf(fmt)                     \


### PR DESCRIPTION
We exited in three different places but only one duplicated the call to `logging_close_global()`. Only the main exit remembered to call `print_application_footer()` and restore any system state we modified (in the current version, the `--vary-frequency` state).

This centralizes everything in a function that Does The Right Thing™, plus removes a magic constant in the code.

Our exit codes are:
* EXIT_SUCCESS (0) - all tests passed (or skipped)
* EXIT_FAILURE (1) - at least one test failed
* EXIT_INVALID (2) - inconclusive result
* EXIT_ABORTED (3) - (documentation only) used by abort() on Windows
* other values (64-78, >=200) - unable to start, logging hasn't started

The shell will report crash (signal) exits by OR'ing the signal number with 128.