### PR TITLE
CI: Install full boost package

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
             elfutils \
             file \
             git \
-            libboost-dev \
+            libboost-all-dev \
             libeigen3-dev \
             libgtest-dev \
             libssl-dev \


### PR DESCRIPTION
Especially when we advise to do so in README

libboost-dev contains only headers, non-header-only packages are in libboost-all-dev