### PR TITLE
Meson: silence warnings about -Wl options during compilation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -94,10 +94,16 @@ nasm_system_flags = [
 default_c_flags = []
 default_cpp_flags = []
 
-add_project_arguments([
+foreach ccflag : [
+    '-fstack-clash-protection',
     '-fstack-protector-strong',
     '-fcf-protection=full',
-], language: [ 'c', 'cpp' ])
+    '-mcet-switch',
+]
+    if cc.has_argument(ccflag)
+        add_project_arguments(ccflag, language: [ 'c', 'cpp' ])
+    endif
+endforeach
 
 foreach lflag : [
     '-Wl,-z,relro',
@@ -157,14 +163,6 @@ else
 if get_option('buildtype') == 'debug'
     debug_nasm_flags = '-gdwarf'
 endif
-if cc.get_id() == 'gcc'
-    march_flags += [
-        '-mcet-switch',
-    ]
-endif
-march_flags += [
-    '-fstack-clash-protection',
-]
 endif
 
 default_c_flags += [

--- a/meson.build
+++ b/meson.build
@@ -95,13 +95,23 @@ default_c_flags = []
 default_cpp_flags = []
 
 add_project_arguments([
-    '-Wl,-z,relro',
-    '-Wl,-z,noexecstack',
-    '-pie',
     '-fstack-protector-strong',
     '-fcf-protection=full',
 ], language: [ 'c', 'cpp' ])
 
+foreach lflag : [
+    '-Wl,-z,relro',
+    '-Wl,-z,noexecstack',
+    '-pie',
+]
+    if cc.links(
+       'int main() { return 0; }',
+       args: [ lflag ],
+       name: lflag
+    )
+        add_project_link_arguments(lflag, language : [ 'c', 'cpp' ])
+    endif
+endforeach
 
 if target_machine.system() == 'windows'
 add_project_arguments([


### PR DESCRIPTION
GCC isn't complaining, but Clang is:

```
clang++-19: warning: -Wl,-z,relro: 'linker' input unused [-Wunused-command-line-argument]
clang++-19: warning: -Wl,-z,noexecstack: 'linker' input unused [-Wunused-command-line-argument]
clang++-19: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
```