### PR TITLE
Move call to `gitid.pl` to framework's meson file

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -33,6 +33,17 @@ generated_cpu_features_h = configure_file(
     ],
 )
 
+configure_file(
+    input : [
+        'scripts/make-gitid.pl',
+    ],
+    output : 'gitid.h',
+    encoding : 'ascii',
+    command : [
+        perl, '@INPUT0@', '@OUTPUT@', 'opendcdiag', get_option('version_suffix')
+    ],
+)
+
 generated_builtin_test_list = []
 builtin_test_list_inputs = get_option('builtin_test_list')
 generated_builtin_test_list += custom_target(

--- a/meson.build
+++ b/meson.build
@@ -258,16 +258,6 @@ target_deps += [
     pthread_dep,
 ]
 
-generated_gitid_h = configure_file(
-    input : [
-        'framework/scripts/make-gitid.pl',
-    ],
-    output : 'gitid.h',
-    encoding : 'ascii',
-    command : [
-        perl, '@INPUT0@', '@OUTPUT@', 'opendcdiag', get_option('version_suffix')
-    ],
-)
 top_incdir = include_directories('.')
 
 # Subdirs add (static) libraries to these arrays for linking


### PR DESCRIPTION
Commit moves the call to the `scripts/make-gitid.pl` script from the top-level meson.build file to framework's file. This way top level doesn't have to explicitly invoke the script, making the framework more self-contained.