### PR TITLE
CI: unbreak, by building and testing Windows on Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,9 +43,7 @@ jobs:
             ninja-build \
             python3-yaml \
             zlib1g-dev
-    - uses: actions/checkout@v2
-    - name: setup Git
-      run: git config --system safe.directory '*'
+    - uses: actions/checkout@v4
     - name: meson setup
       run: meson setup builddir -Dssl_link_type=dynamic -Dbuildtype=debugoptimized
     - name: ninja build
@@ -97,9 +95,7 @@ jobs:
             mingw64-zlib \
             mingw64-zstd \
             perl
-    - uses: actions/checkout@v2
-    - name: setup Git
-      run: git config --system safe.directory '*'
+    - uses: actions/checkout@v4
     - name: meson setup
       run: meson setup builddir-windows-cross -Dbuildtype=release --cross-file meson-cross-win32.ini
     - name: ninja build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,6 @@ jobs:
             mingw64-boost \
             mingw64-eigen3 \
             mingw64-gcc-c++ \
-            mingw64-pixman \
             mingw64-pkg-config \
             mingw64-winpthreads-static \
             mingw64-zlib \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,59 +72,54 @@ jobs:
 
 
   Windows:
-    runs-on: ubuntu-latest
-    container: fedora:41
-    env:
-      ENABLE_WINE_WORKAROUNDS: 1
-      WINEDEBUG: -all
-      WINEPREFIX: /tmp/wine_root
-      WINEPATH: d:/bin
-      XDG_RUNTIME_DIR: /tmp/wine_root
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
     - name: Install distro packages
-      run: |
-        dnf install --setopt=install_weak_deps=False -y \
-            cmake \
-            git \
-            meson \
-            mingw64-boost \
-            mingw64-eigen3 \
-            mingw64-gcc-c++ \
-            mingw64-pkg-config \
-            mingw64-winpthreads-static \
-            mingw64-zlib \
-            mingw64-zstd \
-            perl
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ucrt64
+        cache: true
+        release: false
+        install: >-
+            git
+            mingw-w64-ucrt-x86_64-boost
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-eigen3
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-meson
+            mingw-w64-ucrt-x86_64-pkgconf
+            mingw-w64-ucrt-x86_64-python
+            mingw-w64-ucrt-x86_64-python-yaml
+            mingw-w64-ucrt-x86_64-zlib
+            mingw-w64-ucrt-x86_64-zstd
     - uses: actions/checkout@v4
+    - name: install Bats
+      uses: actions/checkout@v4
+      with:
+        repository: bats-core/bats-core
+        ref: v1.11.1
+        path: bats-core
+        fetch-depth: 1
     - name: meson setup
-      run: meson setup builddir-windows-cross -Dbuildtype=release --cross-file meson-cross-win32.ini
-    - name: ninja build
-      run: ninja -C builddir-windows-cross
-    - name: install Wine
       run: |
-        dnf install --setopt=install_weak_deps=False -y \
-            bats \
-            elfutils \
-            python3-pyyaml \
-            wine
-        mkdir -v -m 0700 $XDG_RUNTIME_DIR
-        # Create drive D: at MinGW's sysroot
-        winecfg
-        rpm -ql mingw64-zlib | sed -n '/bin\/zlib1.dll/s///p' | \
-            xargs -rtI@ ln -s @ $WINEPREFIX/dosdevices/d:
-        # Disable the GUI debugger
-        wine reg add 'HKEY_LOCAL_MACHINE\Software\Wine\winedbg' /v ShowCrashDialog /t REG_DWORD /d 00000000
-    - name: confirm Wine works
-      run: wine cmd /c ver
+        meson setup builddir-windows \
+              -Dbuildtype=release \
+              -Ddependency_link=static
+    - name: ninja build
+      run: ninja -C builddir-windows
+    - name: List DLL dependencies
+      run: objdump -p builddir-windows/opendcdiag.exe | grep DLL\ Name
     - name: confirm OpenDCDiag runs
       run: |
-        wine builddir-windows-cross/opendcdiag.exe --version
-        wine builddir-windows-cross/opendcdiag.exe --dump-cpu-info
+        builddir-windows/opendcdiag --version
+        builddir-windows/opendcdiag --dump-cpu-info
     - name: run selftests
-      run: SANDSTONE_BIN=builddir-windows-cross/opendcdiag.exe bats -t bats/sanity-check
+      run: SANDSTONE_BIN=builddir-windows/opendcdiag.exe bats-core/bin/bats -t bats/sanity-check
     - name: run tests quickly
       run: |
-        ulimit -St 120
         nproc=`nproc`
         nproc=$((nproc > 4 ? 4 : nproc))
