### PR TITLE
FW: condition builtin testlist on CPU arch

### DIFF
--- a/framework/scripts/generate_test_list.py
+++ b/framework/scripts/generate_test_list.py
@@ -29,41 +29,52 @@ def main():
     h_file_basename = os.path.basename(h_file)
     cpp_file = args[2]
     root = args[3]
-    config_str = args[4] # the rest is config tuples
-    # test_list_files = { "name1" => "test_list_file1", "name2" =>
-    # "test_list_file2", ... }
+    config_str = args[4]
     test_list_files = {}
+    default_name = None
+    other_names = False
+    test_lists = {}
+    all_tests = {}
+    files = {}
+
     if (config_str == ''):
         config = {}
     else:
         config = config_str.split(',')
-    default_name = None
     for pair in config:
         parsed = pair.split(':')
-        if len(parsed) != 2:
+        if len(parsed) == 2:
+            name = parsed[0]
+            path = parsed[1]
+        elif len(parsed) == 1:
+            name = "default"
+            path = parsed[0]
+        else:
             print(f'Incorrect configuration string: {pair}')
             exit(2)
-        name = parsed[0]
-        path = parsed[1]
-        if default_name is None:
-            default_name = name # the first on the list is the default one,
-                                # it should be called "default", but this does
-                                # not rely on that
-        test_list_files[name] = root + "/" + path
 
-    # test_lists = { "name1" => [ "test1", "test2", ... ], "name2" => [ "test2",
-    # "test4", ..] }
-    # contains all the .c files to generate mapped to the ordered list of tests
-    test_lists = {}
-    all_tests = {}
+        if name == 'auto':
+            print(f'Reserved generation name used for {path}')
+            exit(2)
+        if name == 'default':
+            default_name = name
+        else:
+            other_names = True
 
-    # read and process all the arguments
-    for name, file in test_list_files.items():
-        with open(file, 'r') as f:
+        test_list_files[name] = path
+
+    # collect file names
+    for name, path in test_list_files.items():
+        if path not in files:
+            files[path] = len(files)
+
+    # read and process all files
+    for path, file_id in files.items():
+        with open(root + "/" + path, 'r') as f:
             lines = f.readlines()
 
-        test_lists[name] = []
-        test_list = test_lists[name]
+        test_lists[path] = []
+        test_list = test_lists[path]
         for l in lines:
             l = l.split('#', 1)[0]
             l = l.strip()
@@ -74,32 +85,83 @@ def main():
 
     # generate the .cpp file
     with open(cpp_file, 'w') as f:
