### PR TITLE
Add Uncore frequency manager support.

### DIFF
--- a/framework/frequency_manager.hpp
+++ b/framework/frequency_manager.hpp
@@ -6,7 +6,9 @@
 #ifndef FREQUENCY_MANAGER_HPP
 #define FREQUENCY_MANAGER_HPP
 
-#define BASE_FREQ_PATH         "/sys/devices/system/cpu/cpu"
+#include <unordered_set>
+#define BASE_CORE_FREQ_PATH    "/sys/devices/system/cpu/cpu"
+#define BASE_UNCORE_FREQ_PATH  "/sys/devices/system/cpu/intel_uncore_frequency/package_0"
 #define SCALING_GOVERNOR       "/cpufreq/scaling_governor"
 #define SCALING_SETSPEED       "/cpufreq/scaling_setspeed"
 
@@ -15,6 +17,7 @@ class FrequencyManager
 private:
 
 #ifdef __linux__
+    // core-frequency variables
     int max_core_frequency_supported = 0;
     int min_core_frequency_supported = 0;
     std::vector<std::string> per_cpu_initial_scaling_governor;
@@ -22,7 +25,14 @@ private:
     int current_set_frequency = 0;
     std::vector<int> core_frequency_levels;
     int core_frequency_level_idx = 0;
-    static constexpr int total_frequency_levels = 9;
+    int total_core_frequency_levels = 0;
+
+    // uncore-frequency variables
+    std::vector<std::pair<int, int>> initial_uncore_frequency;  // initial (min, max) un-core pair for each socket
+    std::vector<std::vector<int>> uncore_frequency_levels;  // frequency levels for each socket
+    uint16_t total_sockets = 0;
+    int uncore_frequency_level_idx = 0;
+    int total_uncore_frequency_levels = 0;
 
     std::string read_file(const std::string &file_path)
     {
@@ -68,12 +78,12 @@ private:
         return frequency;
     }
 
-    void populate_frequency_levels(auto &min_max_frequency, bool is_core)
+    void populate_frequency_levels(auto &min_max_frequency, bool is_core, int total_frequency_levels)
     {
         std::vector<int> tmp_frequency_levels;
         tmp_frequency_levels.push_back(min_max_frequency.second);
         tmp_frequency_levels.push_back(min_max_frequency.first);
-
+        
         std::vector<int> tmp = tmp_frequency_levels;
 
         while (tmp_frequency_levels.size() < total_frequency_levels)
@@ -86,6 +96,8 @@ private:
 
         if (is_core)
             core_frequency_levels = std::move(tmp_frequency_levels);
+        else
+            uncore_frequency_levels.push_back(std::move(tmp_frequency_levels));
     }
 
     void check_if_userspace_present()
@@ -109,6 +121,33 @@ private:
         fprintf(stderr, "%s: Cannot find \"userspace\" scaling governor from the file: %s\n", program_invocation_name, scaling_governor_path);
         exit(EX_DATAERR);
     }
+
+    void check_uncore_frequency_support()
+    {
+        // check for 0th socket. 0th socket should always be present.
+        const char *uncore_path = "/sys/devices/system/cpu/intel_uncore_frequency/package_00_die_00/initial_min_freq_khz";
+        FILE *file = fopen(uncore_path, "r");
+
+        if (file == NULL) {
+            fprintf(stderr, "%s: cannot read from file: %s. Please check if intel_uncore_frequency directory is present in the file path /sys/devices/system/cpu: %m\n", program_invocation_name, uncore_path);
+            exit(EX_IOERR);
+        }
+    }
+
+    void calculate_total_sockets()
+    {
+        std::unordered_set<int> found_socket_ids;
+
+        for (size_t cpu = 0; cpu < num_cpus(); cpu++) {
+            int socket_id = cpu_info[cpu].package_id;
+            if (found_socket_ids.count(socket_id) == 0) {
+                total_sockets++;
+                found_socket_ids.insert(socket_id);
+            }
+        }
+    }
+
+
 #endif
 
 public:
@@ -127,20 +166,22 @@ public:
         std::string cpuinfo_min_freq_path{"/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq"};
         min_core_frequency_supported = get_frequency_from_file(cpuinfo_min_freq_path);
 
