### PR TITLE
FW: Remove triage implementation

### DIFF
--- a/bats/sanity-check/10-yaml-validate.bats
+++ b/bats/sanity-check/10-yaml-validate.bats
@@ -15,7 +15,7 @@ load ../testenv
 
 @test "Verify that the python yaml module can import failure output" {
     for test in selftest_failinit selftest_fail selftest_freeze selftest_sigill; do
-        run $SANDSTONE --no-triage --retest-on-failure=1 --on-crash=kill --on-hang=kill --timeout=2s --selftest -o output-${test}.yaml -Y2 -e $test
+        run $SANDSTONE --retest-on-failure=1 --on-crash=kill --on-hang=kill --timeout=2s --selftest -o output-${test}.yaml -Y2 -e $test
         if [[ "$status" = 0 ]]; then
             printf "%s: status is 0\n" $test
             exit 1

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -6,7 +6,7 @@ load ../testenv
 
 sandstone_selftest() {
     VALIDATION=dump
-    run_sandstone_yaml -n$MAX_PROC --disable=mce_check --no-triage --selftests --timeout=20s --retest-on-failure=0 -Y2 "$@"
+    run_sandstone_yaml -n$MAX_PROC --disable=mce_check --selftests --timeout=20s --retest-on-failure=0 -Y2 "$@"
 }
 
 extract_from_yaml() {
@@ -200,7 +200,7 @@ tap_negative_check() {
     # not all tests
     for test in selftest_failinit selftest_fail; do
         local notok
-        run $SANDSTONE --output-format=tap --no-triage --selftests --retest-on-failure=4 --on-crash=kill -e $test -o /dev/null -v
+        run $SANDSTONE --output-format=tap --selftests --retest-on-failure=4 --on-crash=kill -e $test -o /dev/null -v
         [[ $status -eq 1 ]]
         sed 's/\r$//' <<<"$output" | {
             tap_negative_check "$test" ''
@@ -221,7 +221,7 @@ tap_negative_check() {
     fi
     ulimit -Sc 0                # disable core dumps
     for test in ${crashtests[@]}; do
-        run $SANDSTONE --output-format=tap --no-triage --selftests --retest-on-failure=0 --on-crash=kill -e $test -o /dev/null -v
+        run $SANDSTONE --output-format=tap --selftests --retest-on-failure=0 --on-crash=kill -e $test -o /dev/null -v
         [[ $status -eq 1 ]]
         sed 's/\r$//; /^wine: Unhandled/d' <<<"$output" | \
             tap_negative_check "$test" ' (Killed|Core Dumped):.*'
@@ -229,7 +229,7 @@ tap_negative_check() {
 }
 
 @test "TAP output OS error" {
-    run $SANDSTONE --output-format=tap --no-triage --selftests --retest-on-failure=0 --on-crash=kill -e selftest_oserror -o /dev/null -v
+    run $SANDSTONE --output-format=tap --selftests --retest-on-failure=0 --on-crash=kill -e selftest_oserror -o /dev/null -v
     [[ $status -eq 2 ]]
     sed 's/\r$//' <<<"$output" | \
         tap_negative_check selftest_oserror ' Operating system error:.*' "exit: invalid"
@@ -1791,7 +1791,7 @@ selftest_cpuset_negated() {
     # Don't use sandstone_selftest to avoid -n$MAX_PROC
     VALIDATION=dump
     declare -A yamldump
-    run_sandstone_yaml --disable=mce_check --no-triage --selftests --timeout=20s --retest-on-failure=0 -e selftest_logs_getcpu
+    run_sandstone_yaml --disable=mce_check --selftests --timeout=20s --retest-on-failure=0 -e selftest_logs_getcpu
 
     # Did we get anything?
     if [[ ${yamldump[/tests/0/result]} = skip ]]; then

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1624,37 +1624,6 @@ crash_context_socket1_common() {
     test_yaml_regexp "/tests/0/result-details/reason" "Operating system error: configuration error"
 }
 
-@test "triage" {
-    if ! $is_debug; then
-        skip "Test only works with Debug builds (to mock the topology)"
-    fi
-    if (( MAX_PROC < 4 )); then
-        skip "Need at least 4 logical processors to run this test"
-    fi
-    declare -A yamldump
-    export SANDSTONE_MOCK_TOPOLOGY='0 1 2 3'
-
-    # can't use sandstone_selftest because of --no-triage
-    VALIDATION=dump
-    run_sandstone_yaml -n$MAX_PROC --disable=mce_check --selftests --timeout=20s --retest-on-failure=0 -Y -e selftest_fail_socket1 --triage
-
-    # confirm the topology took effect
-    for ((i = 0; i < 4; ++i)); do
-        test_yaml_numeric "/cpu-info/$i/logical" "value == $i"
-        test_yaml_numeric "/cpu-info/$i/package" "value == $i"
-        test_yaml_numeric "/cpu-info/$i/core" 'value == 0'
-        test_yaml_numeric "/cpu-info/$i/thread" 'value == 0'
-    done
-
-    # now confirm it exited properly
-    [[ "$status" -eq 1 ]]
-    test_yaml_regexp "/exit" fail
-
-    # and test it did triage properly
-    test_yaml_numeric "/triage-results@len" 'value == 1'
-    test_yaml_numeric "/triage-results/0" 'value == 1'
-}
-
 function selftest_cpuset() {
     local expected_logical=$1
     local expected_package=$2

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3156,7 +3156,6 @@ int main(int argc, char **argv)
     int total_skips = 0;
     int thread_count = -1;
     bool fatal_errors = false;
-    bool do_not_triage = true;
     const char *on_hang_arg = nullptr;
     const char *on_crash_arg = nullptr;
 
@@ -3328,12 +3327,6 @@ int main(int argc, char **argv)
             break;
         case no_slicing_option:
             max_cores_per_slice = -1;
-            break;
-        case triage_option:
-            do_not_triage = false;
-            break;
-        case no_triage_option:
-            do_not_triage = true;
             break;
         case on_crash_option:
             on_crash_arg = optarg;
@@ -3544,8 +3537,10 @@ int main(int argc, char **argv)
         case mem_sample_time_option:
         case mem_samples_per_log_option:
         case no_mem_sampling_option:
+        case no_triage_option:
         case schedule_by_option:
         case shortened_runtime_option:
+        case triage_option:
         case weighted_testrun_option:
             warn_deprecated_opt(long_options[coptind].name);
             break;
@@ -3601,7 +3596,6 @@ int main(int argc, char **argv)
 
         sApp->delay_between_tests = 50ms;
         sApp->thermal_throttle_temp = INT_MIN;
-        do_not_triage = SandstoneConfig::NoTriage;
         fatal_errors = true;
         builtin_test_list_name = "auto";
 


### PR DESCRIPTION
Remove the triage implementation. Deprecate `--triage` and `--no-triage` options. Clean up tests.

I think at this point it might be safe to do so.