### PR TITLE
FW/ContextDump: update the C API to return a buffer

### DIFF
--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -520,20 +520,22 @@ void dump_xsave(std::string &f, const void *xsave_area, size_t xsave_size, int x
 }
 
 // C API
-void dump_gprs(FILE *f, SandstoneMachineContext mc)
+char *dump_gprs(SandstoneMachineContext mc)
 {
     std::string out;
     dump_gprs(out, mc);
     if (out.size())
-        fwrite(out.c_str(), 1, out.size(), f);
+        return strdup(out.c_str());
+    return nullptr;
 }
 
-void dump_xsave(FILE *f, const void *xsave_area, size_t xsave_size, int xsave_dump_mask)
+char *dump_xsave(const void *xsave_area, size_t xsave_size, int xsave_dump_mask)
 {
     std::string out;
     dump_xsave(out, xsave_area, xsave_size, xsave_dump_mask);
     if (out.size())
-        fwrite(out.c_str(), 1, out.size(), f);
+        return strdup(out.c_str());
+    return nullptr;
 }
 
 #endif // x86-64

--- a/framework/sandstone_context_dump.h
+++ b/framework/sandstone_context_dump.h
@@ -6,8 +6,6 @@
 #ifndef SANDSTONE_CONTEXT_DUMP_H
 #define SANDSTONE_CONTEXT_DUMP_H
 
-#include <stdio.h>
-
 #if defined(__APPLE__)
 #  include <sys/ucontext.h>
 typedef mcontext_t SandstoneMachineContext;
@@ -26,8 +24,8 @@ typedef const struct _CONTEXT *SandstoneMachineContext;
 extern "C" {
 #endif
 
-extern void dump_gprs(FILE *, SandstoneMachineContext);
-extern void dump_xsave(FILE *, const void *xsave_area, size_t xsave_size, int xsave_dump_mask);
+extern char *dump_gprs(SandstoneMachineContext);
+extern char *dump_xsave(const void *xsave_area, size_t xsave_size, int xsave_dump_mask);
 
 #ifdef __cplusplus
 }

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -901,6 +901,8 @@ static const kvm_config_t *selftest_kvm_config_real_setup_check()
 
 BEGIN_ASM_FUNCTION(payload_prot_64bit_fail)
     asm("mov $1, %eax\n"
+        "fld1\n"
+        "pcmpeqb %xmm0, %xmm0\n"
         "hlt");
 END_ASM_FUNCTION()
 
@@ -918,6 +920,7 @@ static const kvm_config_t *selftest_kvm_config_prot_64bit_fail()
 
 BEGIN_ASM16_FUNCTION(payload_real_16bit_fail)
     asm("mov $1, %ax\n"
+        "fld1\n"
         "hlt");
 END_ASM_FUNCTION()
 


### PR DESCRIPTION
This completes the removal of `FILE *` in the API. This allowed for a much more easier inclusion of the CPU register context in kvm.c.