### PR TITLE
Reverting dependency on libboost-all-dev in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
             elfutils \
             file \
             git \
-            libboost-all-dev \
+            libboost-dev \
             libeigen3-dev \
             libgtest-dev \
             libssl-dev \


### PR DESCRIPTION
Reverting PR #555 which modified dependency on Boost from`libboost-dev` to `libboost-all-dev`, which was needed for command line parser refactoring. Initial round of review concluded that we'd like to keep a header-only dependency on Boost.

Also, `libboost-all-dev` introduces a large number of additional packages which cause a bit of problems in CI due to broken dependency chains in Debian Sid.