### PR TITLE
FW/Topology: fix num_packages() in -f exec mode (i.e. Windows)

### DIFF
--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -204,6 +204,7 @@ static int selftest_cxxthrowcatch_run(struct test *test, int cpu)
 
 static int selftest_skip_init(struct test *test)
 {
+    log_info("{\"packages\": %d, \"cpus\": %d}", num_packages(), num_cpus());
     log_info("Requesting skip (this message should be visible)");
     return EXIT_SKIP;
 }

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -1084,10 +1084,11 @@ void restrict_topology(CpuRange range)
     assert(range.starting_cpu + range.cpu_count <= sApp->thread_count);
     auto old_cpu_info = std::exchange(cpu_info, sApp->shmem->cpu_info + range.starting_cpu);
     int old_thread_count = std::exchange(sApp->thread_count, range.cpu_count);
-    if (old_cpu_info == cpu_info && old_thread_count == sApp->thread_count)
-        return;
 
-    cached_topology() = build_topology();
+    Topology &topo = cached_topology();
+    if (old_cpu_info != cpu_info || old_thread_count != sApp->thread_count ||
+            topo.packages.size() == 0)
+        topo = build_topology();
 }
 
 static char character_for_mask(uint32_t mask)


### PR DESCRIPTION
We weren't rebuilding the cached topology if the resulting set was the same as the original. In general, that's a good thing, except when there was no cached topology in the first place...