### PR TITLE
Add message when running beta tests without `--beta` option

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2160,7 +2160,11 @@ static TestResult run_one_test_once(const struct test *test)
         (void) missing;
 
         children.results.emplace_back(ChildExitStatus{ TestResult::Skipped });
-    } else {
+    } else if (test->quality_level >= 0 && test->quality_level < sApp->requested_quality) {
+        init_per_thread_data();
+        log_skip(TestResourceIssueSkipCategory, "Test %s is in BETA quality, try again using --beta option", test->id);
+        children.results.emplace_back(ChildExitStatus{ TestResult::Skipped });
+    } else if (test->quality_level >= sApp->requested_quality) {
         run_one_test_children(children, test);
     }
 
@@ -2556,7 +2560,7 @@ static SandstoneTestSet::EnabledTestList::iterator get_first_test()
 {
     logging_print_iteration_start();
     auto it = test_set->begin();
-    while (it != test_set->end() && it->test->quality_level < sApp->requested_quality)
+    while (it != test_set->end() && (it->test->quality_level < 0 && sApp->requested_quality >= 0))
         ++it;
     return it;
 }
@@ -2569,7 +2573,7 @@ get_next_test(SandstoneTestSet::EnabledTestList::iterator next_test)
         return test_set->end();
 
     ++next_test;
-    while (next_test != test_set->end() && next_test->test->quality_level < sApp->requested_quality)
+    while (next_test != test_set->end() && (next_test->test->quality_level < 0 && sApp->requested_quality >= 0))
         ++next_test;
     if (next_test == test_set->end()) {
         if (should_start_next_iteration()) {


### PR DESCRIPTION
This change removes the iteration condition for tests with quality lower that requested and add it before calling `run_one_test`. Also, a warning is logged for BETA tests.

Example:
For a test with `TEST_QUALITY_PROD`
```
$ ./builddir/opendcdiag -e smi_count
command-line: 'opendcdiag -e smi_count'
version: opendcdiag-7df166cfa4e4-dirty
exit: pass
```

For a test with `TEST_QUALITY_BETA`
```
$ ./builddir/opendcdiag -e simple_add
command-line: 'opendcdiag -e simple_add'
version: opendcdiag-7df166cfa4e4-dirty
Test simple_add is in BETA quality. Try again with --beta option.
exit: pass
```
