### PR TITLE
FW: fix getting messages from the main thread under -fno

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2042,8 +2042,9 @@ static void run_one_test_children(ChildrenList &children, int *tc, const struct 
                 TestResult result = child_run(const_cast<struct test *>(test), i);
                 if (sApp->current_fork_mode() == SandstoneApplication::fork_each_test)
                     _exit(test_result_to_exit_code(result));
-                else
-                    children.results.emplace_back(ChildExitStatus{ result });
+
+                children.results.emplace_back(ChildExitStatus{ result });
+                return;
             } else {
                 children.add(ret);
             }


### PR DESCRIPTION
We were calling `wait_for_children()` even with `-fno`, so it reset the `children.results` vector back to empty.