### PR TITLE
FW: simplify the test iteration code to fix looping (-T)

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -584,6 +584,20 @@ selftest_log_skip_init_socket_common() {
     test_yaml_numeric "/tests/0/test-runtime" 'value >= 250'
 }
 
+@test "selftest_timedpass -t 25 -T 250" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_timedpass -t 25 -T 250
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    local test_count=${yamldump[/tests@len]}
+    local i
+    for ((i = 0; i < test_count; ++i)); do
+        test_yaml_regexp "/tests/$i/result" pass
+        test_yaml_numeric "/tests/$i/test-runtime" 'value >= 25'
+    done
+    test_yaml_numeric "/tests/$((i-1))/time-at-end/elapsed" 'value >= 250'
+}
+
 @test "selftest_timedpass -t 1150" {
     # With over 800 ms, we should see fracturing
     declare -A yamldump


### PR DESCRIPTION
Fixed #523

Looks like an off-by-one error where we skipped the last or first entry... resulting in reading one-past-the-end and a crash. Plus there was some dangling pointer dereferences I didn't investigate.

Instead, I removed the special Iterator class added by commit @e89cd594fcda062209c3fccf7fa7a34bbe62b58f (at my urging in the PR review), but it turns out to have been more complex than necessary and more harm than good. So this just cleans up by removing that iterator class completely and relying on `get_next_test()` function to do the looping.
