### PR TITLE
FW: fix spelling of the "--max-logdata" option name

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3426,7 +3426,7 @@ int main(int argc, char **argv)
 
         case max_logdata_option: {
             sApp->shmem->max_logdata_per_thread = ParseIntArgument<unsigned>{
-                    .name = "--max-log-data",
+                    .name = "--max-logdata",
                     .explanation = "maximum number of bytes of test's data to log per thread (0 is unlimited))",
                     .base = 0,      // accept hex
                     .range_mode = OutOfRangeMode::Saturate


### PR DESCRIPTION
We printed "--max-log-data" (with an extra dash) when its argument failed to properly parse as a number.