### PR TITLE
FW: Fix hang-on-crash for second or further slice

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1626,6 +1626,18 @@ function check_gdb_usable() {
 
     declare -A yamldump
     selftest_crash_context_common -n2 --timeout=5m -e selftest_sigsegv --on-crash=backtrace --max-cores-per-slice=1
+
+    # We should have as output two main threads and two worker threads
+    test_yaml_regexp "/tests/0/threads/0/thread" "main"
+    test_yaml_regexp "/tests/0/threads/0/messages/0/level" "info"
+    test_yaml_regexp "/tests/0/threads/0/messages/0/text" "Backtrace:.*"
+
+    test_yaml_regexp "/tests/0/threads/1/thread" "main 1"
+    test_yaml_regexp "/tests/0/threads/1/messages/0/level" "info"
+    test_yaml_regexp "/tests/0/threads/1/messages/0/text" "Backtrace:.*"
+
+    test_yaml_regexp "/tests/0/threads/2/thread" "0"
+    test_yaml_regexp "/tests/0/threads/3/thread" "1"
 }
 
 @test "selftest_oserror" {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1647,7 +1647,7 @@ static void wait_for_children(ChildrenList &children, const struct test *test)
         auto now = MonotonicTimePoint::clock::now();
         if (pollfd &pfd = children.pollfds.back(); pfd.revents & POLLIN) {
             // one child (or more than one) is crashing
-            debug_crashed_child();
+            debug_crashed_child(children.handles);
         }
 
         // check if any of the children have exited
@@ -1713,7 +1713,7 @@ static void wait_for_children(ChildrenList &children, const struct test *test)
         int idx = result - WAIT_OBJECT_0;
         if (idx == 0 && sApp->shmem->debug_event) {
             // one child (or more than one) is crashing
-            debug_crashed_child();
+            debug_crashed_child(children.handles);
             return 0;
         }
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1763,7 +1763,7 @@ static void wait_for_children(ChildrenList &children, const struct test *test)
         for (size_t i = 0; i < children.handles.size(); ++i) {
             auto child = children.handles[i];
             if (children.results[i].endtime == MonotonicTimePoint{}) {
-                debug_hung_child(child);
+                debug_hung_child(child, children.handles);
 #ifdef _WIN32
                 log_message(-int(i) - 1, SANDSTONE_LOG_ERROR "Child %ld did not exit, using TerminateProcess()",
                             GetProcessId(HANDLE(child)));

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -95,12 +95,6 @@ struct mmap_region
  */
 void cpu_specific_init(void);
 
-/* child_debug.cpp */
-void debug_init_child(void);
-void debug_init_global(const char *on_hang_arg, const char *on_crash_arg);
-void debug_crashed_child();
-void debug_hung_child(pid_t child);
-
 /* splitlock_detect.c */
 bool splitlock_enforcement_enabled(void);
 
@@ -658,6 +652,12 @@ template <typename F> inline auto scopeExit(F &&f)
 
 static_assert(std::is_trivially_copyable_v<SandstoneApplication::SharedMemory>);
 static_assert(std::is_trivially_destructible_v<SandstoneApplication::SharedMemory>);
+
+/* child_debug.cpp */
+void debug_init_child(void);
+void debug_init_global(const char *on_hang_arg, const char *on_crash_arg);
+void debug_crashed_child();
+void debug_hung_child(pid_t child);
 
 /* logging.cpp */
 int logging_stdout_fd(void);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -657,7 +657,7 @@ static_assert(std::is_trivially_destructible_v<SandstoneApplication::SharedMemor
 void debug_init_child(void);
 void debug_init_global(const char *on_hang_arg, const char *on_crash_arg);
 void debug_crashed_child(std::span<const pid_t> children);
-void debug_hung_child(pid_t child);
+void debug_hung_child(pid_t child, std::span<const pid_t> children);
 
 /* logging.cpp */
 int logging_stdout_fd(void);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -656,7 +656,7 @@ static_assert(std::is_trivially_destructible_v<SandstoneApplication::SharedMemor
 /* child_debug.cpp */
 void debug_init_child(void);
 void debug_init_global(const char *on_hang_arg, const char *on_crash_arg);
-void debug_crashed_child();
+void debug_crashed_child(std::span<const pid_t> children);
 void debug_hung_child(pid_t child);
 
 /* logging.cpp */

--- a/framework/sysdeps/windows/child_debug.cpp
+++ b/framework/sysdeps/windows/child_debug.cpp
@@ -354,10 +354,11 @@ void debug_crashed_child(std::span<const pid_t> children)
     sApp->shmem->debug_event = 0;
 }
 
-void debug_hung_child(pid_t child)
+void debug_hung_child(pid_t child, std::span<const pid_t> children)
 {
     if (!SandstoneConfig::ChildDebugHangs || on_hang_action == kill_on_hang)
         return;
+    (void) children;
 
     // pid_t is actually a HANDLE in disguise (using _spawnv)
     if (on_hang_action == attach_gdb_on_hang)

--- a/framework/sysdeps/windows/child_debug.cpp
+++ b/framework/sysdeps/windows/child_debug.cpp
@@ -293,12 +293,13 @@ static void attach_gdb(HANDLE child)
     close(saved_stdout);
 }
 
-void debug_crashed_child()
+void debug_crashed_child(std::span<const pid_t> children)
 {
     if (!SandstoneConfig::ChildDebugCrashes)
         return;
     if (hSlot == INVALID_HANDLE_VALUE)
         return;
+    (void) children;
 
     ResetEvent(HANDLE(sApp->shmem->debug_event));
 


### PR DESCRIPTION
Amends commit bdc345642e79555cfbfc62a34028d75ddf4b6ad8 ("FW/child_debug: use futexes to make the child wait for gdb") and more importantly commit b92a2efd7eab9cbb9ad4d1a4289304ec26be1b31 ("FW/SharedMemory: add support for multiple main threads").

This caused OpenDCDiag to wake up the wrong child (always the first) when GDB backtrace support was active, which is the default. Because of that, the actual crashed child would be stuck forever in `futex_wait()` in `child_crash_handler()`:
https://github.com/opendcdiag/opendcdiag/blob/b8bdda557a388a06d66eb6a9d4455263a56e472b/framework/sysdeps/unix/child_debug.cpp#L207-L211

Additionally, we printed the backtrace in the to the first ("main") slice, which can be misleading because one might conclude it was that child that crashed.

On Windows we don't support backtraces, so there the child doesn't wait and no changes are necessary.
