### PR TITLE
FW: Fix bug in frequency manager

### DIFF
--- a/framework/frequency_manager.hpp
+++ b/framework/frequency_manager.hpp
@@ -111,7 +111,7 @@ private:
             exit(EX_IOERR);
         }
 
-        while (fscanf(file, "%s", read_file)) {
+        while (fscanf(file, "%s", read_file) != EOF) {
             if (strcmp(read_file, "userspace") == 0) {
                 fclose(file);
                 return;


### PR DESCRIPTION
Return value of fscanf should be checked for EOF instead of relying on boolean logical operator.

Should be working fine:

```
 ./opendcdiag -vv -e eigen_gemm_double14 -e zlib -t30s --vary-frequency
./opendcdiag: Cannot find "userspace" scaling governor from the file: /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors
```