### PR TITLE
FW/Win32: stop using _aligned_recalloc with UCRT

### DIFF
--- a/framework/sysdeps/windows/aligned_alloc.cpp
+++ b/framework/sysdeps/windows/aligned_alloc.cpp
@@ -38,12 +38,6 @@ static inline void *check_null_pointer(void *ptr)
 extern "C" {
 void *aligned_alloc(size_t alignment, size_t size)
 {
-#ifdef _UCRT
-    // Use ucrt's _aligned_recalloc
-    return check_null_pointer(_aligned_recalloc(NULL, 1, size, alignment));
-#endif
-
-    // old VC6 CRT doesn't have _aligned_recalloc, so we align and memset
     void *ptr = check_null_pointer(_aligned_malloc(size, alignment));
     return memset(ptr, 0, size);
 }
@@ -95,11 +89,6 @@ size_t aligned_msize(void *ptr)
 
 void *realloc(void *ptr, size_t size)
 {
-#ifdef _UCRT
-    // Use ucrt's _aligned_recalloc
-    return check_null_pointer(_aligned_recalloc(ptr, 1, size, DEFAULT_ALIGNMENT));
-#endif
-
     size_t oldsize = aligned_msize(ptr);
     void *newptr = check_null_pointer(_aligned_realloc(ptr, size, DEFAULT_ALIGNMENT));
     size = aligned_msize(newptr);


### PR DESCRIPTION
This is an interesting function that allows us to avoid having to `memset()` ourselves (presumably, if the CRT knows it's zeroed, it wouldn't need to do it again). But WINE hasn't implemented it, so let's not rely on it.