### PR TITLE
Fix SegFaults when building with `restricted-cmdline`

### DIFF
--- a/framework/sandstone_test_groups.cpp
+++ b/framework/sandstone_test_groups.cpp
@@ -5,11 +5,8 @@
 
 #include "sandstone_p.h"
 
-#if SANDSTONE_RESTRICTED_CMDLINE
-#  define TEST_GROUP(name, descr)   .id = nullptr, .description = nullptr
-#else
-#  define TEST_GROUP(name, descr)   .id = name, .description = descr
-#endif
+#define TEST_GROUP(name, descr)   .id = name, .description = descr
+
 #define TEST_GROUP_ATTRIBUTES                                           \
     __attribute__((section(SANDSTONE_SECTION_PREFIX "test_group"), aligned(8)))
 


### PR DESCRIPTION
This is a fix for side effect from https://github.com/opendcdiag/opendcdiag/pull/626. I reviewed that PR wrong building my test build without `restricted-cmdline` option. Building with it causes the application to Seg Fault.