### PR TITLE
FW/child_debug: use std::string

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1139,15 +1139,6 @@ void logging_finish()
 {
 }
 
-LoggingStream logging_user_messages_stream(int thread_num, int level)
-{
-    LoggingStream stream(sApp->thread_data(thread_num)->log_fd);
-    sApp->thread_data(thread_num)->messages_logged.fetch_add(1, std::memory_order_relaxed);
-    uint8_t code = message_code(UserMessages, level);
-    stream.write(code);
-    return stream;
-}
-
 static inline void assert_log_message(const char *fmt)
 {
     assert(fmt);

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -774,6 +774,14 @@ static void log_message_preformatted(int thread_num, std::string_view msg)
     if (msg[0] == 'E')
         logging_mark_thread_failed(thread_num);
 
+    return log_message_preformatted(thread_num, level, msg);
+}
+
+void log_message_preformatted(int thread_num, int level, std::string_view msg)
+{
+    if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
+        return;
+
     std::atomic<int> &messages_logged = sApp->thread_data(thread_num)->messages_logged;
     if (messages_logged.load(std::memory_order_relaxed) >= sApp->shmem->max_messages_per_thread)
         return;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -654,6 +654,7 @@ static_assert(std::is_trivially_copyable_v<SandstoneApplication::SharedMemory>);
 static_assert(std::is_trivially_destructible_v<SandstoneApplication::SharedMemory>);
 
 /* logging.cpp */
+void log_message_preformatted(int thread_num, int level, std::string_view msg);
 int logging_stdout_fd(void);
 void logging_init_global(void);
 void logging_init_global_child();

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -281,42 +281,6 @@ struct SandstoneBackgroundScan
 #endif
 };
 
