### PR TITLE
Framework extension to log a message without a use of logging facility

### DIFF
--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -87,6 +87,7 @@ enum {
     vary_uncore_frequency,
     version_option,
     weighted_testrun_option,
+    pts_option,
 };
 
 void suggest_help(char **argv) {
@@ -525,6 +526,7 @@ int parse_cmdline(int argc, char** argv, SandstoneApplication* app, ParsedCmdLin
         { "verbose", no_argument, nullptr, 'v' },
         { "version", no_argument, nullptr, version_option },
         { "weighted-testrun-type", required_argument, nullptr, weighted_testrun_option },
+        { "pts", required_argument, nullptr, pts_option },
         { "yaml", optional_argument, nullptr, 'Y' },
 
 #if defined(__SANITIZE_ADDRESS__)
@@ -916,6 +918,10 @@ int parse_cmdline(int argc, char** argv, SandstoneApplication* app, ParsedCmdLin
                 app->max_test_loop_count = ParseIntArgument<>{"--max-test-loop-count"}();
                 if (app->max_test_loop_count == 0)
                         app->max_test_loop_count = std::numeric_limits<int>::max();
+                break;
+
+            case pts_option:
+                sApp->pts_arg = std::make_unique<std::string>(optarg);
                 break;
 
                 /* deprecated options */

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -394,6 +394,8 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     std::string gdb_server_comm;
 #endif
 
+    std::unique_ptr<std::string> pts_arg;
+
     static constexpr int DefaultTemperatureThreshold = -1;
     int thermal_throttle_temp = DefaultTemperatureThreshold;
     int threshold_time_remaining = 30000;


### PR DESCRIPTION
PTS console (as passed with PTS environment variable) is used to log all the messages.
Default implementation to print (xbyak) code and to print buffer (as bytes) included.

`--pts` (or `PTS` environment variables) allows to define where the logs should be logged. Any text file, device file (e.g. any pseudo-terminal session /dev/pts/xxx, e.g. `tmux` pane tty) or open file descriptor (`./sandstone --pts=3 .... 3>log.txt`) works. Per-cpu syntax not available.
`PRINT_ASM` environment variable might be used to pass the script to parse binary into human readable assembly form (defaults to `print_asm.sh`). Script not included.