### PR TITLE
FW/child_debug: identify #VE and #CP fault names on x86

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -888,7 +888,8 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
             "OF", "BR", "UD", "NM",
             "DF", "MF", "TS", "NP",
             "SS", "GP", "PF", "spu",
-            "MF", "AC", "MC", "XF",
+            "MF", "AC", "MC", "XM",
+            "VE", "CP",
         };
         const char *trap_name = "??";
         if (ctx.trap_nr == 32)


### PR DESCRIPTION
And fix the name of interrupt 19 (SIMD Floating-Point Exception) to `#XM`. The name `XF` comes from the Linux kernel constant `X86_TRAP_XF`, but that doesn't match the Intel manual (SDM Volume 3, Chapter 7).

`#VE` is "Virtualization Exception", which we are unlikely to get.

`#CP` is "Control Protection Exception", which we can get in userspace.