### PR TITLE
Unit Tests: fix build - missing #include

### DIFF
--- a/framework/unit-tests/sandstone_data_tests.cpp
+++ b/framework/unit-tests/sandstone_data_tests.cpp
@@ -7,6 +7,7 @@
 #include "sandstone_data.h"
 
 #include <string.h>
+#include <iomanip>
 
 static constexpr bool UseF16C = false
 #ifdef __F16C__


### PR DESCRIPTION
I don't know why it's suddenly started failing in the GitHub CI:
```
../framework/unit-tests/sandstone_data_tests.cpp:71:27: error: no member named 'setfill' in namespace 'std'
    s << std::hex << std::setfill('0') << std::setw(8) << u;
                     ~~~~~^
../framework/unit-tests/sandstone_data_tests.cpp:71:48: error: no member named 'setw' in namespace 'std'
    s << std::hex << std::setfill('0') << std::setw(8) << u;
                                          ~~~~~^
```