### PR TITLE
FW: ensure we handle tests that log_xxx() but EXIT_SUCCESS in their init()/run()/cleanup()

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1104,8 +1104,38 @@ test_list_file_ignores_beta() {
     i=$((0 + yamldump[/tests/0/threads@len]))
     [[ "$i" -eq 1 ]]
     test_yaml_regexp "/tests/0/threads/0/thread" 'main'
-    test_yaml_regexp "/tests/0/threads/0/messages/1/level" info
-    test_yaml_regexp "/tests/0/threads/0/messages/1/text" 'I> cleanup returns FAIL'
+    test_yaml_regexp "/tests/0/threads/0/messages/0/level" info
+    test_yaml_regexp "/tests/0/threads/0/messages/0/text" 'I> cleanup returns FAIL'
+}
+
+@test "selftest_logerror_cleanup" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_logerror_cleanup
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+    test_yaml_regexp "/tests/0/threads/0/thread" 'main'
+    test_yaml_regexp "/tests/0/threads/0/messages/0/level" error
+    test_yaml_regexp "/tests/0/threads/0/messages/0/text" 'E> cleanup failure'
+}
+
+@test "selftest_fail_cleanup_after_skip" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_fail_cleanup_after_skip
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+    test_yaml_regexp "/tests/0/threads/0/thread" 'main'
+    test_yaml_regexp "/tests/0/threads/0/messages/0/level" info
+    test_yaml_regexp "/tests/0/threads/0/messages/0/text" 'I> cleanup returns FAIL'
+}
+
+@test "selftest_logerror_cleanup_after_skip" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_logerror_cleanup_after_skip
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+    test_yaml_regexp "/tests/0/threads/0/thread" 'main'
+    test_yaml_regexp "/tests/0/threads/0/messages/0/level" error
+    test_yaml_regexp "/tests/0/threads/0/messages/0/text" 'E> cleanup failure'
 }
 
 fail_common() {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -927,10 +927,10 @@ static uintptr_t thread_runner(int thread_number)
         // let SIGQUIT handler know we're done
         ThreadState new_state = thread_failed;
         if (!this_thread->has_failed()) {
-            if (ret == EXIT_SUCCESS)
-                new_state = thread_succeeded;
-            else if (ret < EXIT_SUCCESS)
+            if (this_thread->has_skipped() || ret < EXIT_SUCCESS)
                 new_state = thread_skipped;
+            else if (ret == EXIT_SUCCESS)
+                new_state = thread_succeeded;
         }
         this_thread->thread_state.store(new_state, std::memory_order_relaxed);
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1702,22 +1702,17 @@ static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
 
         run_threads(test);
 
-        if (sApp->shmem->use_strict_runtime && wallclock_deadline_has_expired(sApp->endtime)){
-            // skip cleanup on the last test when using strict runtime
-        } else {
-            if (test->test_cleanup) {
-                ret = test->test_cleanup(test);
-                if (state == TestResult::Passed) {
-                    if (ret == EXIT_SKIP) {
-                        log_skip(RuntimeSkipCategory, "SKIP requested in cleanup");
-                        state = TestResult::Skipped;
-                    } else if (ret < EXIT_SUCCESS) {
-                        log_skip(RuntimeSkipCategory, "Unexpected OS error in cleanup: %s", strerror(-ret));
-                        state = TestResult::Skipped;
-                    } else if (ret > EXIT_SUCCESS) {
-                        state = TestResult::Failed;
-                    }
-                }
+        if (test->test_cleanup) {
+            ret = test->test_cleanup(test);
+            PerThreadData::Main *thr = sApp->main_thread_data();
+            if (ret > EXIT_SUCCESS || thr->has_failed()) {
+                state = TestResult::Failed;
+            } else if (ret == EXIT_SKIP || thr->has_skipped()) {
+                log_skip(RuntimeSkipCategory, "SKIP requested in cleanup");
+                state = TestResult::Skipped;
+            } else if (ret < EXIT_SUCCESS) {
+                log_skip(RuntimeSkipCategory, "Unexpected OS error in cleanup: %s", strerror(-ret));
+                state = TestResult::Skipped;
             }
         }
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -196,13 +196,17 @@ struct Common
     MonotonicTimePoint fail_time;
     bool has_failed() const
     {
-        return fail_time < MonotonicTimePoint::max();
+        return fail_time > MonotonicTimePoint{};
+    }
+    bool has_skipped() const
+    {
+        return fail_time < MonotonicTimePoint{};
     }
 
     void init()
     {
         thread_state.store(thread_not_started, std::memory_order_relaxed);
-        fail_time = MonotonicTimePoint::max();
+        fail_time = MonotonicTimePoint{};
         messages_logged.store(0, std::memory_order_relaxed);
         data_bytes_logged.store(0, std::memory_order_relaxed);
     }

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -333,7 +333,7 @@ template <int PackageId> static int selftest_log_skip_socket_run(struct test *te
 static int selftest_log_skip_run_all_threads(struct test *test, int cpu)
 {
     log_skip(SelftestSkipCategory, "Skipping on all threads");
-    return EXIT_SKIP;
+    return EXIT_SUCCESS;
 }
 
 static int selftest_log_skip_run_even_threads(struct test *test, int cpu)

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -282,7 +282,7 @@ static int selftest_log_skip_init(struct test *test)
 static int selftest_skipmsg_success_cleanup(struct test *test)
 {
     log_skip(SelftestSkipCategory, "SUCCESS after skipmsg from cleanup");
-    return EXIT_SKIP;
+    return EXIT_SUCCESS;
 }
 
 static int selftest_skipmsg_skip_cleanup(struct test *test)
@@ -314,6 +314,12 @@ static int selftest_fail_cleanup(struct test *test)
 {
     log_info("cleanup returns FAIL");
     return EXIT_FAILURE;
+}
+
+static int selftest_logerror_cleanup(struct test *test)
+{
+    log_error("cleanup failure");
+    return EXIT_SUCCESS;
 }
 
 template <int PackageId> static int selftest_log_skip_socket_init(struct test *test)
@@ -1599,9 +1605,35 @@ static struct test selftests_array[] = {
     .id = "selftest_fail_cleanup",
     .description = "Fails in the cleanup function",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
-    .test_init = selftest_logs_random_init,
     .test_run = selftest_pass_run,
     .test_cleanup = selftest_fail_cleanup,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_logerror_cleanup",
+    .description = "Fails in the cleanup function with log_error()",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_run = selftest_pass_run,
+    .test_cleanup = selftest_logerror_cleanup,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_fail_cleanup_after_skip",
+    .description = "Fails in the cleanup function after having skipped",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_run = selftest_log_skip_run_all_threads,
+    .test_cleanup = selftest_fail_cleanup,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_logerror_cleanup_after_skip",
+    .description = "Fails in the cleanup function with log_error() after having skipped",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_run = selftest_log_skip_run_all_threads,
+    .test_cleanup = selftest_logerror_cleanup,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -276,12 +276,6 @@ static int selftest_skip_run(struct test *test, int cpu)
 static int selftest_log_skip_init(struct test *test)
 {
     log_skip(SelftestSkipCategory, "This is a skip in init");
-    return EXIT_SKIP;
-}
-
-static int selftest_logerror_init(struct test *test)
-{
-    log_error("Error logged in init, test is not expected to run any threads");
     return EXIT_SUCCESS;
 }
 
@@ -494,6 +488,40 @@ static int selftest_failinit_run(struct test *test, int cpu)
 {
     log_error("We should not reach here");
     abort();
+    return EXIT_SUCCESS;
+}
+
+static int selftest_failinit_and_logskip_init(struct test *test)
+{
+    selftest_randomprint_init(test);
+    log_skip(SelftestSkipCategory, "This is a skip in init");
+    return EXIT_FAILURE;
+}
+
+static int selftest_logerror_init(struct test *test)
+{
+    log_error("Error logged in init, test is not expected to run any threads");
+    return EXIT_SUCCESS;
+}
+
+static int selftest_logerror_and_logskip_init(struct test *test)
+{
+    log_error("This is an error message from init");
+    log_skip(SelftestSkipCategory, "This is a skip in init");
+    return EXIT_SUCCESS;
+}
+
+static int selftest_logerror_and_logskip_exitskip_init(struct test *test)
+{
+    log_error("This is an error message from init");
+    log_skip(SelftestSkipCategory, "This is a skip in init");
+    return EXIT_SKIP;
+}
+
+static int selftest_logskip_and_logerror_init(struct test *test)
+{
+    log_skip(SelftestSkipCategory, "This is a skip in init");
+    log_error("This is an error message from init");
     return EXIT_SUCCESS;
 }
 
@@ -1192,7 +1220,7 @@ static struct test selftests_array[] = {
     .description = "Skips by returning EXIT_SKIP from the init function",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_init = selftest_skip_init,
-    .test_run = selftest_skip_run,
+    .test_run = selftest_noreturn_run,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },
@@ -1201,7 +1229,7 @@ static struct test selftests_array[] = {
     .description = "Skips using log_skip() in the init function",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_init = selftest_log_skip_init,
-    .test_run = selftest_skip_run,
+    .test_run = selftest_noreturn_run,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },
@@ -1505,6 +1533,24 @@ static struct test selftests_array[] = {
     /* Negative tests */
 
 {
+    .id = "selftest_failinit",
+    .description = "Fails in the init function",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_failinit_init,
+    .test_run = selftest_failinit_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_failinit_and_logskip",
+    .description = "Fails by returning EXIT_FAILURE after log_skip() in init",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_failinit_and_logskip_init,
+    .test_run = selftest_noreturn_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
     .id = "selftest_logerror_init",
     .description = "Fails on error logged in init",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
@@ -1514,20 +1560,38 @@ static struct test selftests_array[] = {
     .quality_level = TEST_QUALITY_PROD,
 },
 {
+    .id = "selftest_logerror_and_logskip",
+    .description = "Fails by with log_error() and log_skip() in init",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logerror_and_logskip_init,
+    .test_run = selftest_noreturn_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_logerror_and_logskip_exitskip",
+    .description = "Fails by with log_error(), log_skip(), return EXIT_SKIP in init",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logerror_and_logskip_exitskip_init,
+    .test_run = selftest_noreturn_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_logskip_and_logerror",
+    .description = "Fails by with log_skip() and log_error() in init",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_init = selftest_logskip_and_logerror_init,
+    .test_run = selftest_noreturn_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
     .id = "selftest_fail",
     .description = "Fails by way of returning",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
     .test_init = selftest_randomprint_init,
     .test_run = selftest_fail_run,
-    .desired_duration = -1,
-    .quality_level = TEST_QUALITY_PROD,
-},
-{
-    .id = "selftest_failinit",
-    .description = "Fails in the init function",
-    .groups = DECLARE_TEST_GROUPS(&group_negative),
-    .test_init = selftest_failinit_init,
-    .test_run = selftest_failinit_run,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },


### PR DESCRIPTION
For more complex tests, it's possible that some nested function sets the state but fails to notify the outer functions that they did. If the callback function returned with `EXIT_SUCCESS`, we may end up not noticing the state had changed. We already handled some cases, but not all of them:

| Function \ Stage | init | run | cleanup |
| --- | --- | --- | --- |
| `log_skip()` | ✘ | ✔* | ✘ |
| `log_error()` | ✔ | ✔ | ✘ |
| `report_fail_msg()` / `memcmp_or_fail()` | N/A | ✔ | N/A |

(*) Probably didn't work if running in no-output logging mode.

This PR fixes the issue by storing whether the test has skipped, which is done by using a negative `fail_time`. It also changes the non-fail case to store zero there to simplify the cleaning up of the shared memory area between tests.

Drive-by fix running the cleanup in the case of strict runtime. Some tests perform testing during clean up, so it's not optional.
