### PR TITLE
CI/Bats: disable the selftest_timedpass_fork test for the silent run

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -236,14 +236,14 @@ tap_negative_check() {
 }
 
 @test "TAP silent output" {
-    opts="--output-format=tap --quick --selftests --quiet --disable=mce_check -e @positive"
-    $SANDSTONE $opts > $BATS_TEST_TMPDIR/output.tap
+    local -a opts=(--output-format=tap --quick --selftests --quiet --disable=mce_check --disable="*fork" -e @positive)
+    $SANDSTONE "${opts[@]}" > $BATS_TEST_TMPDIR/output.tap
 
     sed -i -e 's/\r$//' $BATS_TEST_TMPDIR/output.tap
     {
         read line
         echo line 1: $line
-        [[ "$line" = "# ${SANDSTONE##*/} $opts" ]]
+        [[ "$line" = "# ${SANDSTONE##*/} ${opts[@]}" ]]
 
         read line
         echo line 2: $line
@@ -259,14 +259,14 @@ tap_negative_check() {
 }
 
 @test "YAML silent output" {
-    opts="-Y --quick --selftests --quiet --disable=mce_check -e @positive"
-    $SANDSTONE $opts > $BATS_TEST_TMPDIR/output.yaml
+    local -a opts=(-Y --quick --selftests --quiet --disable=mce_check --disable="*fork" -e @positive)
+    $SANDSTONE "${opts[@]}" > $BATS_TEST_TMPDIR/output.yaml
 
     sed -i -e 's/\r$//' $BATS_TEST_TMPDIR/output.yaml
     {
         read line
         echo line 1: $line
-        [[ "$line" = "command-line: '${SANDSTONE##*/} $opts'" ]]
+        [[ "$line" = "command-line: '${SANDSTONE##*/} ${opts[@]}'" ]]
 
         read line
         echo line 2: $line


### PR DESCRIPTION
This test was added by commit 8c1466a1abea002f6eac023a390d546021a3d306 and is part of the standard `@positive` group of selftests. It appears to pass just fine under normal circumstances, but we have observed it to fail in:
- ASAN builds
- More than 10 threads

This appears to trigger some race condition inside libasan that causes the child processes to remain behind. When that happens, Bats hangs.

This problem does not affect the "selftest_freeze_fork" bats test because it runs with -n4 or fewer CPUs. Plus, in the freezing case, the framework will kill those child processes, so Bats won't hang.