### PR TITLE
FW/child_debug: allow debugging when a kernel LSM may be active

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -1015,6 +1015,12 @@ void debug_init_child()
         // we're in the child side of an execve()
         xsave_size = get_xsave_size();
     }
+
+#ifdef __linux__
+    // Allow the parent process to debug us (this also grants permission to a
+    // process the parent may launch).
+    (void) prctl(PR_SET_PTRACER, getppid());
+#endif
 }
 
 void debug_crashed_child()


### PR DESCRIPTION
The YAMA LSM[1] defaults[2] to denying a ptrace() to a process that isn't a child. That is the regular debugging behaviour: gdb launches the child, so it is allowed to trace its own children.

In OpenDCDiag's case, the parent process launches the debugger, so the debugger is a sibling, not a parent. That results in gdb getting an EPERM when we attempt to launch it for `--on-crash=backtrace` or `--on-hang=backtrace`. The child must grant explicit permission instead to allow a sibling debugger process to trace it.

[1] https://www.kernel.org/doc/Documentation/security/Yama.txt
[2] https://codebrowser.dev/linux/linux/security/yama/yama_lsm.c.html#ptrace_scope