### PR TITLE
FW: add missing #include for std::stringstream

### DIFF
--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <charconv>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Found in one of our internal builds:
```
../opendcdiag/framework/sandstone_tests.cpp: In function 'std::vector<test_cfg_info> load_test_list(std::ifstream&, SandstoneTestSet*, bool, std::vector<std::__cxx11::basic_string<char> >&)':
../opendcdiag/framework/sandstone_tests.cpp:197:35: error: aggregate 'std::stringstream msg_strm' has incomplete type and cannot be defined
```