### PR TITLE
CI: update the -T test

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -595,7 +595,7 @@ selftest_log_skip_init_socket_common() {
         test_yaml_regexp "/tests/$i/result" pass
         test_yaml_numeric "/tests/$i/test-runtime" 'value >= 25'
     done
-    test_yaml_numeric "/tests/$((i-1))/time-at-end/elapsed" 'value >= 250'
+    test_yaml_numeric "/tests/$((i-1))/time-at-start/elapsed" 'value < 250'
 }
 
 @test "selftest_timedpass -t 1150" {


### PR DESCRIPTION
This was added by commit 9601936870325fe2d857973bfd3f750135db0af0 and passed on my machine and in the CI, but I don't know how because it doesn't now. Maybe f60599d3b77d79dfd08a13b11c839b2dee98f352 has an effect.

In any case, we can't tell much about the time-at-end: `should_start_next_iteration()` only starts the next iteration if the remaining time until the deadline is more than the average iteration time. In CIs, we can't tell much about the average time and the deviation from the average for this next iteration can be huge.