### PR TITLE
FW/Tests: Allow test lists to specify different times for each test

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -957,7 +957,7 @@ test_list_file() {
 }
 
 @test "--test-list-file with duration" {
-    test_list_file selftest_pass:default selftest_timedpass:50
+    test_list_file selftest_pass:default selftest_timedpass:250 selftest_timedpass:10
 }
 
 @test "--test-list-file with comments and empty lines" {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3696,10 +3696,10 @@ int main(int argc, char **argv)
         sApp->mce_counts_start = sApp->get_mce_interrupt_counts();
 
         if (sApp->current_fork_mode() == SandstoneApplication::exec_each_test) {
-            test_set->disable(mce_test.id);
+            test_set->disable(&mce_test);
         } else if (sApp->mce_counts_start.empty()) {
             logging_printf(LOG_LEVEL_QUIET, "# WARNING: Cannot detect MCE events - you may be running in a VM - MCE checking disabled\n");
-            test_set->disable(mce_test.id);
+            test_set->disable(&mce_test);
         }
 
         sApp->mce_count_last = std::accumulate(sApp->mce_counts_start.begin(), sApp->mce_counts_start.end(), uint64_t(0));

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3691,7 +3691,7 @@ int main(int argc, char **argv)
     if (sApp->shmem->verbosity == -1)
         sApp->shmem->verbosity = (sApp->requested_quality < SandstoneApplication::DefaultQualityLevel) ? 1 : 0;
 
-    if (InterruptMonitor::InterruptMonitorWorks && test_set->is_enabled(mce_test.id)) {
+    if (InterruptMonitor::InterruptMonitorWorks && test_set->is_enabled(&mce_test)) {
         sApp->last_thermal_event_count = sApp->count_thermal_events();
         sApp->mce_counts_start = sApp->get_mce_interrupt_counts();
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2440,11 +2440,11 @@ static auto collate_test_groups()
         std::vector<const struct test *> entries;
     };
     std::map<std::string_view, Group> groups;
-    for (struct test *t : *test_set) {
-        for (auto ptr = t->groups; ptr && *ptr; ++ptr) {
+    for (const auto &ti : *test_set) {
+        for (auto ptr = ti.test->groups; ptr && *ptr; ++ptr) {
             Group &g = groups[(*ptr)->id];
             g.definition = *ptr;
-            g.entries.push_back(t);
+            g.entries.push_back(ti.test);
         }
     }
 
@@ -2460,8 +2460,8 @@ static void list_tests(int opt)
     auto groups = collate_test_groups();
     int i = 0;
 
-    for (auto it = test_set->begin(); it != test_set->end(); ++it) {
-        struct test *test = *it;
+    for (const auto &ti : *test_set) {
+        struct test *test = ti.test;
         if (test->quality_level >= sApp->requested_quality) {
             if (include_tests) {
                 if (include_descriptions) {
@@ -2537,14 +2537,14 @@ static bool should_start_next_iteration(void)
     return true;
 }
 
-static SandstoneTestSet::TestSet::iterator
-get_next_test(SandstoneTestSet::TestSet::iterator next_test)
+static SandstoneTestSet::EnabledTestList::iterator
+get_next_test(SandstoneTestSet::EnabledTestList::iterator next_test)
 {
     if (sApp->shmem->use_strict_runtime && wallclock_deadline_has_expired(sApp->endtime))
         return test_set->end();
 
     ++next_test;
-    while (next_test != test_set->end() && (*next_test)->quality_level < sApp->requested_quality)
+    while (next_test != test_set->end() && next_test->test->quality_level < sApp->requested_quality)
         ++next_test;
     if (next_test == test_set->end()) {
         if (should_start_next_iteration()) {
@@ -2557,17 +2557,17 @@ get_next_test(SandstoneTestSet::TestSet::iterator next_test)
         }
     }
 
-    assert((*next_test)->id);
-    assert((*next_test)->description);
-    assert(strlen((*next_test)->id));
+    assert(next_test->test->id);
+    assert(next_test->test->description);
+    assert(strlen(next_test->test->id));
     return next_test;
 }
 
-static SandstoneTestSet::TestSet::iterator get_first_test()
+static SandstoneTestSet::EnabledTestList::iterator get_first_test()
 {
     logging_print_iteration_start();
     auto it = test_set->begin();
-    while (it != test_set->end() && (*it)->quality_level < sApp->requested_quality)
+    while (it != test_set->end() && it->test->quality_level < sApp->requested_quality)
         ++it;
     return it;
 }
@@ -3734,7 +3734,8 @@ int main(int argc, char **argv)
 
     initialize_smi_counts();  // used by smi_count test
 
-    for (auto test = get_first_test(); test != test_set->end(); test = get_next_test(test)) {
+    for (auto it = get_first_test(); it != test_set->end(); it = get_next_test(it)) {
+        struct test *const *test = &it->test;
         if (lastTestResult != TestResult::Skipped) {
             if (sApp->service_background_scan) {
                 if (!background_scan_wait()) {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -634,8 +634,10 @@ static ShortDuration test_duration()
     return SandstoneApplication::DefaultTestDuration;
 }
 
-static ShortDuration test_duration(const struct test *test)
+static ShortDuration test_duration(const test_cfg_info &test_cfg)
 {
+    const struct test *test = test_cfg.test;
+
     /* Start with the test prefered default time */
     ShortDuration target_duration(test->desired_duration);
     ShortDuration min_duration(test->minimum_duration);
@@ -644,6 +646,10 @@ static ShortDuration test_duration(const struct test *test)
     /* apply the global (-t) override */
     if (sApp->test_time.count())
         target_duration = sApp->test_time;
+
+    /* apply the per-test time from the test list (overrides global -t) */
+    if (test_cfg.duration.count())
+        target_duration = test_cfg.duration;
 
     /* fallback to the default if test preference is zero */
     if (target_duration <= 0s)
@@ -2294,8 +2300,10 @@ static void analyze_test_failures(const struct test *test, int fail_count, int a
     }
 }
 
-TestResult run_one_test(const struct test *test, SandstoneApplication::PerCpuFailures &per_cpu_fails)
+static TestResult
+run_one_test(const test_cfg_info &test_cfg, SandstoneApplication::PerCpuFailures &per_cpu_fails)
 {
+    const struct test *test = test_cfg.test;
     TestResult state = TestResult::Skipped;
     int fail_count = 0;
     std::unique_ptr<char[]> random_allocation;
@@ -2321,7 +2329,7 @@ TestResult run_one_test(const struct test *test, SandstoneApplication::PerCpuFai
         });
     };
 
-    sApp->current_test_duration = test_duration(test);
+    sApp->current_test_duration = test_duration(test_cfg);
     first_iteration_target = MonotonicTimePoint::clock::now() + 10ms;
 
     if (sApp->max_test_loop_count) {
@@ -3735,7 +3743,6 @@ int main(int argc, char **argv)
     initialize_smi_counts();  // used by smi_count test
 
     for (auto it = get_first_test(); it != test_set->end(); it = get_next_test(it)) {
-        struct test *const *test = &it->test;
         if (lastTestResult != TestResult::Skipped) {
             if (sApp->service_background_scan) {
                 if (!background_scan_wait()) {
@@ -3750,7 +3757,7 @@ int main(int argc, char **argv)
             }
         }
 
-        lastTestResult = run_one_test(*test, per_cpu_failures);
+        lastTestResult = run_one_test(*it, per_cpu_failures);
 
         total_tests_run++;
         if (lastTestResult == TestResult::Failed) {

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -109,14 +109,21 @@ struct test_cfg_info SandstoneTestSet::disable(struct test *t) {
     return ti;
 }
 
-std::vector<struct test_cfg_info> SandstoneTestSet::disable(const char *name) {
-    std::vector<struct test_cfg_info> res;
+/// Returns the number of tests that were removed from the test list, which may
+/// be zero if the test is valid but did not match. If it matched nothing, this
+/// function returns -1.
+int SandstoneTestSet::disable(const char *name)
+{
     std::vector tests = lookup(name);
+    if (tests.size() == 0)
+        return -1;
+
+    int res = 0;
     for (auto t : tests) {
         struct test_cfg_info ti = disable(t);
         for (auto it = test_set.begin(); it != test_set.end(); ) {
             if (*it == t) {
-                res.push_back(ti);
+                ++res;
                 test_set.erase(it);
             } else {
                 ++it;

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -228,16 +228,16 @@ std::vector<struct test_cfg_info> SandstoneTestSet::add_test_list(const char *fn
     std::ifstream list_file(fname, std::ios_base::in);
     std::vector<struct test_cfg_info> entries = load_test_list(list_file, this, cfg.ignore_unknown_tests, errors);
     if (!errors.empty()) return {};
-    for (auto e : entries) {
-        if (e.test->desired_duration != -1 /* never reset a -1 specified by the test definition. */
-                && !e.attribute.empty()
+    for (auto &e : entries) {
+        if (!e.attribute.empty()
                 && strcasecmp(e.attribute.c_str(), "default")) {
-            e.test->desired_duration = string_to_millisecs(e.attribute).count();
+            e.duration = string_to_millisecs(e.attribute);
         }
     }
     if (!errors.size()) {
+        test_set.reserve(test_set.capacity() + entries.size());
         for (auto e : entries) {
-            test_set.push_back(e.test);
+            test_set.push_back(e);
         }
     }
     return entries;

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -180,7 +180,10 @@ static line_type parse_test_list_line(std::string line, SandstoneTestSet *test_s
     if (!set.size()) return LT_TEST_NOT_FOUND;
     if (set.size() != 1) return LT_SYNTAX_ERROR; /* Artificially do not allow specifying wildcards or groups in the list file. */
     ti.test = set[0];
-    if (tokens.size() == 2) ti.attribute = tokens[1];
+    if (tokens.size() == 2) {
+        if (tokens[1].size() && strcasecmp(tokens[1].c_str(), "default") != 0)
+            ti.duration = string_to_millisecs(tokens[1]);
+    }
     return LT_VALID_TEST;
 }
 
@@ -228,13 +231,9 @@ std::vector<struct test_cfg_info> SandstoneTestSet::add_test_list(const char *fn
     std::ifstream list_file(fname, std::ios_base::in);
     std::vector<struct test_cfg_info> entries = load_test_list(list_file, this, cfg.ignore_unknown_tests, errors);
     if (!errors.empty()) return {};
-    for (auto &e : entries) {
-        if (!e.attribute.empty()
-                && strcasecmp(e.attribute.c_str(), "default")) {
-            e.duration = string_to_millisecs(e.attribute);
-        }
-    }
-    if (!errors.size()) {
+    if (test_set.empty()) {
+        test_set = entries;
+    } else {
         test_set.reserve(test_set.capacity() + entries.size());
         for (auto e : entries) {
             test_set.push_back(e);

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -89,7 +89,7 @@ public:
 
     TestSet::iterator end() noexcept { return test_set.end(); }
 
-    std::vector<struct test_cfg_info> disable(const char *name);
+    int disable(const char *name);
     struct test_cfg_info disable(struct test *t);
 
     std::vector<struct test_cfg_info> enable(const char *name);

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -45,7 +45,6 @@ struct test_cfg_info {
         not_found = -1,
     };
     struct test *test = nullptr;
-    std::string attribute;
     test_status status = not_found;
     ShortDuration duration = ShortDuration::zero();
 

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -94,9 +94,14 @@ public:
 
     std::vector<struct test_cfg_info> enable(const char *name);
     struct test_cfg_info enable(struct test *t);
+    struct test_cfg_info enable(test_cfg_info t);
 
-    bool is_disabled(const char *name) { auto it = test_map.find(name); return (it != test_map.end() ? (it->second).status == test_cfg_info::disabled : true); };
-    bool is_enabled(const char *name) { return !is_disabled(name); };
+    bool is_enabled(struct test *test) const
+    {
+        return std::any_of(test_set.begin(), test_set.end(), [&](const struct test *t) {
+            return t == test;
+        });
+    }
 
     std::vector<struct test_cfg_info> add_test_list(const char *name, std::vector<std::string> &errors);
 

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 
 #include "sandstone.h"
+#include "sandstone_chrono.h"
 #include "sandstone_p.h"
 #include <sandstone_test_lists.h>
 
@@ -46,6 +47,7 @@ struct test_cfg_info {
     struct test *test = nullptr;
     std::string attribute;
     test_status status = not_found;
+    ShortDuration duration = ShortDuration::zero();
 
     /* implicit */ test_cfg_info(struct test *test = nullptr) : test(test) {}
 };


### PR DESCRIPTION
This refactors `SandstoneTestSet` to keep extra options in each test that is added to the roster. The only one for the moment is the requested duration, but this allows expanding later as needed. This restores the behaviour prior to e89cd594fcda062209c3fccf7fa7a34bbe62b58f.

Fixes #533.