+        total_core_frequency_levels = std::min(16, (max_core_frequency_supported - min_core_frequency_supported) / 100000);
+
         // populate different frequencies for each test to run
         std::pair<int, int> min_max_frequency(min_core_frequency_supported, max_core_frequency_supported);
-        populate_frequency_levels(min_max_frequency, true);
+        populate_frequency_levels(min_max_frequency, true, total_core_frequency_levels);
 
         // save states
         for (int cpu = 0; cpu < num_cpus(); cpu++) {
             //save scaling governor for every cpu
-            std::string scaling_governor_path = BASE_FREQ_PATH;
+            std::string scaling_governor_path = BASE_CORE_FREQ_PATH;
             scaling_governor_path += std::to_string(cpu_info[cpu].cpu_number);
             scaling_governor_path += SCALING_GOVERNOR;
             per_cpu_initial_scaling_governor.push_back(read_file(scaling_governor_path));
 
             //save frequency for every cpu
-            std::string initial_scaling_setspeed_frequency_path = BASE_FREQ_PATH;
+            std::string initial_scaling_setspeed_frequency_path = BASE_CORE_FREQ_PATH;
             initial_scaling_setspeed_frequency_path += std::to_string(cpu_info[cpu].cpu_number);
             initial_scaling_setspeed_frequency_path += SCALING_SETSPEED;
             per_cpu_initial_scaling_setspeed.push_back(read_file(initial_scaling_setspeed_frequency_path));
@@ -151,16 +192,60 @@ public:
 #endif 
     }
 
+    void initial_uncore_frequency_setup()
+    {
+#ifdef __linux__
+        check_uncore_frequency_support();
+
+        calculate_total_sockets();
+
+        for (size_t socket = 0; socket < total_sockets; socket++) {
+            std::pair<int, int> max_min_frequency;
+            std::string uncore_frequency_path = BASE_UNCORE_FREQ_PATH;
+            uncore_frequency_path += std::to_string(socket);
+
+            std::string min_freq_file = uncore_frequency_path + "_die_00/min_freq_khz";
+            max_min_frequency.first = get_frequency_from_file(min_freq_file);
+
+            std::string max_freq_file = uncore_frequency_path + "_die_00/max_freq_khz";
+            max_min_frequency.second = get_frequency_from_file(max_freq_file);
+
+            total_uncore_frequency_levels = std::min(8, (max_min_frequency.second - max_min_frequency.first) / 100000);
+
+            populate_frequency_levels(max_min_frequency, false, total_uncore_frequency_levels);
+            initial_uncore_frequency.push_back(std::move(max_min_frequency));
+        }
+#endif
+    }
+
     void change_core_frequency()
     {
 #ifdef __linux__
-        current_set_frequency = core_frequency_levels[core_frequency_level_idx++ % total_frequency_levels];
+        current_set_frequency = core_frequency_levels[core_frequency_level_idx++ % total_core_frequency_levels];
         
         for (int cpu = 0; cpu < num_cpus(); cpu++) {
-            std::string scaling_setspeed = BASE_FREQ_PATH;
+            std::string scaling_setspeed = BASE_CORE_FREQ_PATH;
             scaling_setspeed += std::to_string(cpu_info[cpu].cpu_number);
             scaling_setspeed += SCALING_SETSPEED;
             write_file(scaling_setspeed, std::to_string(current_set_frequency));
+        }
+#endif
+    }
+
+    void change_uncore_frequency()
+    {
+#ifdef __linux__
+        for (size_t socket = 0; socket < total_sockets; socket++) {
+            std::pair<int, int> max_min_frequency;
+            std::string uncore_frequency_path = BASE_UNCORE_FREQ_PATH;
+            uncore_frequency_path += std::to_string(socket);
+
+            std::string min_freq_file = uncore_frequency_path + "_die_00/min_freq_khz";
+            std::string frequency_to_write = std::to_string(uncore_frequency_levels[socket][uncore_frequency_level_idx++ % total_uncore_frequency_levels]);
+            write_file(min_freq_file, frequency_to_write);
+
+            std::string max_freq_file = uncore_frequency_path + "_die_00/max_freq_khz";
+            write_file(max_freq_file, frequency_to_write);
         }
 #endif
     }
