### PR TITLE
FW/KVM: don't try to set XCRS on systems without XSAVE

### DIFF
--- a/framework/sysdeps/linux/kvm.c
+++ b/framework/sysdeps/linux/kvm.c
@@ -486,9 +486,11 @@ static int kvm_generic_setup_vcpu(kvm_ctx_t *ctx)
             ret = kvm_prot64_setup_sregs(ctx->cpu_fd, &sregs);
             if (ret < 0)
                 return EXIT_FAILURE;
-            ret = kvm_prot64_setup_xsave(ctx->cpu_fd);
-            if (ret < 0)
-                return EXIT_FAILURE;
+            if (cpu_has_feature(cpu_feature_avx)) {
+                ret = kvm_prot64_setup_xsave(ctx->cpu_fd);
+                if (ret < 0)
+                    return EXIT_FAILURE;
+            }
 
             ret = kvm_prot64_setup_payload(ctx);
             if (ret < 0)


### PR DESCRIPTION
The kernel doesn't like that:
```c
static int kvm_vcpu_ioctl_x86_set_xcrs(struct kvm_vcpu *vcpu,
				       struct kvm_xcrs *guest_xcrs)
{
	int i, r = 0;
	if (!boot_cpu_has(X86_FEATURE_XSAVE))
		return -EINVAL;
```

This change is a no-op for our regular `-march=haswell` build because AVX requires XSAVE.