### PR TITLE
Fix: Populate all_tests but not all_group_map.

### DIFF
--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -33,11 +33,10 @@ struct test mce_test = {
 void SandstoneTestSet::load_all_tests()
 {
     std::span<struct test> known_tests = cfg.is_selftest ? selftests : regular_tests;
-
-    if (!SandstoneConfig::RestrictedCommandLine) {
-        // only populate all_group_map if we're parsing command-line
-        for (struct test &t : known_tests) {
-            all_tests.push_back(&t);
+    for (struct test &t : known_tests) {
+        all_tests.push_back(&t);
+        if (!SandstoneConfig::RestrictedCommandLine) {
+            // only populate all_group_map if we're parsing command-line
             for (auto ptr = t.groups; ptr && *ptr; ++ptr) {
                 all_group_map[(*ptr)->id].push_back(&t);
             }


### PR DESCRIPTION
The change in https://github.com/opendcdiag/opendcdiag/pull/631 was too excessive. This resulted in test failures with exit error: `EX_DATAERR`

We hit it in `exec_mode_run`

See: `if (tests_to_run.size() != 1) return EX_DATAERR;`

The affected build was Windows build but not Linux.