### PR TITLE
CI: Fix runs on Windows with WINE

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
     container: fedora:41
     env:
       ENABLE_WINE_WORKAROUNDS: 1
-      WINEDEBUG: fixme-all,-dbghelp_stabs
+      WINEDEBUG: -all
       WINEPREFIX: /tmp/wine_root
       WINEPATH: d:/bin
       XDG_RUNTIME_DIR: /tmp/wine_root

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,6 +81,7 @@ jobs:
       WINEDEBUG: fixme-all,-dbghelp_stabs
       WINEPREFIX: /tmp/wine_root
       WINEPATH: d:/bin
+      XDG_RUNTIME_DIR: /tmp/wine_root
     steps:
     - name: Install distro packages
       run: |
@@ -111,6 +112,7 @@ jobs:
             elfutils \
             python3-pyyaml \
             wine
+        mkdir -v -m 0700 $XDG_RUNTIME_DIR
         # Create drive D: at MinGW's sysroot
         winecfg
         rpm -ql mingw64-zlib | sed -n '/bin\/zlib1.dll/s///p' | \


### PR DESCRIPTION
During one of our tests under WINE, we're getting the outputs:
```
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
0690:err:winediag:nodrv_CreateWindow Application tried to create a window, but no driver could be loaded.
```

The former is coming from libwayland-client, probably through Gtk as a dependency of WINE:
https://gitlab.freedesktop.org/wayland/wayland/-/blob/1.23.1/src/wayland-client.c?ref_type=tags#L1154-1160

The second happens when WINE attempts to launch the debugger, but there's no GUI in the CI.

Both began to be a problem with 3432e1190e343d71a516ceadedb6f31cfef62e63 (PR #587). So we now set `XDG_RUNTIME_DIR` and suppress all WINE output.