### PR TITLE
FW/Logging: refuse to overwrite time-based log files

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -634,7 +634,7 @@ void logging_init_global(void)
 #endif
         }
         if (isdir) {
-            file_log_fd = open(time_based_log_path(), O_RDWR | O_CLOEXEC | O_CREAT | O_TRUNC, 0666);
+            file_log_fd = open(time_based_log_path(), O_RDWR | O_CLOEXEC | O_CREAT | O_TRUNC | O_EXCL, 0666);
             delete_log_on_success = true;
         }
         if (file_log_fd == -1) {


### PR DESCRIPTION
When the user does not provide us with a name for the log file, we generate one based on the current univesal time. This change makes OpenDCDiag refuse to overwrite such an existing file.

The file name contains the current timestamp down to microseconds, so it's extremely unlikely one *can* match an existing file anyway.