@@ -170,16 +255,35 @@ public:
 #ifdef __linux__
         for (int cpu = 0; cpu < num_cpus(); cpu++) {
             //restore saved scaling governor for every cpu
-            std::string scaling_governor_path = BASE_FREQ_PATH;
+            std::string scaling_governor_path = BASE_CORE_FREQ_PATH;
             scaling_governor_path += std::to_string(cpu_info[cpu].cpu_number);
             scaling_governor_path += SCALING_GOVERNOR;
             write_file(scaling_governor_path, per_cpu_initial_scaling_governor[cpu]);
 
             //restore saved frequency for every cpu
-            std::string scaling_setspeed_path = BASE_FREQ_PATH;
+            std::string scaling_setspeed_path = BASE_CORE_FREQ_PATH;
             scaling_setspeed_path += std::to_string(cpu_info[cpu].cpu_number);
             scaling_setspeed_path += SCALING_SETSPEED;
             write_file(scaling_setspeed_path, per_cpu_initial_scaling_setspeed[cpu]);
+        }
+#endif
+    }
+
+    void restore_uncore_frequency_initial_state()
+    {
+#ifdef __linux__
+        for (size_t socket = 0; socket < total_sockets; socket++) {
+            std::pair<int, int> max_min_frequency;
+            std::string uncore_frequency_path = BASE_UNCORE_FREQ_PATH;
+            uncore_frequency_path += std::to_string(socket);
+
+            std::string min_freq_file = uncore_frequency_path + "_die_00/min_freq_khz";
+            std::string frequency_to_write = std::to_string(initial_uncore_frequency[socket].first);
+            write_file(min_freq_file, frequency_to_write);
+
+            frequency_to_write = std::to_string(initial_uncore_frequency[socket].second);
+            std::string max_freq_file = uncore_frequency_path + "_die_00/max_freq_khz";
+            write_file(max_freq_file, frequency_to_write);
         }
 #endif
     }
@@ -188,6 +292,7 @@ public:
     {
 #ifdef __linux__
         core_frequency_level_idx = 0;
+        uncore_frequency_level_idx = 0;
 #endif
     }
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -168,6 +168,7 @@ enum {
     ud_on_failure_option,
     use_builtin_test_list_option,
     vary_frequency,
+    vary_uncore_frequency,
     version_option,
     weighted_testrun_option,
 };
