### PR TITLE
Make device_specific_init overloadable

### DIFF
--- a/framework/devicedeps/cpu/devices.h
+++ b/framework/devicedeps/cpu/devices.h
@@ -13,11 +13,4 @@ struct DeviceRange
     int device_count;
 };
 
-/*
- * Called from sandstone_main(). The default implementation performs no
- * checks, they just return. Feel free to implement a strong version elsewhere
- * if you prefer the framework to check for system or CPU criteria.
- */
-static __attribute__((unused, noinline)) void device_specific_init() {}
-
 #endif // INC_DEVICES_H

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1298,6 +1298,10 @@ static void slice_plan_init(int max_cores_per_slice)
     }
 }
 
+__attribute__((weak, noclone, noinline)) void device_specific_init()
+{
+}
+
 __attribute__((weak, noclone, noinline)) void print_application_banner()
 {
 }


### PR DESCRIPTION
`device_specific_init()` function was incorectly defined in devices.h header (as empty function). This was preventing from overloading the function, as intended.

Commit fixes this by restoring original approach from `cpu_specific_init()`; empty implementation is provided with 'weak' attribute set, allowing for overloading the function as needed.