### PR TITLE
FW/Win32: dynamically load pdh.dll only if --service is enabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -109,7 +109,6 @@ add_project_link_arguments([
     '-Wl,--stack,8388608',
     '-static-libgcc',
     '-Wl,-static',
-    '-lpdh',
     '-lpthread',
     '-lm',
     '-lssp',


### PR DESCRIPTION
This library is not present on stripped-down builds of Windows, such as Windows PE. So don't link OpenDCDiag to it, but instead load it after we've been told to use --service.

Introduced by 2ac0d930ae7f3472794d4e05fbfdfd014c928e44.