### PR TITLE
Move generation of gitid.h to the framework

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -33,6 +33,18 @@ generated_cpu_features_h = configure_file(
     ],
 )
 
+configure_file(
+    input : [
+        'scripts/make-gitid.pl',
+    ],
+    output : 'gitid.h',
+    encoding : 'ascii',
+    command : [
+        perl, '@INPUT0@', '@OUTPUT@', 'opendcdiag', get_option('version_suffix')
+    ],
+)
+
+
 generated_builtin_test_list = []
 builtin_test_list_inputs = get_option('builtin_test_list')
 generated_builtin_test_list += custom_target(

--- a/meson.build
+++ b/meson.build
@@ -258,16 +258,6 @@ target_deps += [
     pthread_dep,
 ]
 
-generated_gitid_h = configure_file(
-    input : [
-        'framework/scripts/make-gitid.pl',
-    ],
-    output : 'gitid.h',
-    encoding : 'ascii',
-    command : [
-        perl, '@INPUT0@', '@OUTPUT@', 'opendcdiag', get_option('version_suffix')
-    ],
-)
 top_incdir = include_directories('.')
 
 # Subdirs add (static) libraries to these arrays for linking


### PR DESCRIPTION
Commit moves the call to `make-gitid.pl` script from the top-level meson.build to the framework's meson file. This way framework's build files are more self-contained and the top-level build doesn't have to explicitly invoke the script.