### PR TITLE
Framework: Add `TestObsolete` skip category.

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -475,6 +475,8 @@ static const char *char_to_skip_category(int val)
         return "OSResourceIssue";
     case IgnoredMceCategory:
         return "IgnoredMceCategory";
+    case TestObsoleteSkipCategory:
+        return "TestObsolete";
     }
 
     return "NO CATEGORY PRESENT";

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -94,6 +94,7 @@ typedef enum SkipCategory {
     UnknownSkipCategory,
     IgnoredMceCategory,
     RuntimeSkipCategory,
+    TestObsoleteSkipCategory,
     SelftestSkipCategory,
 } SkipCategory;
 


### PR DESCRIPTION
There are multiple reasons one may want to remove or make obsolete an existing content.
This commit purpose is to give means to developer to leave message for the user to explain what happened to the test.
We can not rely on release notes on this matter.
    
Making the obsolete test quality to `SKIP` is not an answer either as we do not leave any message when skipping due to test quality.
    
[ChangeLog] Added new runtime skip category called `TestObsolete`.