### PR TITLE
CI: Upgrade the Windows build to Fedora 41

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
 
   Windows:
     runs-on: ubuntu-latest
-    container: fedora:38
+    container: fedora:41
     env:
       ENABLE_WINE_WORKAROUNDS: 1
       WINEDEBUG: fixme-all,-dbghelp_stabs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:38
     env:
+      ENABLE_WINE_WORKAROUNDS: 1
       WINEDEBUG: fixme-all,-dbghelp_stabs
       WINEPREFIX: /tmp/wine_root
       WINEPATH: d:/bin

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -22,3 +22,7 @@ framework_files += \
         '../generic/msr.c',
         '../generic/physicaladdress.c',
     )
+
+if run_command([shell, '-c', 'echo $ENABLE_WINE_WORKAROUNDS'], capture: true).stdout().strip() == '1'
+    default_cpp_flags += [ '-DENABLE_WINE_WORKAROUNDS', ]
+endif


### PR DESCRIPTION
We need to do these once in a while.

To do that, we need to stop calling `SetThreadIdealProcessorEx` because that breaks the CI.