-        wine builddir-windows-cross/opendcdiag.exe --quick --retest-on-failure=0 -n$nproc -o -
+        builddir-windows/opendcdiag --quick -n$nproc --retest-on-failure=0 -o -

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,6 +48,11 @@ jobs:
       run: meson setup builddir -Dssl_link_type=dynamic -Dbuildtype=debugoptimized
     - name: ninja build
       run: ninja -C builddir
+    - uses: actions/upload-artifact@v4
+      with:
+        name: linux-${{ matrix.name }}-binary
+        path: builddir/opendcdiag
+        retention-days: 3
     - name: confirm opendcdiag runs
       run: |
         builddir/opendcdiag --version
@@ -69,6 +74,15 @@ jobs:
         nproc=`nproc`
         nproc=$((nproc > 4 ? 4 : nproc))
         builddir/opendcdiag --quick -n$nproc --retest-on-failure=0 -o -
+    - name: upload test run logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-linux-${{ matrix.name }}-logs
+        if-no-files-found: ignore
+        path: |
+          *.yaml
+        retention-days: 3
 
 
   Windows:
@@ -112,6 +126,11 @@ jobs:
       run: ninja -C builddir-windows
     - name: List DLL dependencies
       run: objdump -p builddir-windows/opendcdiag.exe | grep DLL\ Name
+    - uses: actions/upload-artifact@v4
+      with:
+        name: windows-binary
+        path: builddir-windows/opendcdiag.exe
+        retention-days: 3
     - name: confirm OpenDCDiag runs
       run: |
         builddir-windows/opendcdiag --version
@@ -123,3 +142,12 @@ jobs:
         nproc=`nproc`
         nproc=$((nproc > 4 ? 4 : nproc))
         builddir-windows/opendcdiag --quick -n$nproc --retest-on-failure=0 -o -
+    - name: upload test run logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-windows-logs
+        if-no-files-found: ignore
+        path: |
+          *.yaml
+        retention-days: 3

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1436,11 +1436,13 @@ selftest_crash_common() {
     # 0xC0000409 is STATUS_STACK_BUFFER_OVERRUN, which is not a buffer overrun
     # - see https://devblogs.microsoft.com/oldnewthing/20190108-00/?p=100655
     #       https://devblogs.microsoft.com/oldnewthing/20080404-00/?p=22863
-    selftest_crash_common selftest_abortinit SIGABRT '0xC0000602 || value == 0xC0000409' "Aborted"
+    selftest_crash_common selftest_abortinit SIGABRT '0xC0000602 || value == 0xC0000409' \
+                          "Aborted|Program self-triggered abnormal termination"
 }
 
 @test "selftest_abort" {
-    selftest_crash_common selftest_abort SIGABRT '0xC0000602 || value == 0xC0000409' "Aborted"
+    selftest_crash_common selftest_abort SIGABRT '0xC0000602 || value == 0xC0000409' \
+                          "Aborted|Program self-triggered abnormal termination"
 }
 
 @test "selftest_sigill" {

--- a/meson.build
+++ b/meson.build
@@ -79,10 +79,10 @@ else
     ]
 endif
 
-if get_option('static_libstdcpp') == true
-add_project_link_arguments([
-    '-static-libstdc++',
-], language : 'cpp')
+if get_option('static_libstdcpp') == true or target_machine.system() == 'windows'
+    add_project_link_arguments([
+        '-static-libstdc++',
+    ], language : 'cpp')
 endif
 
 nasm_system_flags = [
@@ -321,7 +321,7 @@ executable(
 summary({
         'Logging format': get_option('logging_format'),
         'Using -march': march_base,
-        'Static libstdc++': get_option('static_libstdcpp'),
+        'Static libstdc++': get_option('static_libstdcpp') or target_machine.system() == 'windows',
         'Executable name': get_option('executable_name'),
         'Fallback executable name': get_option('fallback_exec'),
     },


### PR DESCRIPTION
The upgrade to Fedora 41 was not a good idea (PR #587). The WINE in that system is giving us trouble and I haven't been able to figure out what it was. Instead, let's run on Windows for real.

To do that, we need to switch to UCRT, because the MSVCRT-based build was having problems, like for example the `tmpfile()` function failing. Since Fedora doesn't have UCRT build packages, we have to build *on* Windows now.

I had resisted doing that because it used to take much longer to build on Windows, especially package installation, but it seems to have improved.

| Step                    | Cross-compiling | Native |
|---|---|---|
| Installing dependencies | 32 + 44 =  76 s |  182 s |
| Compilation             | 2 + 171 = 173 s |  285 s |
| Run tests               |           187 s |  100 s |
| Total                   |           436 s |  567 s |

There are a couple of other, minor changes to the CI, including the ability to save artefacts for later debugging.