### PR TITLE
Selftests: Fix build: impossible constraint

### DIFF
--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -934,7 +934,7 @@ static int selftest_inject_idle(struct test *test, int cpu)
             int a_variable = cpu * 2;
             a_variable += 1;
             // use the result so the compiler doesn't optimize this away
-            __asm__ ("" : "+gv" (a_variable));
+            __asm__ volatile ("" : "+g" (a_variable));
         }
     }
     auto loop_end = std::chrono::steady_clock::now();


### PR DESCRIPTION
Some compilers didn't like this "+gv" constraint:
```
selftest.cpp:937:13: error: impossible constraint in 'asm'
  937 |             __asm__ ("" : "+gv" (a_variable));
      |             ^~~~~~~
```

But we don't need the "v" here because we know `a_variable` is an integer, therefore can only be stored in a general purpose register and "g" is slightly more general-purpose than "r":

```
‘g’
     Any register, memory or immediate integer operand is allowed,
     except for registers that are not general registers.
...
‘r’
     A register operand is allowed provided that it is in a general
     register.
```
https://gcc.gnu.org/onlinedocs/gcc/Simple-Constraints.html

Also add the `volatile` marker, otherwise the compiler eliminates because we didn't use the result of the statement.

