### PR TITLE
Tests/Eigen: make the dimensions changeable at runtime

### DIFF
--- a/tests/eigen_gemm/double14.cpp
+++ b/tests/eigen_gemm/double14.cpp
@@ -43,8 +43,9 @@ struct eigen_test_data {
 static int eigen_gemm_double14_init(struct test *test) {
     test->data = new(eigen_test_data);
     try {
-        CAST(test->data)->lhs = Mat::Random(M_DIM, M_DIM);
-        CAST(test->data)->rhs = Mat::Random(M_DIM, M_DIM);
+        Mat::Index dim = get_testspecific_knob_value_int(test, "Dim", M_DIM);
+        CAST(test->data)->lhs = Mat::Random(dim, dim);
+        CAST(test->data)->rhs = Mat::Random(dim, dim);
         CAST(test->data)->prod = CAST(test->data)->lhs * CAST(test->data)->rhs;
     } catch (...) {
         report_fail_msg("Exception on Eigen code, most probably OOM");

--- a/tests/eigen_gemm/gemm_cdouble_dynamic_square.cpp
+++ b/tests/eigen_gemm/gemm_cdouble_dynamic_square.cpp
@@ -44,8 +44,9 @@ struct eigen_test_data {
 static int eigen_gemm_cdouble_dynamic_square_init(struct test *test) {
     test->data = new(eigen_test_data);
     try {
-        CAST(test->data)->lhs = Mat::Random(M_DIM, M_DIM);
-        CAST(test->data)->rhs = Mat::Random(M_DIM, M_DIM);
+        Mat::Index dim = get_testspecific_knob_value_int(test, "Dim", M_DIM);
+        CAST(test->data)->lhs = Mat::Random(dim, dim);
+        CAST(test->data)->rhs = Mat::Random(dim, dim);
         CAST(test->data)->prod = CAST(test->data)->lhs * CAST(test->data)->rhs;
     } catch (...) {
         report_fail_msg("Exception on Eigen code, most probably OOM");
@@ -62,7 +63,7 @@ static int eigen_gemm_cdouble_dynamic_square_run(struct test *test, int cpu) {
         x = testdata->lhs * testdata->rhs;
 
         memcmp_or_fail(reinterpret_cast<double *>(x.data()),
-                       reinterpret_cast<double *>(testdata->prod.data()), 2 * M_DIM * M_DIM);
+                       reinterpret_cast<double *>(testdata->prod.data()), 2 * x.rows() * x.cols());
     } while (test_time_condition(test));
     //log_info("Num iters = %i\n", i);
     return EXIT_SUCCESS;

--- a/tests/eigen_gemm/gemm_double_dynamic_square.cpp
+++ b/tests/eigen_gemm/gemm_double_dynamic_square.cpp
@@ -42,8 +42,9 @@ struct eigen_test_data {
 static int eigen_gemm_double_dynamic_square_init(struct test *test) {
     test->data = new(eigen_test_data);
     try {
-        CAST(test->data)->lhs = Mat::Random(M_DIM, M_DIM);
-        CAST(test->data)->rhs = Mat::Random(M_DIM, M_DIM);
+        Mat::Index dim = get_testspecific_knob_value_int(test, "Dim", M_DIM);
+        CAST(test->data)->lhs = Mat::Random(dim, dim);
+        CAST(test->data)->rhs = Mat::Random(dim, dim);
         CAST(test->data)->prod = CAST(test->data)->lhs * CAST(test->data)->rhs;
     } catch (...) {
         report_fail_msg("Exception on Eigen code, most probably OOM");
@@ -59,7 +60,7 @@ static int eigen_gemm_double_dynamic_square_run(struct test *test, int cpu) {
         Mat x;
         x = testdata->lhs * testdata->rhs;
 
-        memcmp_or_fail(x.data(), testdata->prod.data(), M_DIM * M_DIM);
+        memcmp_or_fail(x.data(), testdata->prod.data(), x.rows() * x.cols());
     } while (test_time_condition(test));
     //log_info("Num iters = %i\n", i);
     return EXIT_SUCCESS;

--- a/tests/eigen_gemm/gemm_float_dynamic_square.cpp
+++ b/tests/eigen_gemm/gemm_float_dynamic_square.cpp
@@ -43,8 +43,9 @@ struct eigen_test_data {
 static int eigen_gemm_float_dynamic_square_init(struct test *test) {
     test->data = new(eigen_test_data);
     try {
-        CAST(test->data)->lhs = Mat::Random(M_DIM, M_DIM);
-        CAST(test->data)->rhs = Mat::Random(M_DIM, M_DIM);
+        Mat::Index dim = get_testspecific_knob_value_int(test, "Dim", M_DIM);
+        CAST(test->data)->lhs = Mat::Random(dim, dim);
+        CAST(test->data)->rhs = Mat::Random(dim, dim);
         CAST(test->data)->prod = CAST(test->data)->lhs * CAST(test->data)->rhs;
     } catch (...) {
         report_fail_msg("Exception on Eigen code, most probably OOM");
@@ -60,7 +61,7 @@ static int eigen_gemm_float_dynamic_square_run(struct test *test, int cpu) {
         Mat x;
         x = testdata->lhs * testdata->rhs;
 
-        memcmp_or_fail(x.data(), testdata->prod.data(), M_DIM * M_DIM);
+        memcmp_or_fail(x.data(), testdata->prod.data(), x.rows() * x.cols());
     } while (test_time_condition(test));
     //log_info("Num iters = %i\n", i);
     return EXIT_SUCCESS;


### PR DESCRIPTION
All of these tests use `Dynamic` as their structural size (i.e., not a fixed at compile-time). So do allow changing them with a command-line option: we've had an interest in doing that to measure how the test behaves.