### PR TITLE
FW:Fix _strdup Interception for MinGW Builds

### DIFF
--- a/framework/sysdeps/windows/aligned_alloc.cpp
+++ b/framework/sysdeps/windows/aligned_alloc.cpp
@@ -110,6 +110,11 @@ char *strdup(const char *str)
     return static_cast<char *>(memcpy(newstr, str, strlen(str) + 1));
 }
 
+// Fake a DLL import to _strdup pointing back to our strdup() above.
+// We need to do this because MinGW's <string.h> unconditionally declares _strdup()
+// as __declspec(dllimport).
+extern const auto __imp__strdup = &strdup;
+
 char *strndup(const char *str, size_t n)
 {
     size_t len = strnlen(str, n);


### PR DESCRIPTION
This commit addresses an issue with builds compiled using the MinGW toolchain where the strdup function is not correctly intercepted due to the use of `_strdup` in MinGW's <string.h>. MinGW unconditionally declares `_strdup()` as `__declspec(dllimport)`, which causes calls to _strdup to bypass the custom strdup implementation.
https://github.com/mingw-w64/mingw-w64/blob/a421d2c0c68396bc342053c9348de85ecafa057e/mingw-w64-headers/crt/string.h#L67-L74

Libhwloc, a library for hardware locality, specifically calls `_strdup` instead of `strdup` for Windows compatibility. This means that simply defining `strdup` as we do for other functions in the file is insufficient, as it does not intercept `_strdup` calls. To resolve this, we fake DLL import to `_strdup` that points back to the custom `strdup()` implementation. This ensures that all calls to `_strdup` are correctly intercepted and handled.