-        f.write('#include <span>\n')
-        f.write(f'#include "{h_file_basename}"\n\n')
-        f.write('using namespace std;\n\n')
-        decls = [ f'extern struct test _test_{test};' for test in sorted(all_tests.keys()) ]
-        f.write('\n'.join(decls))
-        f.write('\n\n')
-        for name, tests in test_lists.items():
-            f.write(f'static constexpr struct test * const {name}_test_list[] = {{')
-            test_list = [ f'    &_test_{test}' for test in tests ]
-            f.write(',\n'.join(test_list))
-            f.write('\n};\n\n')
-        # write selector function
-        f.write('optional<const span<struct test * const>> get_test_list(const char *test_list_name) {\n')
+        f.write("// **This is generated file, do not edit**\n\n")
+        f.write(f'#include "{h_file_basename}"\n')
+        f.write(f'#include "sandstone_p.h"\n\n')
+
+        # list of tests (all from files, in alphabetical order)
+        if len(all_tests) != 0:
+            decls = [ f'extern struct test _test_{test};' for test in sorted(all_tests.keys()) ]
+            f.write('\n'.join(decls))
+            f.write('\n\n')
+
+        if len(files) != 0:
+            for path, tests in test_lists.items():
+                file_id = files[path]
+                num_tests = len(tests)
+                f.write(f'// content of {path}\n')
+                f.write(f'static const std::array<struct test*, {num_tests}> test_list_{file_id}{{')
+                test_list = [ f'\n    &_test_{test}' for test in tests ]
+                f.write(','.join(test_list))
+                f.write('\n};\n')
+            f.write('\n')
+
+        # build all defined lists
+        for name, path in test_list_files.items():
+            file_id = files[path]
+            f.write(f'static const struct TestList {name}_test_list{{ {"cpu_" + name if name != "default" else 0}, "{name}", test_list_{file_id} }};\n')
+        # create default "null" list if not defined
+        if default_name is None:
+            f.write(f'static const struct TestList default_test_list{{ 0, "default", std::nullopt }};\n')
+        f.write('\n')
+
+        # function to check if the list is selected, applied to non-default lists only
+        if other_names:
+            f.write('static bool test_list_matches(const TestList* test_list, const char* name)\n')
+            f.write('{\n')
+            f.write('#ifdef SANDSTONE\n')
+            f.write('    if ((name == nullptr) || (strcmp(name, "auto") == 0)) {\n')
+            f.write('        return (test_list->features & cpu_features) == test_list->features;\n')
+            f.write('    }\n')
+            f.write('#endif\n')
+            f.write('    return (name != nullptr) && (strcmp(name, test_list->name) == 0);\n')
+            f.write('}\n\n')
+
+        # selector function
+        f.write('const TestList& select_test_list(const char *name)\n')
+        f.write('{\n')
+        for name in test_list_files.keys():
+            if default_name is None or name != default_name:
+                f.write(f'    if (test_list_matches(&{name}_test_list, name)) return {name}_test_list;\n')
+
+        # emit warning if neither list matches
         if default_name is not None:
-            f.write(f'    if (!test_list_name) return {default_name}_test_list;\n')
-        for name in test_lists.keys():
-            f.write(f'    if  (!strcmp(test_list_name, "{name}")) return {name}_test_list;\n')
-        f.write('    return nullopt;\n')
+            f.write('    if (name && (strcmp(name, "default") != 0)) {\n')
+            f.write('        logging_printf(LOG_LEVEL_QUIET, "# ERROR: list for %s not found. Using default\\n", name);\n')
+            f.write('    }\n')
+        f.write('    return default_test_list;\n')
         f.write('}\n')
 
     # generate .h file
     with open(h_file, 'w') as f:
+        f.write("// **This is generated file, do not edit**\n\n")
+        f.write('#include "sandstone.h"\n')
         f.write('#include <optional>\n')
-        f.write('#include <span>\n')
-        f.write('#include "sandstone.h"\n\n')
-        f.write('std::optional<const std::span<struct test * const>> get_test_list(const char *);\n')
+        f.write('#include <span>\n\n')
+
+        # per-gen list definition
+        f.write('typedef struct TestList {\n')
+        f.write('    uint64_t features;\n')
+        f.write('    const char* name;\n')
+        f.write('    const std::optional<std::span<struct test* const>> tests;\n')
+        f.write('} TestList;\n\n')
+
+        f.write('const TestList& select_test_list(const char *);\n\n')
+
+        f.write('static inline std::optional<const std::span<struct test * const>> get_test_list(const char *name)\n')
+        f.write('{\n')
+        f.write('    return select_test_list(name).tests;\n')
+        f.write('}\n')
 
     exit(0)
 


### PR DESCRIPTION
The generator updated according the discussion from PR #454. The commit includes two behavioural changes:
- default list is always "at the end" (when there's no matching list, either by name or features), location of this entry in the list is not important
- it is not required to name 'default' list (only a filename might be put into the option, without 'default' prefix)
- internal data model slightly changed: each file (by name) is parsed once, might be shared between lists for multiple generations.

If no matching list is defined during compilation (and selected with --use-builtin-test-list), appropriate warning is emitted in runtime.

Signed-off-by: Jarek Poswiata <jaroslaw.poswiata@intel.com>

[ChangeLog] Default list must be explicitly defined in the option. If no matching list is found in the list (by either name or features, checked in the order in the list, 'default' is skipped), the 'default'  is assumed, and appropriate warning is emitted.