### PR TITLE
FW: Implement cpu jump during test execution

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -625,7 +625,7 @@ int num_packages() __attribute__((pure));
 
 /// Check point for cpu jump feature, which allows the test to jump execution
 /// to a different cpu. If cpujump is not set, this does nothing
-void checkpoint(int cpu);
+void checkpoint();
 
 #ifdef __cplusplus
 }

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -623,6 +623,10 @@ int num_cpus() __attribute__((pure));
 /// test.
 int num_packages() __attribute__((pure));
 
+/// Check point for cpu jump feature, which allows the test to jump execution
+/// to a different cpu. If cpujump is not set, this does nothing
+void checkpoint(int cpu);
+
 #ifdef __cplusplus
 }
 inline int cpu_info::cpu() const

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -29,6 +29,7 @@
 #ifdef __cplusplus
 #include <memory>
 #include <span>
+#include <barrier>
 
 #include <sandstone_config.h>
 #include <sandstone_chrono.h>
@@ -328,7 +329,7 @@ struct SandstoneThreadSynchronizationBase
 };
 
 struct CPUJump {
-    pthread_barrier_t *barrier = nullptr;
+    std::barrier<void(*)(void) noexcept> *barrier;
     int current_cpu;
     int next_cpu;
 };

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -447,6 +447,11 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     SandstoneBackgroundScan background_scan;
     SandstoneThreadSynchronizationBase *thread_synchronization = nullptr;
 
+    bool cpujump = false;
+    int barrier_count = 0;
+    int members_per_barrier = 2; // Make this configurable
+    std::vector<pthread_barrier_t*> cpujump_barrier_vec;
+
 private:
     SandstoneApplication() = default;
     ~SandstoneApplication() = delete;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -216,11 +216,15 @@ struct alignas(64) Test : Common
     /* Thread's effective CPU frequency during execution */
     double effective_freq_mhz;
 
+    /* Last TSC reading */
+    uint64_t last_tsc;
+
     void init()
     {
         Common::init();
         inner_loop_count = inner_loop_count_at_fail = 0;
         effective_freq_mhz = 0.0;
+        last_tsc = 0;
     }
 };
 } // namespace PerThreadData
@@ -314,6 +318,13 @@ public:
 private:
     int fd;
     friend LoggingStream logging_user_messages_stream(int thread_num, int level);
+};
+
+struct SandstoneThreadSynchronizationBase
+{
+    virtual ~SandstoneThreadSynchronizationBase() = default;
+    virtual void init() noexcept = 0;
+    virtual void synchronize() noexcept = 0;
 };
 
 struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>
@@ -434,6 +445,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     void select_main_thread(int slice);
 
     SandstoneBackgroundScan background_scan;
+    SandstoneThreadSynchronizationBase *thread_synchronization = nullptr;
 
 private:
     SandstoneApplication() = default;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -327,6 +327,12 @@ struct SandstoneThreadSynchronizationBase
     virtual void synchronize() noexcept = 0;
 };
 
+struct CPUJump {
+    pthread_barrier_t *barrier = nullptr;
+    int current_cpu;
+    int next_cpu;
+};
+
 struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>
 {
     enum class OutputFormat : int8_t {
@@ -448,9 +454,8 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     SandstoneThreadSynchronizationBase *thread_synchronization = nullptr;
 
     bool cpujump = false;
-    int barrier_count = 0;
     int members_per_barrier = 2; // Make this configurable
-    std::vector<pthread_barrier_t*> cpujump_barrier_vec;
+    std::vector<CPUJump*> cpujump_vec;
 
 private:
     SandstoneApplication() = default;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -37,6 +37,7 @@
 #include <sandstone_utils.h>
 
 #include "effective_cpu_freq.hpp"
+#include "gettid.h"
 #include "topology.h"
 #include "interrupt_monitor.hpp"
 #include "thermal_monitor.hpp"
@@ -219,6 +220,9 @@ struct alignas(64) Test : Common
 
     /* Last TSC reading */
     uint64_t last_tsc;
+
+    /* Thread Process ID */
+    std::atomic<tid_t> tid;
 
     void init()
     {

--- a/framework/sandstone_thread.cpp
+++ b/framework/sandstone_thread.cpp
@@ -89,6 +89,8 @@ void SandstoneTestThread::start(RunnerFunction *f, int cpu)
     auto runner = +[](void *ptr) {
         auto self = static_cast<SandstoneTestThread *>(ptr);
         ::thread_num = self->thread_num;
+        sApp->test_thread_data(self->thread_num)->tid.store(gettid());
+        //auto clear_tid = scopeExit([] { sApp->test_thread_data(thread_num) = 0; }); // TODO: Fix this
         return reinterpret_cast<void *>(self->target(self->thread_num));
     };
 

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -186,6 +186,7 @@ private:
 LogicalProcessorSet ambient_logical_processor_set();
 bool pin_to_logical_processor(LogicalProcessor, const char *thread_name = nullptr);
 bool pin_to_logical_processors(CpuRange, const char *thread_name);
+bool pin_thread_to_logical_processor(LogicalProcessor n, const char *thread_name, pid_t thread_pid);
 
 void apply_cpuset_param(char *param);
 void init_topology(const LogicalProcessorSet &enabled_cpus);

--- a/meson.build
+++ b/meson.build
@@ -123,6 +123,7 @@ add_project_link_arguments([
     '-lm',
     '-lssp',
     '-Wl,-Bdynamic',
+    '-lsynchronization',
     '-lshlwapi',
     '-lntdll',
 ], language : [ 'c', 'cpp' ])


### PR DESCRIPTION
The goal of this change is allow tests to be executed in multiple cpus during their runtime, always choosing the next available logical cpu.