### PR TITLE
FW: undo -T triggering --strict-runtime

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3339,7 +3339,6 @@ int main(int argc, char **argv)
             } else {
                 sApp->endtime = sApp->starttime + string_to_millisecs(optarg);
             }
-            sApp->shmem->use_strict_runtime = true;
             test_set_config.cycle_through = true; /* Time controls when the execution stops as
                                                      opposed to the number of tests. */
             break;


### PR DESCRIPTION
It was not our behaviour and that causes timing tests to fail because a test can exit sooner than expected:

```yaml
command-line: 'opendcdiag --on-crash=core --on-hang=kill -Y -o - -n4 --disable=mce_check --no-triage --selftests --timeout=20s --retest-on-failure=0 -Y2 -e selftest_timedpass -t 25 -T 250'
- test: selftest_timedpass
  details: { quality: beta, description: "Loops around usleep() for the regular test time" }
  state: { seed: 'LCG:376818534', iteration: 0, retry: false }
  time-at-start: { elapsed:    193.332, now: !!timestamp '2024-07-10T10:38:47Z' }
  result: pass
  time-at-end:   { elapsed:    226.665, now: !!timestamp '2024-07-10T10:38:47Z' }
  test-runtime: 31.710
 # Loop iteration 6 finished, average time 40.11
- test: selftest_timedpass
  details: { quality: beta, description: "Loops around usleep() for the regular test time" }
  state: { seed: 'LCG:220964624', iteration: 0, retry: false }
  time-at-start: { elapsed:    233.331, now: !!timestamp '2024-07-10T10:38:47Z' }
  result: pass
  time-at-end:   { elapsed:    246.665, now: !!timestamp '2024-07-10T10:38:47Z' }
  test-runtime: 11.518
```

That last test ran for 11.5 ms instead of the requested 25 ms.