### PR TITLE
FW/frequency_manager: simple clean ups and fixes

### DIFF
--- a/framework/frequency_manager.hpp
+++ b/framework/frequency_manager.hpp
@@ -6,7 +6,14 @@
 #ifndef FREQUENCY_MANAGER_HPP
 #define FREQUENCY_MANAGER_HPP
 
+#include <sandstone_utils.h>
+
+#include <string>
 #include <unordered_set>
+#include <vector>
+
+#include <stdint.h>
+
 #define BASE_CORE_FREQ_PATH    "/sys/devices/system/cpu/cpu"
 #define BASE_UNCORE_FREQ_PATH  "/sys/devices/system/cpu/intel_uncore_frequency/package_0"
 #define SCALING_GOVERNOR       "/cpufreq/scaling_governor"

--- a/framework/frequency_manager.hpp
+++ b/framework/frequency_manager.hpp
@@ -46,20 +46,19 @@ private:
     {
         /* Read first line of given file */
         char line[100]; //100 characters should be more than enough
-        FILE *file = fopen(file_path.data(), "r");
+        AutoClosingFile file(fopen(file_path.data(), "r"));
 
         if (file == nullptr) {
             fprintf(stderr, "%s: cannot read from file: %s: %m\n", program_invocation_name, file_path.data());
             exit(EX_IOERR);
         }
         fscanf(file, "%s", line);
-        fclose(file);
         return std::string(line);
     }
 
     void write_file(std::string_view file_path, std::string_view line)
     {
-        FILE *file = fopen(file_path.data(), "w");
+        AutoClosingFile file(fopen(file_path.data(), "w"));
 
         if (file == nullptr) {
             fprintf(stderr, "%s: cannot write \"%s\" to file \"%s\". Make sure the user is root: %m\n", program_invocation_name, line.data(), file_path.data());
@@ -67,21 +66,19 @@ private:
         }
 
         fprintf(file, "%s", line.data());
-        fclose(file);
     }
 
     int get_frequency_from_file(std::string_view file_path)
     {
         /* Read frequency value from file */
         int frequency = 0;
-        FILE *file = fopen(file_path.data(), "r");
+        AutoClosingFile file(fopen(file_path.data(), "r"));
 
         if (file == nullptr) {
             fprintf(stderr, "%s: cannot read from file: %s: %m\n", program_invocation_name, file_path.data());
             exit(EX_IOERR);
         }
         fscanf(file, "%d", &frequency);
-        fclose(file);
         return frequency;
     }
 
@@ -111,7 +108,7 @@ private:
     {
         const char *scaling_governor_path = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors";
         char read_file[100];
-        FILE *file = fopen(scaling_governor_path, "r");
+        AutoClosingFile file(fopen(scaling_governor_path, "r"));
 
         if (file == nullptr) {
             fprintf(stderr, "%s: cannot read from file: %s: %m\n", program_invocation_name, scaling_governor_path);
@@ -126,7 +123,6 @@ private:
             }
         }
 
-        fclose(file);
         return userspace_present;
     }
 
