### PR TITLE
FW: add a way for OpenDCDiag to ignore SIGBUS relating to MCEs

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1509,6 +1509,23 @@ selftest_crash_common() {
     test_yaml_regexp "/tests/0/result-details/reason" Killed
 }
 
+@test "selftest_sigtrap_int3 --ignore-mce-error" {
+    if ! $is_debug; then
+        skip "Debug-only test"
+    fi
+    if $is_windows; then
+        skip "Unix-only test"
+    fi
+    declare -A yamldump
+    sandstone_selftest -vvv -e selftest_sigtrap_int3 --on-crash=context --ignore-mce-error
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/result" skip
+    test_yaml_regexp "/tests/0/skip-category" IgnoredMceCategory
+    test_yaml_regexp "/tests/0/skip-reason" "Debugging SIGTRAP"
+    test_yaml_regexp "/tests/0/threads/2/messages/0/text" "W> MCE was delivered to or is related to this thread"
+}
+
 @test "selftest_malloc_fail" {
     declare -A yamldump
     selftest_crash_common selftest_malloc_fail SIGABRT 0xC0000017 "Out of memory condition"

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1471,6 +1471,10 @@ selftest_crash_common() {
     selftest_crash_common selftest_sigsegv_instruction SIGSEGV 0xC0000005 'Access violation'
 }
 
+@test "selftest_sigtrap_int3" {
+    selftest_crash_common selftest_sigtrap_int3 SIGTRAP 0x80000003 'Breakpoint'
+}
+
 @test "selftest_fastfail" {
     if ! $is_windows; then
         skip "Windows-only test"

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -473,6 +473,8 @@ static const char *char_to_skip_category(int val)
         return "CpuTopologyIssue";
     case OSResourceIssueSkipCategory:
         return "OSResourceIssue";
+    case IgnoredMceCategory:
+        return "IgnoredMceCategory";
     }
 
     return "NO CATEGORY PRESENT";

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -118,6 +118,7 @@ enum {
     dump_cpu_info_option,
     fatal_skips_option,
     gdb_server_option,
+    ignore_mce_errors_option,
     ignore_os_errors_option,
     ignore_unknown_tests_option,
     is_asan_option,
@@ -3094,6 +3095,7 @@ int main(int argc, char **argv)
         { "fatal-skips", no_argument, nullptr, fatal_skips_option },
         { "fork-mode", required_argument, nullptr, 'f' },
         { "help", no_argument, nullptr, 'h' },
+        { "ignore-mce-errors", no_argument, nullptr, ignore_mce_errors_option },
         { "ignore-os-errors", no_argument, nullptr, ignore_os_errors_option },
         { "ignore-timeout", no_argument, nullptr, ignore_os_errors_option },
         { "ignore-unknown-tests", no_argument, nullptr, ignore_unknown_tests_option },
@@ -3323,6 +3325,9 @@ int main(int argc, char **argv)
             sApp->gdb_server_comm = optarg;
             break;
 #endif
+        case ignore_mce_errors_option:
+            sApp->ignore_mce_errors = true;
+            break;
         case ignore_os_errors_option:
             sApp->ignore_os_errors = true;
             break;
@@ -3694,10 +3699,10 @@ int main(int argc, char **argv)
         }
     }
 
-
     /* Add mce_check as the last test to the set. It will be kept last by
      * SandstoneTestSet in case randomization is requested. */
-    test_set->add(&mce_test);
+    if (!sApp->ignore_mce_errors)
+        test_set->add(&mce_test);
 
     /* Remove all the tests we were told to disable */
     if (disabled_tests.size()) {

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -92,6 +92,7 @@ typedef enum SkipCategory {
     DeviceNotFoundSkipCategory,
     DeviceNotConfiguredSkipCategory,
     UnknownSkipCategory,
+    IgnoredMceCategory,
     RuntimeSkipCategory,
     SelftestSkipCategory,
 } SkipCategory;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -369,6 +369,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
 #else
             fork_each_test;
 #endif
+    bool ignore_mce_errors = false;
     bool ignore_os_errors = false;
     bool force_test_time = false;
     bool service_background_scan = false;

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -1007,7 +1007,7 @@ void debug_init_child()
     action.sa_sigaction = child_crash_handler;
     action.sa_flags = SA_NODEFER;       // allow recursive signalling, so the child can raise()
     action.sa_flags |= SA_SIGINFO;
-    for (int signum : { SIGILL, SIGABRT, SIGFPE, SIGBUS, SIGSEGV }) {
+    for (int signum : { SIGILL, SIGTRAP, SIGABRT, SIGFPE, SIGBUS, SIGSEGV }) {
         sigaction(signum, &action, nullptr);
     }
 


### PR DESCRIPTION
This adds a `--ignore-mce-errors` option, which a) disables the `mce_check` test and b) makes the framework ignore SIGBUS errors that are related to MCEs. The Linux kernel sends those with `.si_code` equal to either `BUS_MCEERR_AO` or `BUS_MCEERR_AR`.

[ChangeLog][Framework] Added `--ignore-mce-errors` option, which will disable handling of Machine Check Exceptions. This option is useful if the user wants the tool to only react to Silent Data Errors (uncorrected MCEs are User-Observable Errors).

[ChangeLog][Framework] The --ignore-mce-errors will also cause the tool to ignore SIGBUS errors sent by the Linux kernel with signal codes indicating they were caused by MCEs. If those are detected, the test will terminate the test and mark it as skipped.

In debug builds, we also ignore SIGTRAP (Breakpoints), which allows this functionality to be tested. There's no way to send the required `si_code` for SIGBUS from userspace - only the OS kernel is allowed to set those values.

