### PR TITLE
FW: initialize rescheduling on first use

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1041,6 +1041,54 @@ int num_packages() {
     return Topology::topology().packages.size();
 }
 
+namespace {
+class QueueDeviceSchedule : public DeviceSchedule
+{
+public:
+    int get_next_cpu() override
+    {
+        // Returns next CPU from the queue
+        std::lock_guard lock(q_mutex);
+        if (q_idx >= queue.size())
+            shuffle_queue();
+        return queue[q_idx++];
+    }
+
+    void populate_devices_info() override
+    {
+        // Populate queue with the indexes available
+        for (int i=0; i<num_cpus(); i++)
+            queue.push_back(i);
+        shuffle_queue();
+    }
+
+private:
+    int q_idx = 0;
+    std::vector<int> queue;
+    std::mutex q_mutex;
+
+    void shuffle_queue()
+    {
+        // Must be called with mutex locked
+        std::default_random_engine rng(random32());
+        std::shuffle(queue.begin(), queue.end(), rng);
+        q_idx = 0;
+    }
+};
+
+class RandomDeviceSchedule : public DeviceSchedule
+{
+public:
+    int get_next_cpu() override
+    {
+        // return random cpu
+        return random32() % num_cpus();
+    }
+
+    void populate_devices_info() override {}
+};
+} // unnamed namespace
+
 void reschedule()
 {
     if (sApp->device_schedule == nullptr) return;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -327,7 +327,6 @@ private:
 class DeviceSchedule {
 public:
     virtual int get_next_cpu() = 0;
-    virtual void populate_devices_info() = 0;
     virtual ~DeviceSchedule() = default;
 };
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -331,52 +331,6 @@ public:
     virtual ~DeviceSchedule() = default;
 };
 
-class QueueDeviceSchedule : public DeviceSchedule {
-public:
-    QueueDeviceSchedule() {}
-
-    int get_next_cpu() override
-    {
-        // Returns next CPU from the queue
-        std::lock_guard lock(q_mutex);
-        if (q_idx >= queue.size())
-            shuffle_queue();
-        return queue[q_idx++];
-    }
-
-    void populate_devices_info() override
-    {
-        // Populate queue with the indexes available
-        for (int i=0; i<num_cpus(); i++)
-            queue.push_back(i);
-        shuffle_queue();
-    }
-
-private:
-    int q_idx = 0;
-    std::vector<int> queue;
-    std::mutex q_mutex;
-
-    void shuffle_queue() {
-        // Must be called with mutex locked
-        std::default_random_engine rng(random32());
-        std::shuffle(queue.begin(), queue.end(), rng);
-        q_idx = 0;
-    }
-};
-
-class RandomDeviceSchedule : public DeviceSchedule {
-public:
-    RandomDeviceSchedule() {}
-
-    int get_next_cpu() override {
-        // return random cpu
-        return random32() % num_cpus();
-    }
-
-    void populate_devices_info() override {}
-};
-
 struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>
 {
     enum class OutputFormat : int8_t {


### PR DESCRIPTION
 This fixes running it in `--fork=no` mode, because we don't require something in `child_run()`. Moreover, it also makes the start up of tests that don't ever `reschedule()` be faster.
