### PR TITLE
FW/frequency_manager: improve userspace detection logic and ensure file closure

### DIFF
--- a/framework/frequency_manager.hpp
+++ b/framework/frequency_manager.hpp
@@ -111,14 +111,16 @@ private:
             exit(EX_IOERR);
         }
 
+        bool userspace_present = false;
         while (fscanf(file, "%s", read_file) != EOF) {
             if (strcmp(read_file, "userspace") == 0) {
-                fclose(file);
-                return true;
+                userspace_present = true;
+                break;
             }
         }
 
-        return false;
+        fclose(file);
+        return userspace_present;
     }
 
     void check_uncore_frequency_support()
@@ -131,6 +133,7 @@ private:
             fprintf(stderr, "%s: cannot read from file: %s. Please check if intel_uncore_frequency directory is present in the file path /sys/devices/system/cpu: %m\n", program_invocation_name, uncore_path);
             exit(EX_IOERR);
         }
+        fclose(file);
     }
 
     void enable_disable_userspace(bool should_enable_userspace)

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -956,7 +956,7 @@ static void init_topology_internal(const LogicalProcessorSet &enabled_cpus)
     }
 
     auto detect = [](void *ptr) -> void * {
-        auto enabled_cpus = *static_cast<const LogicalProcessorSet *>(ptr);
+        const auto & enabled_cpus = *static_cast<const LogicalProcessorSet *>(ptr);
         int curr_cpu = 0;
         for (int i = 0; i < sApp->thread_count; ++i, ++curr_cpu) {
             auto lp = LogicalProcessor(curr_cpu);


### PR DESCRIPTION
Commit modifies two functions in the frequency manager to ensure opened files are properly closed in all code paths in the functions.

In addition, a minor change in Topology, where copying a variable via auto is replaced with a reference.

Signed-off-by: Lukasz Tuz 