### PR TITLE
eigen_sparse: Remove `return EXIT_FAILURE` after `report_fail`

### DIFF
--- a/tests/eigen_sparse/eigen_sparse.cpp
+++ b/tests/eigen_sparse/eigen_sparse.cpp
@@ -80,7 +80,6 @@ static int eigen_sparse_init(struct test *test) {
     }
     if (solver.info() != Eigen::Success) {
         report_fail(test);
-        return EXIT_FAILURE;
     }
 
     test->data = d.release();
@@ -104,11 +103,9 @@ static int eigen_sparse_run(struct test *test, int cpu) {
         }
         if (solver.info() != Eigen::Success) {
             report_fail(test);
-            return EXIT_FAILURE;
         }
         if (x != d->golden) {
             report_fail(test);
-            return EXIT_FAILURE;
         }
     } while (test_time_condition(test));
     return EXIT_SUCCESS;


### PR DESCRIPTION
These return statements are the code that will never be reached when the test reports a failure.