-class LoggingStream
-{
-public:
-    LoggingStream(int fd = -1) : fd(fd) {}
-    LoggingStream(const LoggingStream &) = delete;
-    LoggingStream &operator=(const LoggingStream &) = delete;
-    constexpr LoggingStream(LoggingStream &&other) : fd(other.fd)
-    {
-        other.fd = -1;
-    }
-    constexpr LoggingStream &operator=(LoggingStream &&other)
-    {
-        std::swap(fd, other.fd);
-        return *this;
-    }
-
-    ~LoggingStream()
-    {
-        if (fd != -1)
-            write('\0');
-    }
-    operator int() const
-    {
-        return fd;
-    }
-
-    template <typename... Args> ssize_t write(Args &&... args)
-    {
-        return writevec(fd, std::forward<Args>(args)...);
-    }
-
-private:
-    int fd;
-    friend LoggingStream logging_user_messages_stream(int thread_num, int level);
-};
-
 struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>
 {
     enum class OutputFormat : int8_t {
@@ -674,7 +638,6 @@ void logging_flush(void);
 void logging_init(const struct test *test);
 void logging_init_child_preexec();
 void logging_finish();
-LoggingStream logging_user_messages_stream(int thread_num, int level);
 TestResult logging_print_results(std::span<const ChildExitStatus> status, int *tc, const struct test *test);
 
 /* random.cpp */

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -450,11 +450,16 @@ static int run_process(int stdout_fd, const char *args[])
     return -1;
 }
 
-static void communicate_gdb_backtrace(int log, int in, int out, uintptr_t handle, int cpu)
+static auto communicate_gdb_backtrace(int in, int out, uintptr_t handle)
 {
     using namespace std::chrono;
     using namespace std::chrono_literals;
     constexpr auto GdbCommunicationTimeout = SandstoneConfig::Debug ? 1h : 30s;
+
+    struct R {
+        std::string thread_info;    // output of "frame" and "x/i $pc" (if Python is supported)
+        std::string backtrace;      // output of "thread apply all bt full"
+    } result;
 
     ssize_t ret;
     char buf[4096];
@@ -482,11 +487,11 @@ static void communicate_gdb_backtrace(int log, int in, int out, uintptr_t handle
         static const char needle[] = "(gdb) ";
         ret = wait_for_more();
         if (ret <= 0)
-            return;
+            return result;
 
         ret = read(in, buf, sizeof(buf) - 1);
         if (ret <= 0)
-            return;
+            return result;
         buf[ret] = '\0';
 
         // ### the needle may be split between buffers!
@@ -500,31 +505,31 @@ static void communicate_gdb_backtrace(int log, int in, int out, uintptr_t handle
     // send a python command setting the search handle
     ret = dprintf(out, gdb_preamble_commands, handle);
     if (ret <= 0)
-        return;
+        return result;
     ret = wait_for_more();
     if (ret <= 0)
-        return;
+        return result;
 
     ret = read(in, buf, sizeof(buf) - 1);
     if (ret <= 0)
-        return;
+        return result;
     buf[ret] = '\0';
 
     bool send_python = handle && (strcmp(buf, "ok\n") == 0);
     if (send_python) {
         ret = write(out, gdb_python_commands, strlen(gdb_python_commands));
         if (ret != ssize_t(strlen(gdb_python_commands)))
-            return;
+            return result;
 
         // skip the >>>>> caused by the multi-line python command
         for (;;) {
             ret = wait_for_more();
             if (ret <= 0)
-                return;
+                return result;
 
             ret = read(in, buf, sizeof(buf) - 1);
             if (ret <= 0)
-                return;
+                return result;
             buf[ret] = '\0';
 
             char *msg = buf;
@@ -541,53 +546,43 @@ static void communicate_gdb_backtrace(int log, int in, int out, uintptr_t handle
         for (;;) {
             static const char needle[] = "..Done..\n";
             if (ret >= strlen(needle) && strcmp(buf + ret - strlen(needle), needle) == 0) {
-                buf[ret - strlen(needle)] = '\0';
+                result.thread_info = std::string_view(buf, ret - strlen(needle));
                 break;
             }
 
             ssize_t ret2 = wait_for_more();
             if (ret2 <= 0)
-                return;
+                return result;
 
             ret2 = read(in, buf + ret, sizeof(buf) - ret);
             if (ret2 <= 0)
-                return;
+                return result;
             buf[ret + ret2] = '\0';
             ret += ret2;
-        }
-
-        if (cpu != -1) {
-            // log to the specific CPU
-            log_message(cpu, SANDSTONE_LOG_WARNING "%s", buf);
-        } else {
-            IGNORE_RETVAL(write(log, buf, strlen(buf)));
         }
     }
 
     // now get the actual backtrace (includes "quit")
     ret = write(out, gdb_bt_commands, strlen(gdb_bt_commands));
     if (ret != ssize_t(strlen(gdb_bt_commands)))
-        return;
+        return result;
 
     // splice backtrace from gdb to our log file
     for (;;) {
         ret = wait_for_more();
         if (ret <= 0)
-            return;
+            return result;
 
-#if defined(SPLICE_F_NONBLOCK)
-        ret = splice(in, nullptr, log, nullptr, std::numeric_limits<int>::max(),
-                     SPLICE_F_NONBLOCK);
-#else
         ret = read(in, buf, sizeof(buf));
-        if (ret > 0)
-            IGNORE_RETVAL(write(log, buf, ret));
-#endif
         if (ret == -1 && (errno == EINTR || errno == EWOULDBLOCK))
             continue;
         if (ret <= 0)
-            return;
+            return result;
+
+        result.backtrace += std::string_view(buf, ret);
     }
+
+    return result;
 }
 
 static void generate_backtrace(const char *pidstr, uintptr_t handle = 0, int cpu = -1)
@@ -634,10 +629,11 @@ static void generate_backtrace(const char *pidstr, uintptr_t handle = 0, int cpu
         sigaction(SIGPIPE, &ign_sigpipe, &old_sigpipe);
     }
 
-    {
-        LoggingStream stream = logging_user_messages_stream(-1, LOG_LEVEL_VERBOSE(2));
-        communicate_gdb_backtrace(stream, gdb_out.in(), gdb_in.out(), handle, cpu);
-    }
+    auto r = communicate_gdb_backtrace(gdb_out.in(), gdb_in.out(), handle);
+    if (r.thread_info.size())
+        log_message(cpu, SANDSTONE_LOG_WARNING "%s", r.thread_info.c_str());
+    if (r.backtrace.size())
+        log_message_preformatted(-1, LOG_LEVEL_VERBOSE(2), r.backtrace);
 
     // close the pipes and wait for gdb to exit
     gdb_in.close_output();

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -874,20 +874,17 @@ static void print_crash_info(const char *pidstr, CrashContext &ctx)
 
     // now include the register state
     if (handle && ctx.contents & CrashContext::MachineContext) {
-        char *buffer = nullptr;
-        size_t buflen = 0;
-        FILE *log = open_memstream(&buffer, &buflen);
-        fprintf(log, "Registers:\n");
+        std::string log;
 
 #ifdef __x86_64__
         dump_gprs(log, &ctx.mc);
         dump_xsave(log, ctx.xsave_buffer.data(), ctx.xsave_buffer.size(), -1);
 #endif
 
-        fclose(log);
-        logging_user_messages_stream(cpu, LOG_LEVEL_VERBOSE(2))
-                .write(std::string_view(buffer, buflen));
-        free(buffer);
+        if (log.size()) {
+            log.insert(0, "Registers:\n");
+            log_message_preformatted(cpu, LOG_LEVEL_VERBOSE(2), log);
+        }
     }
 }
 


### PR DESCRIPTION
This changes both the Unix and Windows child-debuggers to use `std::string` more instead of writing to file descriptors. This should improve performance a bit because we don't make system calls to store our content as it's being built. It also allows us to remove the `LoggingStream` class (was added in #286's 040bc365e8eeddf27b4a4a892dfb2a7a2a5cb912 to replace the `FILE *`-based API).

Using the API added in #479, this removes `open_memstream()` on Unix systems and more importantly, removes the need for an actual temporary file on Windows.