### PR TITLE
FW: Fix deprecation warning.

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3212,8 +3212,10 @@ int main(int argc, char **argv)
         init_topology(std::move(enabled_cpus));
     }
 
+    int coptind = -1;
+
     while (!SandstoneConfig::RestrictedCommandLine &&
-           (opt = simple_getopt(argc, argv, long_options)) != -1) {
+           (opt = simple_getopt(argc, argv, long_options, &coptind)) != -1) {
         switch (opt) {
         case disable_option:
             disable_tests(test_set, optarg);
@@ -3577,7 +3579,7 @@ int main(int argc, char **argv)
         case mem_samples_per_log_option:
         case no_mem_sampling_option:
         case schedule_by_option:
-            warn_deprecated_opt(argv[optind]);
+            warn_deprecated_opt(long_options[coptind].name);
             break;
 
         case 0:

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1428,17 +1428,6 @@ Common command-line options are:
      Randomizes the order in which tests are executed.
  --test-delay <time in ms>
      Delay between individual test executions in milliseconds.
- --schedule-by <selection>
-     Valid options for <selection> are [core, thread]. Default is thread.
-     This selection comes into play when Sandstone has to limit the number
-     of concurrent logical cpus on which a test can run (which is the case
-     when --max-concurrent-threads is specified or if the test has an
-     implicit maximum concurrent threads limit). If the selection is to
-     schedule by thread, Sandstone groups the specified set of logical cpus
-     numerically according to thread number. This means that typically both
-     logical cpus on a core will not be running the test concurrently. On
-     the other hand, if the selection is to schedule by core, Sandstone will
-     try to pick logical cpus belonging to the same core to run concurrently.
   -Y, --yaml [<indentation>]
      Use YAML for logging. The optional argument is the number of spaces to
      indent each line by (defaults to 0).


### PR DESCRIPTION
optind points to the next option to be processed, so pass the argument to getopt to get the current index.

Before:
```
./opendcdiag: option '(null)' is ignored and will be removed in a future version.
```
After:
```
./opendcdiag: option 'schedule-by' is ignored and will be removed in a future version.
```