### PR TITLE
IFS: don't load the next image if we are retesting a failure

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -732,6 +732,12 @@ bool test_time_condition() noexcept
     return !wallclock_deadline_has_expired(sApp->shmem->current_test_endtime);
 }
 
+bool test_is_retry() noexcept
+{
+    // negative values indicate a retry
+    return sApp->current_iteration_count < 0;
+}
+
 // Creates a string containing all socket temperatures like: "P0:30oC P2:45oC"
 static string format_socket_temperature_string(const vector<int> & temps)
 {

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -503,6 +503,9 @@ extern void test_loop_end(void) noexcept;
 extern bool test_time_condition() noexcept;
 #define test_time_condition(test)       test_time_condition()
 
+/// Returns true if this is a retry.
+bool test_is_retry() noexcept __attribute__((pure));
+
 /// outputs msg to the logs, prefixing it with the string "Platform issue:"
 /// This function is usually used to log a warning when an error is detected
 /// in a test's test_init or test_run functions that is due to a platform issue

--- a/framework/sandstone_unittests_utils.cpp
+++ b/framework/sandstone_unittests_utils.cpp
@@ -13,3 +13,5 @@ struct cpu_info *cpu_info = nullptr;
 /* Define dummy number of dummy cpus */
 int num_cpus() { return UNITTESTS_NUM_CPUS; }
 
+bool test_is_retry() noexcept { return false; }
+

--- a/framework/sandstone_unittests_utils.h
+++ b/framework/sandstone_unittests_utils.h
@@ -9,12 +9,12 @@
 
 /* Define empty log_* macros not useful for unittests */
 #undef  log_warning
-#define log_warning
+#define log_warning(...)
 #undef  log_error
-#define log_error
+#define log_error(...)
 #undef  log_info
-#define log_info
+#define log_info(...)
 #undef  log_debug
-#define log_debug
+#define log_debug(...)
 #undef log_skip
-#define log_skip
+#define log_skip(...)


### PR DESCRIPTION
Because if we load the next image, then we aren't retesting the same thing. We'd be testing the next image.

Logging with only `log_debug` to avoid creating unnecessary noise in the log output. We already know it's a retest.