### PR TITLE
FW: add IGNORE_RETVAL() for mprotect()

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1115,7 +1115,7 @@ static void protect_shmem()
     size_t protected_len = sApp->shmem->thread_data_offset;
     assert(protected_len == ROUND_UP_TO_PAGE(protected_len) &&
             "SharedMemory::main_thread_data is not page-aligned");
-    mprotect(sApp->shmem, protected_len, PROT_READ);
+    IGNORE_RETVAL(mprotect(sApp->shmem, protected_len, PROT_READ));
 }
 
 static void slice_plan_init(int max_cores_per_slice)

--- a/framework/sandstone_thread.cpp
+++ b/framework/sandstone_thread.cpp
@@ -46,7 +46,7 @@ unsigned char *SandstoneTestThreadAttributes::allocate_stack_block()
     auto ptr = static_cast<unsigned char *>(map);
     for (int i = 0; i < num_cpus(); ++i) {
         ptr += GuardSize;
-        mprotect(ptr, THREAD_STACK_SIZE, PROT_READ | PROT_WRITE);
+        IGNORE_RETVAL(mprotect(ptr, THREAD_STACK_SIZE, PROT_READ | PROT_WRITE));
         ptr += THREAD_STACK_SIZE;
     }
     return ptr;


### PR DESCRIPTION
Either we can actually ignore because they don't make a difference or there's no recourse in case it fails, so we may as well let the started threads crash.