### PR TITLE
Meson: fix warning about using set01() with value 0

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -77,9 +77,9 @@ framework_config.set('SANDSTONE_DEFAULT_LOGGING', 'SandstoneApplication::OutputF
 
 framework_config.set10('SANDSTONE_RESTRICTED_CMDLINE', get_option('framework_options').contains('restricted-cmdline'))
 if get_option('framework_options').contains('no-child-debug')
-    framework_config.set10('SANDSTONE_CHILD_DEBUG_CRASHES', 0)
-    framework_config.set10('SANDSTONE_CHILD_DEBUG_HANGS', 0)
-    framework_config.set10('SANDSTONE_CHILD_BACKTRACE', 0)
+    framework_config.set10('SANDSTONE_CHILD_DEBUG_CRASHES', false)
+    framework_config.set10('SANDSTONE_CHILD_DEBUG_HANGS', false)
+    framework_config.set10('SANDSTONE_CHILD_BACKTRACE', false)
 else
     framework_config.set10('SANDSTONE_CHILD_DEBUG_CRASHES', not get_option('framework_options').contains('no-child-debug-crashes'))
     framework_config.set10('SANDSTONE_CHILD_DEBUG_HANGS', not get_option('framework_options').contains('no-child-debug-hangs'))


### PR DESCRIPTION
Isn't that what the name implies?

```
framework/meson.build:80: DEPRECATION: configuration_data.set10 with number. The `set10` method should only be used with booleans
framework/meson.build:81: DEPRECATION: configuration_data.set10 with number. The `set10` method should only be used with booleans
framework/meson.build:82: DEPRECATION: configuration_data.set10 with number. The `set10` method should only be used with booleans
```