### PR TITLE
FW: Restart the test iteration properly.

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2546,6 +2546,16 @@ static bool should_start_next_iteration(void)
     return true;
 }
 
+static SandstoneTestSet::EnabledTestList::iterator get_first_test()
+{
+    logging_print_iteration_start();
+    auto it = test_set->begin();
+    while (it != test_set->end() && it->test->quality_level < sApp->requested_quality)
+        ++it;
+    return it;
+}
+
+
 static SandstoneTestSet::EnabledTestList::iterator
 get_next_test(SandstoneTestSet::EnabledTestList::iterator next_test)
 {
@@ -2557,10 +2567,7 @@ get_next_test(SandstoneTestSet::EnabledTestList::iterator next_test)
         ++next_test;
     if (next_test == test_set->end()) {
         if (should_start_next_iteration()) {
-            /* whenever we're restarting, print the header for the next
-             * iteration. */
-            logging_print_iteration_start();
-            next_test = test_set->begin();
+            return get_first_test();
         } else {
             return test_set->end();
         }
@@ -2570,15 +2577,6 @@ get_next_test(SandstoneTestSet::EnabledTestList::iterator next_test)
     assert(next_test->test->description);
     assert(strlen(next_test->test->id));
     return next_test;
-}
-
-static SandstoneTestSet::EnabledTestList::iterator get_first_test()
-{
-    logging_print_iteration_start();
-    auto it = test_set->begin();
-    while (it != test_set->end() && it->test->quality_level < sApp->requested_quality)
-        ++it;
-    return it;
 }
 
 static bool wait_delay_between_tests()


### PR DESCRIPTION
Whenever we need to start an iteration, use proper entry point which does not skip quality checks and everything else that may need to be done.

If test 'mytest' was of beta quality. Before:
```
$ ./opendcdiag -e mytest --output-format tap -Tforever # force multiple iterations
ok 1 mce_check
ok 2 mytest
ok 3 mce_check
ok 4 mytest
ok 5 mce_check
<...>
```
After:
```
$ ./opendcdiag -e mytest --output-format tap -Tforever # force multiple iterations ok 1 mce_check
ok 2 mce_check
ok 3 mce_check
<... mytest is never ran, as it should be ..>
```