### PR TITLE
FW/Tests: rename {enable,disable} to {add,remove}

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3654,7 +3654,7 @@ int main(int argc, char **argv)
     /* Add all the tests we were told to enable. */
     if (enabled_tests.size()) {
         for (auto name : enabled_tests) {
-            auto tis = test_set->enable(name);
+            auto tis = test_set->add(name);
             if (!tis.size() && !test_set_config.ignore_unknown_tests) {
                 fprintf(stderr, "%s: Cannot find matching tests for '%s'\n", program_invocation_name, name);
                 exit(EX_USAGE);
@@ -3688,27 +3688,27 @@ int main(int argc, char **argv)
 
     /* Add mce_check as the last test to the set. It will be kept last by
      * SandstoneTestSet in case randomization is requested. */
-    test_set->enable(&mce_test);
+    test_set->add(&mce_test);
 
     /* Remove all the tests we were told to disable */
     if (disabled_tests.size()) {
         for (auto name : disabled_tests) {
-            test_set->disable(name);
+            test_set->remove(name);
         }
     }
 
     if (sApp->shmem->verbosity == -1)
         sApp->shmem->verbosity = (sApp->requested_quality < SandstoneApplication::DefaultQualityLevel) ? 1 : 0;
 
-    if (InterruptMonitor::InterruptMonitorWorks && test_set->is_enabled(&mce_test)) {
+    if (InterruptMonitor::InterruptMonitorWorks && test_set->contains(&mce_test)) {
         sApp->last_thermal_event_count = sApp->count_thermal_events();
         sApp->mce_counts_start = sApp->get_mce_interrupt_counts();
 
         if (sApp->current_fork_mode() == SandstoneApplication::exec_each_test) {
-            test_set->disable(&mce_test);
+            test_set->remove(&mce_test);
         } else if (sApp->mce_counts_start.empty()) {
             logging_printf(LOG_LEVEL_QUIET, "# WARNING: Cannot detect MCE events - you may be running in a VM - MCE checking disabled\n");
-            test_set->disable(&mce_test);
+            test_set->remove(&mce_test);
         }
 
         sApp->mce_count_last = std::accumulate(sApp->mce_counts_start.begin(), sApp->mce_counts_start.end(), uint64_t(0));

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -83,7 +83,7 @@ SandstoneTestSet::SandstoneTestSet(struct test_set_cfg cfg, unsigned int flags) 
     }
 };
 
-struct test_cfg_info SandstoneTestSet::enable(test_cfg_info t)
+struct test_cfg_info SandstoneTestSet::add(test_cfg_info t)
 {
     struct test_cfg_info &ti = test_set.emplace_back(t);
     // ensure it's enabled
@@ -91,11 +91,11 @@ struct test_cfg_info SandstoneTestSet::enable(test_cfg_info t)
     return ti;
 }
 
-std::vector<struct test_cfg_info> SandstoneTestSet::enable(const char *name) {
+std::vector<struct test_cfg_info> SandstoneTestSet::add(const char *name) {
     std::vector<struct test_cfg_info> res;
     std::vector<struct test *> tests = lookup(name);
     for (auto t : tests) {
-        struct test_cfg_info ti = enable(t);
+        struct test_cfg_info ti = add(t);
         res.push_back(ti);
     }
     return res;
@@ -103,7 +103,7 @@ std::vector<struct test_cfg_info> SandstoneTestSet::enable(const char *name) {
 
 /// Returns the number of tests that were removed from the test list, which may
 /// be zero.
-int SandstoneTestSet::disable(const struct test *test)
+int SandstoneTestSet::remove(const struct test *test)
 {
     auto it = std::remove_if(test_set.begin(), test_set.end(), [&](const test_cfg_info &ti) {
         return ti.test == test;
@@ -116,7 +116,7 @@ int SandstoneTestSet::disable(const struct test *test)
 /// Returns the number of tests that were removed from the test list, which may
 /// be zero if the test is valid but did not match. If it matched nothing, this
 /// function returns -1.
-int SandstoneTestSet::disable(const char *name)
+int SandstoneTestSet::remove(const char *name)
 {
     std::vector tests = lookup(name);
     if (tests.size() == 0)
@@ -124,7 +124,7 @@ int SandstoneTestSet::disable(const char *name)
 
     int res = 0;
     for (auto t : tests) {
-        res += disable(t);
+        res += remove(t);
     }
     return res;
 }
@@ -252,7 +252,7 @@ std::vector<struct test_cfg_info> SandstoneTestSet::add_builtin_test_list(const 
         return res;
     }
     for (auto t : *builtin.tests) {
-        res.push_back(enable(t));
+        res.push_back(add(t));
         test_set.push_back(t);
     }
     return res;

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -92,13 +92,13 @@ public:
 
     EnabledTestList::iterator end() noexcept { return test_set.end(); }
 
-    int disable(const char *name);
-    int disable(const struct test *t);
+    int remove(const char *name);
+    int remove(const struct test *t);
 
-    std::vector<struct test_cfg_info> enable(const char *name);
-    struct test_cfg_info enable(test_cfg_info t);
+    std::vector<struct test_cfg_info> add(const char *name);
+    struct test_cfg_info add(test_cfg_info t);
 
-    bool is_enabled(struct test *test) const
+    bool contains(struct test *test) const
     {
         return std::any_of(test_set.begin(), test_set.end(), [&](const test_cfg_info &ti) {
             return ti.test == test;


### PR DESCRIPTION
Even though they apply to the command-line options --enable and --disable, this now matches better what the internal behaviour is.