### PR TITLE
CI: Harden GitHub workflow permissions for pr.yaml

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main, socket-separation ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Repeat of #518 but for the other workload.