### PR TITLE
FW: Add command line options `enable-by-feature` and `disable-by-feature`

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -112,11 +112,12 @@ enum {
     thirty_sec_option,
     two_min_option,
     five_min_option,
-
     cpuset_option,
     disable_option,
+    disable_by_feature_option,
     dump_cpu_info_option,
     fatal_skips_option,
+    enable_by_feature_option,
     gdb_server_option,
     ignore_os_errors_option,
     ignore_unknown_tests_option,
@@ -1326,6 +1327,45 @@ static std::string cpu_features_to_string(uint64_t f)
             comma = ",";
         }
     }
+    return result;
+}
+
+static uint64_t cpu_features_to_cpuid(std::string f_str)
+{
+    uint64_t result = 0;
+    uint32_t substrings_num = 0;
+    uint32_t substrings_found_num = 0;
+
+    // Split the input string by commas
+    std::vector<std::string_view> substrings;
+    size_t start = 0;
+    size_t end = f_str.find(',');
+
+    while (end != std::string_view::npos) {
+        substrings.push_back(f_str.substr(start, end - start));
+        substrings_num++;
+        start = end + 1;
+        end = f_str.find(',', start);
+    }
+    substrings.push_back(f_str.substr(start)); // Add the last substring
+    substrings_num++;
+
+    for (const auto& sub : substrings) {
+        for (size_t i = 0; i < std::size(x86_locators); i++) {
+            std::string_view checked_feature = std::string_view(features_string + features_indices[i] + 1);
+
+            if (checked_feature == sub) {
+                substrings_found_num++;
+                result |= UINT64_C(1) << i;
+                break;
+            }
+        }
+    }
+
+    if(substrings_found_num != substrings_num) {
+        return 0x00;
+    }
+
     return result;
 }
 
@@ -3148,8 +3188,10 @@ int main(int argc, char **argv)
         { "beta", no_argument, &sApp->requested_quality, 0 },
         { "cpuset", required_argument, nullptr, cpuset_option },
         { "disable", required_argument, nullptr, disable_option },
+        { "disable-by-feature", required_argument, nullptr, disable_by_feature_option },
         { "dump-cpu-info", no_argument, nullptr, dump_cpu_info_option },
         { "enable", required_argument, nullptr, 'e' },
+        { "enable-by-feature", required_argument, nullptr, enable_by_feature_option },
         { "fatal-errors", no_argument, nullptr, 'F'},
         { "fatal-skips", no_argument, nullptr, fatal_skips_option },
         { "fork-mode", required_argument, nullptr, 'f' },
@@ -3247,6 +3289,10 @@ int main(int argc, char **argv)
         .ignore_unknown_tests = false,
         .randomize = false,
         .cycle_through = false,
+        .enable_by_feature_req = false,
+        .enabled_features_mask = UINT64_MAX, // we set all bits during initialization, so we permit all features
+        .disable_by_feature_req = false,
+        .disabled_features_mask = 0x00, //  we set no bits during initialization, so we disable no features
     };
     const char *builtin_test_list_name = nullptr;
     int starting_test_number = 1;  // One based count for user interface, not zero based
@@ -3373,9 +3419,37 @@ int main(int argc, char **argv)
         case cpuset_option:
             apply_cpuset_param(optarg);
             break;
+        case disable_by_feature_option:
+            if(optarg == nullptr || *optarg == '\0') {
+                fprintf(stderr, "%s: --disable-by-feature requires a non-empty argument\n", argv[0]);
+                return EX_USAGE;
+            }
+
+            test_set_config.disable_by_feature_req = true;
+            test_set_config.disabled_features_mask = cpu_features_to_cpuid(optarg);
+
+            if(test_set_config.disabled_features_mask == 0x00) {
+                fprintf(stderr, "%s: --disable-by-feature: unknown CPU feature(s) requested: %s\n", argv[0], optarg);
+                return EX_USAGE;
+            }
+            break;
         case dump_cpu_info_option:
             dump_cpu_info();
             return EXIT_SUCCESS;
+        case enable_by_feature_option:
+            if(optarg == nullptr || *optarg == '\0') {
+                fprintf(stderr, "%s: --enable-by-feature requires a non-empty argument\n", argv[0]);
+                return EX_USAGE;
+            }
+
+            test_set_config.enable_by_feature_req = true;
+            test_set_config.enabled_features_mask = cpu_features_to_cpuid(optarg);
+
+            if(test_set_config.enabled_features_mask == 0x00) {
+                fprintf(stderr, "%s: --enable-by-feature: unknown CPU feature(s) requested: %s\n", argv[0], optarg);
+                return EX_USAGE;
+            }
+            break;
         case fatal_skips_option:
             sApp->fatal_skips = true;
             break;
@@ -3760,6 +3834,11 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Leave only the tests that require enabled feature. */
+    if(test_set_config.enable_by_feature_req) {
+        test_set->enable_by_feature(test_set_config.enabled_features_mask);
+    }
+
 
     /* Add mce_check as the last test to the set. It will be kept last by
      * SandstoneTestSet in case randomization is requested. */
