### PR TITLE
editorconfig: meson.build formatting changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,8 @@ indent_style = space
 tab_width = 4
 
 [{meson.build,meson_options.txt}]
-indent_style = tab
+indent_style = space
+indent_size = 4
 
 [simd*.conf]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ insert_final_newline = true
 
 [*.{c,cpp,h,hpp}]
 indent_style = space
-tab_width = 4
+indent_size = 4
 
 [{meson.build,meson_options.txt}]
 indent_style = space
@@ -16,3 +16,4 @@ indent_size = 4
 
 [simd*.conf]
 indent_style = tab
+tab_width = 8


### PR DESCRIPTION
Adapt formatting rules for meson files.
* See: b4f390828337 ("Meson: Replace tabs with 4 spaces.")

Also, fix existing formatting rules-- there were some subtleties around `indent_size` and `tab_width` that were not grokked before, see commits for details.