### PR TITLE
Enabling d2i key APIs

### DIFF
--- a/framework/sandstone_ssl.h
+++ b/framework/sandstone_ssl.h
@@ -1497,6 +1497,8 @@
 #define SANDSTONE_SSL_X509_FUNCTIONS(F)         \
     F(i2d_X509_bio)                             \
     F(d2i_X509_bio)                             \
+    F(d2i_PrivateKey_bio)                       \
+    F(d2i_PUBKEY_bio)                           \
     F(X509_add1_ext_i2d)                        \
     F(X509_add1_reject_object)                  \
     F(X509_add1_trust_object)                   \


### PR DESCRIPTION
- Adding d2i to decode private/public key from a bio.

Signed-off-by: Alex V Jaramillo <alex.v.jaramillo@intel.com>