### PR TITLE
FW/shmem: fix Clang warning about VLA in constexpr context

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1065,7 +1065,7 @@ static void attach_shmem_internal(int fd, size_t size)
     ptr += sApp->shmem->thread_data_offset;
 
     sApp->main_thread_data_ptr = reinterpret_cast<PerThreadData::Main *>(ptr);
-    ptr += ROUND_UP_TO_PAGE(sizeof(PerThreadData::Main[sApp->shmem->main_thread_count]));
+    ptr += ROUND_UP_TO_PAGE(sizeof(PerThreadData::Main) * sApp->shmem->main_thread_count);
     sApp->test_thread_data_ptr = reinterpret_cast<PerThreadData::Test *>(ptr);
 }
 


### PR DESCRIPTION
And in an unevaluated context anyway, due to the `sizeof` expression. Simply write what one would expect: a multiplication.

```
../framework/sandstone.cpp:1068:56: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
../framework/sandstone_p.h:507:17: note: expanded from macro 'sApp'
../framework/sandstone_p.h:75:49: note: expanded from macro 'ROUND_UP_TO_PAGE'
../framework/sandstone_p.h:74:40: note: expanded from macro 'ROUND_UP_TO'
../framework/sandstone.cpp:1068:56: note: non-constexpr function '_sApp' cannot be used in a constant expression
../framework/sandstone_p.h:507:17: note: expanded from macro 'sApp'
../framework/sandstone_p.h:500:30: note: declared here
../framework/sandstone.cpp:1068:56: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
../framework/sandstone_p.h:507:17: note: expanded from macro 'sApp'
../framework/sandstone_p.h:75:49: note: expanded from macro 'ROUND_UP_TO_PAGE'
../framework/sandstone_p.h:74:40: note: expanded from macro 'ROUND_UP_TO'
../framework/sandstone.cpp:1068:56: note: non-constexpr function '_sApp' cannot be used in a constant expression
../framework/sandstone_p.h:507:17: note: expanded from macro 'sApp'
```