### PR TITLE
FW: Do allow test groups for obfuscate-test-name mode

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -170,11 +170,10 @@ typedef enum TestQuality {
 
 #ifndef DECLARE_TEST
 #  define DECLARE_TEST(test_id, test_description)       DECLARE_TEST_INNER(test_id, test_description)
-#  define DECLARE_TEST_GROUPS(...) \
-    __extension__ (const struct test_group* const[]){ __VA_ARGS__, NULL }
-#else
-#  define DECLARE_TEST_GROUPS(...)                      NULL
 #endif
+
+#define DECLARE_TEST_GROUPS(...)                                      \
+    __extension__ (const struct test_group* const[]){ __VA_ARGS__, NULL }
 
 #define END_DECLARE_TEST   };
 


### PR DESCRIPTION
The old repository said

> When a replacement macro is defined, we'll suppress the test description and test groups too.

But I didn't write in the commit message why I wanted to suppress them. This is now causing problems for the tests that rely on the group's `group_init` doing something, like detecting whether certain functionality is possible or not (e.g., SELinux enforcing no SMC).