### PR TITLE
FW: fix mismatch between - and _ in the AMX feature names

### DIFF
--- a/framework/scripts/x86simd_generate.pl
+++ b/framework/scripts/x86simd_generate.pl
@@ -76,6 +76,7 @@ while (<FH>) {
             unless grep {$_ eq $arch} @architecture_names;
     } elsif (s/^xsave=//) {
         my ($name, $value, $required) = split /\s+/;
+        $required =~ s/[^a-z0-9_,]/_/g;
         push @xsaveStates,
             { id => $name, value => $value, required_for => $required, comment => $comment };
     } else {
@@ -92,6 +93,7 @@ while (<FH>) {
 
         my $id = uc($name);
         $id =~ s/[^A-Z0-9_]/_/g;
+        $depends =~ s/[^a-z0-9_,]/_/g;
         push @features,
         { name => $name, depends => $depends, id => $id, bit => $bit, leaf => $function, comment => $comment };
         $feature_ids{$name} = $i;


### PR DESCRIPTION
The GCC feature names (for `-m` and `__attribute__((target(xxx)))`) use a dash, but the identifiers, by necessity, use an underscore. This caused the XSAVE requirement "amx-tile" to not match feature "amx_tile". The same problem would have happened for "sse4.1" and "sse4.2", but there's no XSAVE feature for those.

That caused the script to emit:
```c++
// List of features requiring XSave_AmxState
static const uint64_t XSaveReq_AmxState = 0
        | cpu_feature_amx_bf16
        | cpu_feature_amx_int8
        | cpu_feature_amx_fp16;
```

As a result, a test that only required `amx_tile` would *not* get disabled if we couldn't enable the XSAVE state via the Linux `arch_prctl(2)` API or if the OS did not enable it with XGETBV.

Now it emits:
```c++
// List of features requiring XSave_AmxState
static const uint64_t XSaveReq_AmxState = 0
        | cpu_feature_amx_bf16
        | cpu_feature_amx_tile
        | cpu_feature_amx_int8
        | cpu_feature_amx_fp16;
```