### PR TITLE
FW/KVM: set OSXMMEXCPT and OSXSAVE bits in CR4 to run AVX

### DIFF
--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -389,6 +389,8 @@ static int kvm_prot64_setup_sregs(int cpu_fd, struct kvm_sregs *sregs)
     // Enable 64-bit protected mode
     sregs->cr0 |= X86_CR0_PE;
     sregs->cr4 |= X86_CR4_OSFXSR;
+    sregs->cr4 |= X86_CR4_OSXMMEXCPT;
+    sregs->cr4 |= X86_CR4_OSXSAVE;
     sregs->efer |= EFER_LMA;
     sregs->efer |= EFER_LME;
 


### PR DESCRIPTION
Otherwise, we get #UD when trying to run any AVX instruction. This complements commit 06dc207458db78ccf83b69c4e505dece3778699c, which enabled FXSAVE support and thus SSE instructions.