@@ -830,6 +831,9 @@ static int cleanup_global(int exit_code, SandstoneApplication::PerCpuFailures pe
 {
     if (sApp->vary_frequency_mode)
         sApp->frequency_manager.restore_core_frequency_initial_state();
+
+    if (sApp->vary_uncore_frequency_mode)
+        sApp->frequency_manager.restore_uncore_frequency_initial_state();
 
     exit_code = print_application_footer(exit_code, std::move(per_cpu_failures));
     return logging_close_global(exit_code);
@@ -2279,6 +2283,10 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
         if (sApp->vary_frequency_mode == true)
             sApp->frequency_manager.change_core_frequency();
         
+        //change uncore frequency per fracture
+        if (sApp->vary_uncore_frequency_mode == true)
+            sApp->frequency_manager.change_uncore_frequency();
+
         init_internal(test);
 
         // calculate starttime->endtime, reduce the overhead to have better test runtime calculations
@@ -2352,7 +2360,7 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
 
 out:
     //reset frequency level idx for the next test
-    if (sApp->vary_frequency_mode)
+    if (sApp->vary_frequency_mode || sApp->vary_uncore_frequency_mode)
         sApp->frequency_manager.reset_frequency_level_idx();
     
     random_advance_seed();      // advance seed for the next test
@@ -3137,6 +3145,7 @@ int main(int argc, char **argv)
         { "ud-on-failure", no_argument, nullptr, ud_on_failure_option },
         { "use-builtin-test-list", optional_argument, nullptr, use_builtin_test_list_option },
         { "vary-frequency", no_argument, nullptr, vary_frequency},
+        { "vary-uncore-frequency", no_argument, nullptr, vary_uncore_frequency},
         { "verbose", no_argument, nullptr, 'v' },
         { "version", no_argument, nullptr, version_option },
         { "weighted-testrun-type", required_argument, nullptr, weighted_testrun_option },
@@ -3515,6 +3524,14 @@ int main(int argc, char **argv)
             sApp->vary_frequency_mode = true;
             break;
         
+        case vary_uncore_frequency:
+            if (!FrequencyManager::FrequencyManagerWorks) {
+                fprintf(stderr, "%s: --vary-uncore-frequency works only on Linux\n", program_invocation_name);
+                return EX_USAGE;
+            }
+            sApp->vary_uncore_frequency_mode = true;
+            break;
+
         case version_option:
             logging_print_version();
             return EXIT_SUCCESS;
@@ -3673,9 +3690,13 @@ int main(int argc, char **argv)
         sApp->mce_count_last = std::accumulate(sApp->mce_counts_start.begin(), sApp->mce_counts_start.end(), uint64_t(0));
     }
 
-    //if --vary-frequency mode is used, do a initial setup and checks for running different frequencies
+    //if --vary-frequency mode is used, do a initial setup for running different frequencies
     if (sApp->vary_frequency_mode)
         sApp->frequency_manager.initial_core_frequency_setup();
+
+    //if --vary-uncore-frequency mode is used, do a initial setup for running different frequencies
+    if (sApp->vary_uncore_frequency_mode)
+        sApp->frequency_manager.initial_uncore_frequency_setup();
 
 #ifndef __OPTIMIZE__
     logging_printf(LOG_LEVEL_VERBOSE(1), "THIS IS AN UNOPTIMIZED BUILD: DON'T TRUST TEST TIMING!\n");

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -829,7 +829,7 @@ static void cleanup_internal(const struct test *test)
 static int cleanup_global(int exit_code, SandstoneApplication::PerCpuFailures per_cpu_failures)
 {
     if (sApp->vary_frequency_mode)
-        sApp->frequency_manager.restore_initial_state();
+        sApp->frequency_manager.restore_core_frequency_initial_state();
 
     exit_code = print_application_footer(exit_code, std::move(per_cpu_failures));
     return logging_close_global(exit_code);
@@ -2277,8 +2277,8 @@ TestResult run_one_test(int *tc, const struct test *test, SandstoneApplication::
 
         //change frequency per fracture
         if (sApp->vary_frequency_mode == true)
-            sApp->frequency_manager.change_frequency();
-
+            sApp->frequency_manager.change_core_frequency();
+        
         init_internal(test);
 
         // calculate starttime->endtime, reduce the overhead to have better test runtime calculations
@@ -3675,7 +3675,7 @@ int main(int argc, char **argv)
 
     //if --vary-frequency mode is used, do a initial setup and checks for running different frequencies
     if (sApp->vary_frequency_mode)
-        sApp->frequency_manager.initial_setup();
+        sApp->frequency_manager.initial_core_frequency_setup();
 
 #ifndef __OPTIMIZE__
     logging_printf(LOG_LEVEL_VERBOSE(1), "THIS IS AN UNOPTIMIZED BUILD: DON'T TRUST TEST TIMING!\n");

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -375,6 +375,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     bool force_test_time = false;
     bool service_background_scan = false;
     bool vary_frequency_mode = false;
+    bool vary_uncore_frequency_mode = false;
     static constexpr int MaxRetestCount = sizeof(PerCpuFailures::value_type) * 8;
     int retest_count = 10;
     int total_retest_count = -2;


### PR DESCRIPTION
This PR consists of 2 commits. 

First commit will re-factor already existing core frequency manager support so that it makes easier addition of uncore frequency manager support. This does not change any functionality of core frequency manager.

Second commit will add the actual uncore frequency manager support. This commit will add `--vary-uncore-frequency` option to opendcdiag. If this option is used, every test will run at pre-calculated different uncore frequency per fracture of the test within it's allocated time to run. Like core frequency manager, this option works only on linux and the user should be root.

Testing:

All tests are conducted on 2 socket BDX platform(18 core/socket). opendcdiag option used to measure uncore frequency

`opendcdiag -vv -e eigen_gemm_double14 -e zlib -t30s`

1st Test: `--vary-uncore-frequency` is "NOT" used.

![image](https://github.com/opendcdiag/opendcdiag/assets/89599705/88e35122-f387-428c-b675-ee3c9a95bcba)

Uncore frequency for both sockets remains constant. The dips in the graph is the transition from one fracture to another.

2nd Test: `--vary-uncore-frequency` is used.

![image](https://github.com/opendcdiag/opendcdiag/assets/89599705/d5c38d57-8798-4cfb-be2c-574c11be73c5)

Uncore frequency for both sockets varies from 2.8Ghz to 1Ghz between fractures. 

