### PR TITLE
Self tests: Run with threads from two different cores.

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1698,7 +1698,7 @@ function check_gdb_usable() {
     fi
 
     declare -A yamldump
-    selftest_crash_context_common -n2 --timeout=5m -e selftest_sigsegv --on-crash=backtrace --max-cores-per-slice=1
+    selftest_crash_context_common --cpuset=t0 -n2 --timeout=5m -e selftest_sigsegv --on-crash=backtrace --max-cores-per-slice=1
 
     # We should have as output two main threads and two worker threads
     test_yaml_regexp "/tests/0/threads/0/thread" "main"


### PR DESCRIPTION
Slicing would not separate threads from the same core into different slices. When running the test on real hardware (and topology), -n2 and --max-cores-per-slice=1 do not result in two separate slices and the test will not find the main thread for the second slice in the output and, thus, will fail. --cpuset=t0 ensures that only 1 thread from a core is taken and will work if the topology has more than one core.