### PR TITLE
FW/Win32: remove call to SetThreadIdealProcessor

### DIFF
--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -30,14 +30,6 @@ static void set_thread_name(const char *thread_name)
     (void) thread_name;
 }
 
-[[maybe_unused]] static bool running_in_wine()
-{
-    HMODULE hMod = GetModuleHandleW(L"ntdll.dll");
-    if (hMod)
-        return GetProcAddress(hMod, "wine_get_version") != nullptr;
-    return false;
-}
-
 LogicalProcessorSet ambient_logical_processor_set()
 {
     LogicalProcessorSet result = {};        // memsets to zero
@@ -59,20 +51,12 @@ bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
     if (n == LogicalProcessor(-1))
         return true;            // don't change affinity
 
-    HANDLE hThread = GetCurrentThread();
-
-#ifdef ENABLE_WINE_WORKAROUNDS
-    // Work around WINE not implementing SetThreadIdealProcessorEx
-    static const bool is_wine = running_in_wine();
-    if (is_wine && SetThreadIdealProcessor(hThread, DWORD(n)) == 0)
-        return true;
-#endif
-
     PROCESSOR_NUMBER processorNumber = to_processor_number(n);
     GROUP_AFFINITY groupAffinity = {};
     groupAffinity.Group = processorNumber.Group;
     groupAffinity.Mask = KAFFINITY(1) << processorNumber.Number;
 
+    HANDLE hThread = GetCurrentThread();
     if (!SetThreadGroupAffinity(hThread, &groupAffinity, nullptr)) {
         win32_perror("SetThreadGroupAffinity");
         return false;

--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -61,11 +61,6 @@ bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
         win32_perror("SetThreadGroupAffinity");
         return false;
     }
-
-    if (SetThreadIdealProcessorEx(hThread, &processorNumber, nullptr) == 0) {
-        win32_perror("SetThreadIdealProcessorEx");
-        return false;
-    }
     return true;
 }
 

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -22,7 +22,3 @@ framework_files += \
         '../generic/msr.c',
         '../generic/physicaladdress.c',
     )
-
-if run_command([shell, '-c', 'echo $ENABLE_WINE_WORKAROUNDS'], capture: true).stdout().strip() == '1'
-    default_cpp_flags += [ '-DENABLE_WINE_WORKAROUNDS', ]
-endif


### PR DESCRIPTION
We've already called `SetThreadGroupAffinity` with exactly one entry in the affinity mask. The only allowable processor is, by definition, the most ideal as well as the worst ideal processor.

This reverts #587's patch to cpu_affinity.cpp