@@ -134,13 +130,12 @@ private:
     {
         // check for 0th socket. 0th socket should always be present.
         const char *uncore_path = "/sys/devices/system/cpu/intel_uncore_frequency/package_00_die_00/initial_min_freq_khz";
-        FILE *file = fopen(uncore_path, "r");
+        AutoClosingFile file(fopen(uncore_path, "r"));
 
         if (file == nullptr) {
             fprintf(stderr, "%s: cannot read from file: %s. Please check if intel_uncore_frequency directory is present in the file path /sys/devices/system/cpu: %m\n", program_invocation_name, uncore_path);
             exit(EX_IOERR);
         }
-        fclose(file);
     }
 
     void enable_disable_userspace(bool should_enable_userspace)

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -882,10 +882,10 @@ static void cleanup_internal(const struct test *test)
 static int cleanup_global(int exit_code, SandstoneApplication::PerCpuFailures per_cpu_failures)
 {
     if (sApp->vary_frequency_mode)
-        sApp->frequency_manager.restore_core_frequency_initial_state();
+        sApp->frequency_manager->restore_core_frequency_initial_state();
 
     if (sApp->vary_uncore_frequency_mode)
-        sApp->frequency_manager.restore_uncore_frequency_initial_state();
+        sApp->frequency_manager->restore_uncore_frequency_initial_state();
 
     exit_code = print_application_footer(exit_code, std::move(per_cpu_failures));
     return logging_close_global(exit_code);
@@ -2367,11 +2367,11 @@ run_one_test(const test_cfg_info &test_cfg, SandstoneApplication::PerCpuFailures
 
         //change frequency per fracture
         if (sApp->vary_frequency_mode == true)
-            sApp->frequency_manager.change_core_frequency();
+            sApp->frequency_manager->change_core_frequency();
 
         //change uncore frequency per fracture
         if (sApp->vary_uncore_frequency_mode == true)
-            sApp->frequency_manager.change_uncore_frequency();
+            sApp->frequency_manager->change_uncore_frequency();
 
         init_internal(test);
 
@@ -2447,7 +2447,7 @@ run_one_test(const test_cfg_info &test_cfg, SandstoneApplication::PerCpuFailures
 out:
     //reset frequency level idx for the next test
     if (sApp->vary_frequency_mode || sApp->vary_uncore_frequency_mode)
-        sApp->frequency_manager.reset_frequency_level_idx();
+        sApp->frequency_manager->reset_frequency_level_idx();
 
     random_advance_seed();      // advance seed for the next test
     logging_flush();
@@ -3728,13 +3728,16 @@ int main(int argc, char **argv)
         sApp->mce_count_last = std::accumulate(sApp->mce_counts_start.begin(), sApp->mce_counts_start.end(), uint64_t(0));
     }
 
+    if (sApp->vary_frequency_mode || sApp->vary_uncore_frequency_mode)
+        sApp->frequency_manager = std::make_unique<FrequencyManager>();
+
     //if --vary-frequency mode is used, do a initial setup for running different frequencies
     if (sApp->vary_frequency_mode)
-        sApp->frequency_manager.initial_core_frequency_setup();
+        sApp->frequency_manager->initial_core_frequency_setup();
 
     //if --vary-uncore-frequency mode is used, do a initial setup for running different frequencies
     if (sApp->vary_uncore_frequency_mode)
-        sApp->frequency_manager.initial_uncore_frequency_setup();
+        sApp->frequency_manager->initial_uncore_frequency_setup();
 
 #ifndef __OPTIMIZE__
     logging_printf(LOG_LEVEL_VERBOSE(1), "THIS IS AN UNOPTIMIZED BUILD: DON'T TRUST TEST TIMING!\n");

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -550,25 +550,6 @@ template <typename Lambda> static void for_each_test_thread(Lambda &&l)
         l(sApp->test_thread_data(i), i);
 }
 
-struct AutoClosingFile
-{
-    FILE *f = nullptr;
-    AutoClosingFile(FILE *f = nullptr) : f(f) {}
-    ~AutoClosingFile() { if (f) fclose(f); }
-    AutoClosingFile(const AutoClosingFile &) = delete;
-    AutoClosingFile(AutoClosingFile &&other) : f(other.f) { other.f = nullptr; }
-    AutoClosingFile &operator=(const AutoClosingFile &) = delete;
-    AutoClosingFile &operator=(AutoClosingFile &&other)
-    {
-        if (f)
-            fclose(f);
-        f = other.f;
-        other.f = nullptr;
-        return *this;
-    }
-    operator FILE *() const { return f; }
-};
-
 struct Pipe
 {
     enum DontCreateFlag { DontCreate };

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -396,7 +396,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     ShortDuration delay_between_tests = std::chrono::milliseconds(5);
 
     std::unique_ptr<RandomEngineWrapper, RandomEngineDeleter> random_engine;
-    FrequencyManager frequency_manager;
+    std::unique_ptr<FrequencyManager> frequency_manager;
 
 #ifndef __linux__
     std::string path_to_self;

--- a/framework/sandstone_utils.h
+++ b/framework/sandstone_utils.h
@@ -54,4 +54,23 @@ inline int dprintf(int fd, const char *fmt, ...)
 }
 #endif
 
+struct AutoClosingFile
+{
+    FILE *f = nullptr;
+    AutoClosingFile(FILE *f = nullptr) : f(f) {}
+    ~AutoClosingFile() { if (f) fclose(f); }
+    AutoClosingFile(const AutoClosingFile &) = delete;
+    AutoClosingFile(AutoClosingFile &&other) : f(other.f) { other.f = nullptr; }
+    AutoClosingFile &operator=(const AutoClosingFile &) = delete;
+    AutoClosingFile &operator=(AutoClosingFile &&other)
+    {
+        if (f)
+            fclose(f);
+        f = other.f;
+        other.f = nullptr;
+        return *this;
+    }
+    operator FILE *() const { return f; }
+};
+
 #endif //SANDSTONE_UTILS_H_INCLUDED


### PR DESCRIPTION
First, include what you need. Otherwise, IDEs show everything as underlined in this file.

Second, use `AutoClosingFile` to avoid having to remember to `fclose`. This amends commit c837a1d2e52e027fbe6165cb322827248f93e708.

Finally, refer to the object indirectly in sApp. This is a 192-byte structure, which is not used by default in the majority of runs. Move it off to a pointer so we don't need to occupy space in the sApp global for the majority of users.
