### PR TITLE
FW: do #include <immintrin.h> in amx_common.h

### DIFF
--- a/framework/amx_common.h
+++ b/framework/amx_common.h
@@ -9,6 +9,7 @@
 #ifndef signature_INTEL_ebx
 #include <cpuid.h>
 #endif
+#include <immintrin.h>
 #include <stdint.h>
 
 #if __clang_major__ > 10 || defined(_tile_loadd)


### PR DESCRIPTION
For GCC >= 12 and for Clang, we rely in it providing the intrinsics.