### PR TITLE
FW: make it clear --reschedule doesn't work in exec mode (Windows)

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1907,8 +1907,9 @@ selftest_cpuset_negated() {
 
 # Confirm we are rescheduling properly
 @test "thread queue reschedule" {
-    if $is_windows; then
-        skip "Windows not working yet"
+    run $SANDSTONE -n1 --selftests -e selftest_logs_reschedule --reschedule=queue
+    if [[ $status == 64 ]]; then
+       skip "Not supported"
     fi
 
     local -a cpuset=(`$SANDSTONE --dump-cpu-info | awk '/^[0-9]/ { print $1 }'`)

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -3657,10 +3657,17 @@ int main(int argc, char **argv)
         usage(argv);
         return EX_USAGE;
     }
-    if (sApp->shmem->log_test_knobs && sApp->current_fork_mode() == SandstoneApplication::exec_each_test) {
-        fprintf(stderr, "%s: error: --test-option is not supported in this configuration\n",
-                program_invocation_name);
-        return EX_USAGE;
+    if (sApp->current_fork_mode() == SandstoneApplication::exec_each_test) {
+        if (sApp->shmem->log_test_knobs) {
+            fprintf(stderr, "%s: error: --test-option is not supported in this configuration\n",
+                    program_invocation_name);
+            return EX_USAGE;
+        }
+        if (sApp->device_schedule) {
+            fprintf(stderr, "%s: error: --reschedule is not supported in this configuration\n",
+                    program_invocation_name);
+            return EX_USAGE;
+        }
     }
 
     if (sApp->total_retest_count < -1 || sApp->retest_count == 0)


### PR DESCRIPTION
Because the `sApp->device_schedule` class hasn't been created in the child process.

This can be fixed by delaying the creation until `exec_mode_run()`, with some information passed to the child via the shmem block. This isn't necessary for now.