### PR TITLE
FW/kvm: always print the vCPU register state on failure

### DIFF
--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -436,7 +436,7 @@ static int kvm_generic_setup_vcpu(kvm_ctx_t *ctx)
     }
 }
 
-static void kvm_log_registers(const char *log_level, const struct kvm_regs *gprs)
+static void kvm_log_registers(const struct kvm_regs *gprs)
 {
     static const struct FlagMapping {
         uint32_t bit;
@@ -468,12 +468,12 @@ static void kvm_log_registers(const char *log_level, const struct kvm_regs *gprs
     if (ptr != flags)
         ptr[-1] = '\0';
 
-    log_message(thread_num, SANDSTONE_LOG_INFO "%sRegister dump:\n"
+    log_message(thread_num, SANDSTONE_LOG_INFO "Register dump:\n"
                             "rax = 0x%016llx rbx = 0x%016llx rcx = 0x%016llx rdx = 0x%016llx\n"
                             "rsi = 0x%016llx rdi = 0x%016llx rsp = 0x%016llx rbp = 0x%016llx\n"
                             "r8  = 0x%016llx r9  = 0x%016llx rcx = 0x%016llx r11 = 0x%016llx\n"
                             "r12 = 0x%016llx r13 = 0x%016llx r14 = 0x%016llx r15 = 0x%016llx\n"
-                            "rip = 0x%016llx rflags = 0x%016llx [%s]", log_level,
+                            "rip = 0x%016llx rflags = 0x%016llx [%s]",
                 gprs->rax, gprs->rbx, gprs->rcx, gprs->rdx,
                 gprs->rsi, gprs->rdi, gprs->rsp, gprs->rbp,
                 gprs->r8, gprs->r9, gprs->rcx, gprs->r11,
@@ -649,7 +649,7 @@ int kvm_generic_run(struct test *test, int cpu)
                             case 0:
                                 break;
                             default:
-                                kvm_log_registers(SANDSTONE_LOG_INFO, &cregs);
+                                kvm_log_registers(&cregs);
                                 log_error("KVM test reported exit code %lld", cregs.rax);
                                 result = EXIT_FAILURE;
                                 break;

--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -438,6 +438,7 @@ static int kvm_generic_setup_vcpu(kvm_ctx_t *ctx)
 
 static void kvm_log_registers(const struct kvm_regs *gprs)
 {
+#ifdef __x86_64__
     static const struct FlagMapping {
         uint32_t bit;
         char name[4];
@@ -479,6 +480,9 @@ static void kvm_log_registers(const struct kvm_regs *gprs)
                 gprs->r8, gprs->r9, gprs->rcx, gprs->r11,
                 gprs->r12, gprs->r13, gprs->r14, gprs->r15,
                 gprs->rip, gprs->rflags, flags);
+#else
+    (void) gprs;
+#endif // machine-specific
 }
 
 #ifndef MADV_COLD


### PR DESCRIPTION
This is to help debugging why the test failed, most often when writing new tests and trying to figure out why they're not behaving as expected. That includes `KVM_EXIT_FAIL_ENTRY` cases when we set up the state incorrectly.

Now, for every failure, we'll get something like:
```yaml
    - level: info
      text: |1
       I> Register dump:
       rax = 0x0000000000000001 rbx = 0x0000000000000000 rcx = 0x0000000000000000 rdx = 0x0000000000000600
       rsi = 0x0000000000000000 rdi = 0x0000000000000000 rsp = 0x00000000005ff000 rbp = 0x00000000005ff000
       r8  = 0x0000000000000000 r9  = 0x0000000000000000 rcx = 0x0000000000000000 r11 = 0x0000000000000000
       r12 = 0x0000000000000000 r13 = 0x0000000000000000 r14 = 0x0000000000000000 r15 = 0x0000000000000000
       rip = 0x0000000000300006 rflags = 0x0000000000000002 []
       cs  = 0x0008 base = 0x000000000000 limit = 0x000fffff s=1 type=R-Xa dpl=0 db=0 g=1 l=1 present
       ds  = 0x0010 base = 0x000000000000 limit = 0x000fffff s=1 type=RW-a dpl=0 db=1 g=1 l=0 present
       es  = 0x0010 base = 0x000000000000 limit = 0x000fffff s=1 type=RW-a dpl=0 db=1 g=1 l=0 present
       fs  = 0x0000 base = 0x000000000000 limit = 0x0000ffff s=1 type=RW-a dpl=0 db=0 g=0 l=0 present
       gs  = 0x0000 base = 0x000000000000 limit = 0x0000ffff s=1 type=RW-a dpl=0 db=0 g=0 l=0 present
       ss  = 0x0010 base = 0x000000000000 limit = 0x000fffff s=1 type=RW-a dpl=0 db=1 g=1 l=0 present
       cr0 = 0xe0000011 cr2 = 0 cr3 = 0x0000000000201000 cr4 = 0x00000020 efer = 0x500 xcr0 = 0x000001
       gdt: base = 0x0000000000200000 limit = 0x0017
       ldt: base = 0x0000000000000000 limit = 0xffff
```
