### PR TITLE
Implement Rule of Three in ManagedCodeBuffer

### DIFF
--- a/framework/sandstone_test_utils.h
+++ b/framework/sandstone_test_utils.h
@@ -55,6 +55,13 @@ public:
         free_code_buffer();
     }
 
+    // Default constructor
+    ManagedCodeBuffer() {}
+
+    // Do not allow to copy
+    ManagedCodeBuffer(const ManagedCodeBuffer& other) = delete;
+    ManagedCodeBuffer& operator=(const ManagedCodeBuffer& other) = delete;
+
     bool allocate(size_t size) {
         free_code_buffer();
         buffer_ptr = static_cast<uint8_t *>(


### PR DESCRIPTION
Added a constructor, copy constructor and copy assignment operator to ManagedCodeBuffer to adhere to the Rule of Three. This ensures proper copying and management of dynamic memory in the class.