### PR TITLE
FW: don't populate the all_group_map in restricted cmdline mode

### DIFF
--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -34,12 +34,16 @@ void SandstoneTestSet::load_all_tests()
 {
     std::span<struct test> known_tests = cfg.is_selftest ? selftests : regular_tests;
 
-    for (struct test &t : known_tests) {
-        all_tests.push_back(&t);
-        for (auto ptr = t.groups; ptr && *ptr; ++ptr) {
-            all_group_map[(*ptr)->id].push_back(&t);
+    if (!SandstoneConfig::RestrictedCommandLine) {
+        // only populate all_group_map if we're parsing command-line
+        for (struct test &t : known_tests) {
+            all_tests.push_back(&t);
+            for (auto ptr = t.groups; ptr && *ptr; ++ptr) {
+                all_group_map[(*ptr)->id].push_back(&t);
+            }
         }
     }
+
     /* add "special" mce_check as well */
     all_tests.push_back(&mce_test);
 }


### PR DESCRIPTION
In that mode, there is no `--list-groups` or `--enable` option to select test by group names, so there's no point in having this map populated. This fixes a crash on start of Intel's DCDiag tool, introduced by commit 4195782b31d10195942b43c3fe7c03fcaec3ac04:

```
#0  __strlen_evex () at ../sysdeps/x86_64/multiarch/strlen-evex-base.S:81
#1  0x000000000046610f in std::char_traits<char>::length (__s=0x0) at /usr/local/include/c++/14/bits/char_traits.h:391
#2  0x0000000000467e3c in std::basic_string_view<char, std::char_traits<char> >::basic_string_view (this=0x7fffffffdef0, __str=0x0)
    at /usr/local/include/c++/14/string_view:141
#3  0x00000000004a40ae in SandstoneTestSet::load_all_tests (this=0x5d4f4d0) at ../opendcdiag/framework/sandstone_tests.cpp:40
#4  0x00000000004a447f in SandstoneTestSet::SandstoneTestSet (this=0x5d4f4d0, cfg=..., flags=0) at ../opendcdiag/framework/sandstone_tests.cpp:75
#5  0x000000000047a9fc in main (argc=1, argv=0x7fffffffe358) at ../opendcdiag/framework/sandstone.cpp:2900
```