### PR TITLE
C23 hygiene: FW sysdeps, forkfd: stop using obsolete ATOMIC_VAR_INIT macro

### DIFF
--- a/framework/forkfd/forkfd_c11.h
+++ b/framework/forkfd/forkfd_c11.h
@@ -51,7 +51,7 @@ typedef atomic_int ffd_atomic_int;
 #ifdef __cpp_lib_atomic_value_initialization
 #define FFD_ATOMIC_INIT(val)        { val }
 #else
-#define FFD_ATOMIC_INIT(val)        ATOMIC_VAR_INIT(val)
+#define FFD_ATOMIC_INIT(val)        (val)
 #endif
 
 #define ffd_atomic_load(ptr, order) \

--- a/framework/sysdeps/linux/msr.c
+++ b/framework/sysdeps/linux/msr.c
@@ -16,7 +16,7 @@
 
 #include "sandstone_p.h"
 
-static atomic_bool msr_access_denied = ATOMIC_VAR_INIT(false);
+static atomic_bool msr_access_denied = 0;
 
 static void try_load_kmod()
 {

--- a/framework/sysdeps/unix/tmpfile.c
+++ b/framework/sysdeps/unix/tmpfile.c
@@ -52,7 +52,7 @@ static int try_open_tmpfile(const char *dir, int ocloexec)
 static int try_open_regular_tmpfile(const char *dir, int ocloexec)
 {
     /* opens a regular, temporary file but deletes it before returning */
-    static atomic_uint seq_nr = ATOMIC_VAR_INIT(0);
+    static atomic_uint seq_nr = 0;
     char *name;
     int fd;
     int saved_errno;
@@ -84,7 +84,7 @@ int open_memfd(enum MemfdCloexecFlag flag)
         return fd;
 
     // try O_TMPFILE
-    static _Atomic(const char *) s_dir = ATOMIC_VAR_INIT(NULL);
+    static _Atomic(const char *) s_dir = 0;
     const char *dir = atomic_load_explicit(&s_dir, memory_order_acquire);
     __auto_type opener = &try_open_tmpfile;
 


### PR DESCRIPTION
`ATOMIC_VAR_INIT` macro was removed in C23 standard, so best to stop using it to future-proof the codebase.

Folks are free to check C23 hygiene by configuring with:
```sh
meson setup -Dc_std=gnu23 <...>
```

I'd be more than happy to squash these commits.