### PR TITLE
FW/ContextDump: refactor to internally use std::string

### DIFF
--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -197,7 +197,7 @@ static void print_segment(FILE *f, const char *name, uint16_t value)
 }
 
 #if defined(__linux__)
-void dump_gprs(FILE *f, const mcontext_t *mc)
+void dump_gprs(FILE *f, SandstoneMachineContext mc)
 {
     static constexpr struct {
         char name[4];
@@ -233,7 +233,7 @@ void dump_gprs(FILE *f, const mcontext_t *mc)
     }
 }
 #elif defined(__FreeBSD__)
-void dump_gprs(FILE *f, const mcontext_t *mc)
+void dump_gprs(FILE *f, SandstoneMachineContext mc)
 {
     using register_t = decltype(mc->mc_rax);
     static constexpr struct {
@@ -265,7 +265,7 @@ void dump_gprs(FILE *f, const mcontext_t *mc)
     print_segment(f, "gs", mc->mc_gs);
 }
 #elif defined(__APPLE__) || defined(__MACH__)
-void dump_gprs(FILE *f, const mcontext_t mc)
+void dump_gprs(FILE *f, SandstoneMachineContext mc)
 {
     auto *state = &mc->__ss;
     using ThreadState = std::decay_t<decltype(*state)>;
@@ -299,7 +299,7 @@ void dump_gprs(FILE *f, const mcontext_t mc)
     print_segment(f, "gs", state->__gs);
 }
 #elif defined(_WIN32)
-void dump_gprs(FILE *f, const mcontext_t *mc)
+void dump_gprs(FILE *f, SandstoneMachineContext mc)
 {
     static constexpr struct {
         char name[4];

--- a/framework/sandstone_context_dump.h
+++ b/framework/sandstone_context_dump.h
@@ -21,6 +21,8 @@ typedef const struct _CONTEXT *SandstoneMachineContext;
 #define FXSAVE_SIZE     0x200
 
 #ifdef __cplusplus
+# include <string>
+
 extern "C" {
 #endif
 
@@ -29,7 +31,9 @@ extern void dump_xsave(FILE *, const void *xsave_area, size_t xsave_size, int xs
 
 #ifdef __cplusplus
 }
-#endif  // __cplusplus
 
+void dump_gprs(std::string &out, SandstoneMachineContext);
+void dump_xsave(std::string &out, const void *xsave_area, size_t xsave_size, int xsave_dump_mask);
+#endif  // __cplusplus
 
 #endif  // SANDSTONE_CONTEXT_DUMP_H

--- a/framework/sandstone_context_dump.h
+++ b/framework/sandstone_context_dump.h
@@ -6,14 +6,16 @@
 #ifndef SANDSTONE_CONTEXT_DUMP_H
 #define SANDSTONE_CONTEXT_DUMP_H
 
-
 #include <stdio.h>
 
-// macOS doesn't consider itself to be Unix?
-#if defined(__unix__) || defined(__APPLE__)
+#if defined(__APPLE__)
 #  include <sys/ucontext.h>
+typedef mcontext_t SandstoneMachineContext;
+#elif defined(__unix__)
+#  include <sys/ucontext.h>
+typedef const mcontext_t *SandstoneMachineContext;
 #else
-typedef struct _CONTEXT mcontext_t;
+typedef const struct _CONTEXT *SandstoneMachineContext;
 #endif  // __unix__
 
 #define FXSAVE_SIZE     0x200
@@ -22,11 +24,7 @@ typedef struct _CONTEXT mcontext_t;
 extern "C" {
 #endif
 
-#ifdef __APPLE__
-extern void dump_gprs(FILE *, const mcontext_t);
-#else
-extern void dump_gprs(FILE *, const mcontext_t *);
-#endif
+extern void dump_gprs(FILE *, SandstoneMachineContext);
 extern void dump_xsave(FILE *, const void *xsave_area, size_t xsave_size, int xsave_dump_mask);
 
 #ifdef __cplusplus


### PR DESCRIPTION
I had used `FILE *` originally so this code could be useful in C applications too (that's why it didn't use any of our own utilities either). But let's use std::string instead because that will allow me to get rid of `open_memstream()` and temporary files in the caller code.

