### PR TITLE
FW: don't require test descriptions if we're not logging

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2420,8 +2420,8 @@ get_next_test(SandstoneTestSet::EnabledTestList::iterator next_test)
     }
 
     assert(next_test->test->id);
-    assert(next_test->test->description);
     assert(strlen(next_test->test->id));
+    assert(SandstoneConfig::NoLogging || next_test->test->description);
     return next_test;
 }
 


### PR DESCRIPTION
When we're not producing a log file, we don't need the descriptions. This is the operating mode for Intel DCDiag.