### PR TITLE
FW: implement negated --cpuset option

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1701,6 +1701,40 @@ selftest_cpuset_unsorted() {
     selftest_cpuset_unsorted "odd" "${cpuinfo[@]}"
 }
 
+selftest_cpuset_negated() {
+    local arg=$1
+    local not=$2
+
+    # get all the CPUs, except $not
+    local -a cpuinfo=(`$SANDSTONE --dump-cpu-info |
+            awk -v "not=$not" '/^[0-9]/ && $1 != not { print $1; }'`)
+    selftest_cpuset_unsorted "$arg" "${cpuinfo[@]}"
+}
+
+@test "cpuset=number (not first)" {
+    # Get the first logical processor
+    local -a cpuinfo=(`$SANDSTONE --dump-cpu-info | sed -n '/^[0-9]/{p;q;}'`)
+    selftest_cpuset_negated \!${cpuinfo[0]} ${cpuinfo[0]}
+}
+
+@test "cpuset=topology (not first)" {
+    # Get the first logical processor
+    local -a cpuinfo=(`$SANDSTONE --dump-cpu-info | sed -n '/^[0-9]/{p;q;}'`)
+    selftest_cpuset_negated \!p${cpuinfo[1]}c${cpuinfo[2]}t${cpuinfo[3]} ${cpuinfo[0]}
+}
+
+@test "cpuset=number (not last)" {
+    # Get the last logical processor
+    local -a cpuinfo=(`$SANDSTONE --dump-cpu-info | sed -n '$p'`)
+    selftest_cpuset_negated \!${cpuinfo[0]} ${cpuinfo[0]}
+}
+
+@test "cpuset=topology (not last)" {
+    # Get the last logical processor
+    local -a cpuinfo=(`$SANDSTONE --dump-cpu-info | sed -n '$p'`)
+    selftest_cpuset_negated \!p${cpuinfo[1]}c${cpuinfo[2]}t${cpuinfo[3]} ${cpuinfo[0]}
+}
+
 # Confirm that we are roughly using the threads we said we would
 @test "thread usage" {
     local -a cpuset=(`$SANDSTONE --dump-cpu-info | awk '/^[0-9]/ { print $1 }'`)


### PR DESCRIPTION
This is useful when you want to run on all logical processors except a few, and listing all 896 entries but those would be very tiring.

For example, for `--cpuset='!0,3'` on a 4-core system:
```yaml
cpu-info:
  0: { logical: 4, package: 0, core: 0, thread: 1, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  1: { logical: 1, package: 0, core: 1, thread: 0, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  2: { logical: 5, package: 0, core: 1, thread: 1, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  3: { logical: 2, package: 0, core: 2, thread: 0, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  4: { logical: 6, package: 0, core: 2, thread: 1, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  5: { logical: 7, package: 0, core: 3, thread: 1, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
```

And with `--cpuset='!c2'`:
```yaml
cpu-info:
  0: { logical: 0, package: 0, core: 0, thread: 0, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  1: { logical: 4, package: 0, core: 0, thread: 1, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  2: { logical: 1, package: 0, core: 1, thread: 0, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  3: { logical: 5, package: 0, core: 1, thread: 1, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  4: { logical: 3, package: 0, core: 3, thread: 0, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
  5: { logical: 7, package: 0, core: 3, thread: 1, family: 6, model: 0x8c, stepping: 1, microcode: 0xb6, ppin: null }
```

[ChangeLog][Framework] Added the ability to negate the selection of logical processors using the the `--cpuset` option: if the first character in that option's argument is an exclamation mark (!), then the argument removes the matched entries from the list. This option can be combined with other `--cpuset` options to add to or remove from the working set.