### PR TITLE
Device-specific build flags

### DIFF
--- a/framework/devicedeps/cpu/meson.build
+++ b/framework/devicedeps/cpu/meson.build
@@ -21,15 +21,9 @@ generated_cpu_features_h = configure_file(
 framework_files += [
     'devicedeps/cpu/cpu_device.cpp',
     'devicedeps/cpu/topology.cpp',
+    generated_cpu_features_h,
 ]
-device_flags = [
+
+device_flags += [
     '-DSANDSTONE_DEVICE_CPU',
-]
-
-default_c_flags += [
-    device_flags
-]
-
-default_cpp_flags += [
-    device_flags
 ]

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -4,18 +4,13 @@
 framework_config = configuration_data()
 framework_config.set10('SANDSTONE_STATIC', false) # sysdeps may override
 
-device_type = get_option('device_type')
-if device_type == ''
-    device_type = 'cpu'
-endif
-
 sysdeps_dir = 'sysdeps' / target_machine.system()
 devicedeps_dir = 'devicedeps' / device_type
 devicedeps_sys_dir = devicedeps_dir / target_machine.system()
 
 if target_machine.system() == 'cygwin'
     sysdeps_dir = 'sysdeps/windows'
-    devicedeps_dir = 'devicedeps' / device_type / 'windows'
+    devicedeps_sys_dir = 'devicedeps' / device_type / 'windows'
 endif
 
 framework_incdir = [
@@ -25,10 +20,14 @@ framework_incdir = [
             '.',
             sysdeps_dir,
             devicedeps_dir,
-            devicedeps_sys_dir,
         ],
     ),
 ]
+
+fs = import('fs')
+if fs.exists(devicedeps_sys_dir)
+    framework_incdir += include_directories(devicedeps_sys_dir)
+endif
 
 framework_files = files()
 
@@ -108,7 +107,6 @@ framework_files += [
     'random.cpp',
     'sandstone.cpp',
     'sandstone_chrono.cpp',
-    'sandstone_context_dump.cpp',
     'sandstone_data.cpp',
     'sandstone_test_groups.cpp',
     'sandstone_tests.cpp',
@@ -117,6 +115,12 @@ framework_files += [
     'static_vectors.c',
     'test_knobs.cpp',
 ]
+
+if device_type == 'cpu'
+    framework_files += [
+        'sandstone_context_dump.cpp',
+    ]
+endif
 
 if framework_config.get('SANDSTONE_SSL_BUILD') == 1
     # Look for libcrypto
@@ -186,10 +190,14 @@ endif
 
 if target_machine.system() != 'windows' and target_machine.system() != 'cygwin'
     subdir('sysdeps/unix')
-    subdir('devicedeps' / device_type / 'unix')
 endif
 subdir(sysdeps_dir)
-subdir(devicedeps_sys_dir)
+
+# devicedeps_sys_dir may not exist, e.g. for devices without explicit
+# operating system dependencies.
+if fs.exists(devicedeps_sys_dir)
+    subdir(devicedeps_sys_dir)
+endif
 
 framework_config_h = configure_file(
     input: 'sandstone_config.h.in',
@@ -211,6 +219,7 @@ framework_main_a = static_library(
         march_generic_flags,
         default_cpp_flags,
         default_cpp_warn,
+        device_flags,
     ],
 )
 
@@ -218,7 +227,6 @@ framework_a = static_library(
     'framework',
     framework_files,
     generated_builtin_test_list,
-    generated_cpu_features_h,
     build_by_default: false,
     include_directories: [
         framework_incdir,
@@ -234,12 +242,14 @@ framework_a = static_library(
         march_flags,
         default_c_flags,
         default_c_warn,
+        device_flags,
     ],
     cpp_args: [
         debug_c_flags,
         march_flags,
         default_cpp_flags,
         default_cpp_warn,
+        device_flags,
     ],
 )
 

--- a/framework/sysdeps/linux/meson.build
+++ b/framework/sysdeps/linux/meson.build
@@ -1,7 +1,7 @@
 # Copyright 2022 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-if (host_machine.cpu_family() == 'x86_64')
+if (host_machine.cpu_family() == 'x86_64' and device_type == 'cpu')
     framework_files += files(
         'kvm.c',
     )

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,12 @@ if cpp.get_linker_id() != 'ld.bfd' or cc.get_linker_id() != 'ld.bfd'
     warning('We recommend linking OpenDCDiag with the binutils linker (ld). Your build may fail or your executable may not behave as expected.')
 endif
 
+device_type = get_option('device_type')
+if device_type == ''
+    device_type = 'cpu'
+endif
+device_flags = []
+
 march_generic_flags = []
 march_flags = []
 march_base = get_option('march_base')
@@ -271,6 +277,7 @@ executable(
     cpp_args : [
         default_cpp_warn,
         default_cpp_flags,
+        device_flags,
     ],
 )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -15,6 +15,7 @@ tests_common_c_args = [
     default_c_warn,
     default_c_flags,
     march_flags,
+    device_flags,
 ]
 
 tests_common_cpp_args = [
@@ -22,6 +23,7 @@ tests_common_cpp_args = [
     default_cpp_warn,
     default_cpp_flags,
     march_flags,
+    device_flags,
 ]
 
 tests_common_incdirs = [


### PR DESCRIPTION
Commit moves declaration of `device_flags` meson variable to the top-level build file. Device specific flags are now used when building targets. In addition, some pieces of code (kvm, core dump) are only built when CPU is the selected device type.