@@ -3770,6 +3849,11 @@ int main(int argc, char **argv)
         for (auto name : disabled_tests) {
             test_set->disable(name);
         }
+    }
+
+    /* Remove all the tests that require disabled feature. */
+    if(test_set_config.disable_by_feature_req) {
+        test_set->disable_by_feature(test_set_config.disabled_features_mask);
     }
 
     if (sApp->shmem->verbosity == -1)

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -94,6 +94,7 @@ struct test_cfg_info SandstoneTestSet::enable(struct test *t) {
 std::vector<struct test_cfg_info> SandstoneTestSet::enable(const char *name) {
     std::vector<struct test_cfg_info> res;
     std::vector<struct test *> tests = lookup(name);
+
     for (auto t : tests) {
         struct test_cfg_info ti = enable(t);
         res.push_back(ti);
@@ -125,6 +126,39 @@ std::vector<struct test_cfg_info> SandstoneTestSet::disable(const char *name) {
     }
     return res;
 }
+
+std::vector<struct test_cfg_info> SandstoneTestSet::enable_by_feature(uint64_t enabled_features_mask) {
+    std::vector<struct test_cfg_info> res;
+
+    for (auto t = test_set.begin(); t != test_set.end();) {
+        uint64_t t_f_req = ((*t)->minimum_cpu | (*t)->compiler_minimum_cpu);
+
+        if (!(t_f_req & enabled_features_mask)) {
+            res.push_back(disable(*t));
+            test_set.erase(t);
+        } else {
+            t++;
+        }
+    }
+    return res;
+}
+
+std::vector<struct test_cfg_info> SandstoneTestSet::disable_by_feature(uint64_t disabled_features_mask) {
+    std::vector<struct test_cfg_info> res;
+
+    for (auto t = test_set.begin(); t != test_set.end();) {
+        uint64_t t_f_req = ((*t)->minimum_cpu | (*t)->compiler_minimum_cpu);
+
+        if (t_f_req & disabled_features_mask) {
+            res.push_back(disable(*t));
+            test_set.erase(t);
+        } else {
+            t++;
+        }
+    }
+    return res;
+}
+
 
 static inline bool is_ignored(char c) {
     switch (c) {

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -27,14 +27,21 @@ extern struct test __stop_tests;
 extern struct test mce_test;
 
 struct test_set_cfg {
-    bool ignore_unknown_tests;  /* whether an error should be reported if
-                                   there's no test matching the specified name,
-                                   either on command-line or in a test list. */
-    bool randomize;             /* iterate through the tests in random order. */
-    bool cycle_through;         /* start over when an iteration through the test
-                                   set has finished. */
-    bool is_selftest;           /* whether to use regular or selftests as the
-                                   source of the tests. */
+    bool ignore_unknown_tests;          /* whether an error should be reported if
+                                           there's no test matching the specified name,
+                                           either on command-line or in a test list. */
+    bool randomize;                     /* iterate through the tests in random order. */
+    bool cycle_through;                 /* start over when an iteration through the test
+                                           set has finished. */
+    bool is_selftest;                   /* whether to use regular or selftests as the
+                                           source of the tests. */
+    bool enable_by_feature_req;         /* whether to enable tests by the requested
+                                           features. Other tests are disabled. */
+    uint64_t enabled_features_mask;     /* features requested by the user. */
+
+    bool disable_by_feature_req;        /* whether to disable tests by the requested
+                                           features. Other tests are enabled. */
+    uint64_t disabled_features_mask;    /* features requested by the user. */
 };
 
 struct test_cfg_info {
@@ -94,6 +101,9 @@ public:
 
     std::vector<struct test_cfg_info> enable(const char *name);
     struct test_cfg_info enable(struct test *t);
+
+    std::vector<struct test_cfg_info> enable_by_feature(uint64_t enabled_features_mask);
+    std::vector<struct test_cfg_info> disable_by_feature(uint64_t disabled_features_mask);
 
     bool is_disabled(const char *name) { auto it = test_map.find(name); return (it != test_map.end() ? (it->second).status == test_cfg_info::disabled : true); };
     bool is_enabled(const char *name) { return !is_disabled(name); };


### PR DESCRIPTION
These new commandline options allows user enable/disable some tests by specifying a string with CPU features.

For example:

Let's have a subset of tests that require `avx512f` to run and another subset of tests that require `avx2` to run. We may have other kinds of tests which we don't want to run to shorten the runtime of OpenDCDiag.

We'd like to run one experiment that will run only `avx512f` and another one which will use `avx2` tests and last but not least both subsets during the same run.

The command line would look like this:

```
opendcdiag --enable-by-feature avx512f
opendcdiag --enable-by-feature avx2
opendcdiag --enable-by-feature avx512f,avx2
```

If we want to exclude some tests by feature we just simply need to use `--disable-by-feature` option.

If a feature that isn't supported by device uder test, the tests will skip. And the user will see a log skip message about not meeting test required features. The `enable-by-feature` and `disable-by-feature` options can also be combined with other commandline options. Especially with `--enable`, `--disable`, `--beta`, `-T` and `-t` and others.