### PR TITLE
FW/Topology: extract more information (module, tile, and NUMA node ID)

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1316,11 +1316,11 @@ static void dump_cpu_info()
     printf("Detected CPU: %s; family-model-stepping (hex): %02x-%02x-%02x; CPU features: %s\n",
            detected, cpu_info[0].family, cpu_info[0].model, cpu_info[0].stepping,
            cpu_features_to_string(cpu_features).c_str());
-    printf("# CPU\tPkgID\tCoreID\tThrdID\tMicrocode\tPPIN\n");
+    printf("# CPU\tPkgID\tCoreID\tThrdID\tModId\tMicrocode\tPPIN\n");
     for (i = 0; i < num_cpus(); ++i) {
-        printf("%d\t%d\t%d\t%d\t0x%" PRIx64, cpu_info[i].cpu_number,
+        printf("%d\t%d\t%d\t%d\t%d\t0x%" PRIx64, cpu_info[i].cpu_number,
                cpu_info[i].package_id, cpu_info[i].core_id, cpu_info[i].thread_id,
-               cpu_info[i].microcode);
+               cpu_info[i].module_id, cpu_info[i].microcode);
         if (cpu_info[i].ppin)
             printf("\t%016" PRIx64, cpu_info[i].ppin);
         puts("");

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -363,10 +363,23 @@ struct cache_info {
 struct cpu_info {
     uint64_t ppin;          ///! Processor ID read from MSR
     uint64_t microcode;     ///! Microcode version read from /sys
-    int cpu_number;         ///! Logical processor number as seen by OS
-    int thread_id;          ///! Topology info from APIC
-    int core_id;            ///! Topology info from APIC
-    int package_id;         ///! Topology info from APIC
+
+    /// Logical OS processor number.
+    /// On Unix systems, this is a sequential ID; on Windows, it encodes
+    /// 64 * ProcessorGroup + ProcessorNumber
+    int cpu_number;
+
+    /// Thread ID inside a core, usually 0 or 1 (-1 if not known).
+    int16_t thread_id;
+    /// Core ID inside of a package, -1 if not known.
+    int16_t core_id;
+    /// Module ID inside of a package, -1 if not known.
+    int16_t module_id;
+    /// Tile ID inside of a package, -1 if not known. May combine with the die ID.
+    int16_t tile_id;
+    /// Package ID in the system, -1 if not known.
+    int16_t package_id;
+
     struct cache_info cache[3]; ///! Cache info from OS
     uint8_t family;         ///! CPU family (usually 6)
     uint8_t stepping;       ///! CPU stepping

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -26,6 +26,9 @@
 #   include <windows.h>
 #endif
 
+static void update_topology(std::span<const struct cpu_info> new_cpu_info,
+                            std::span<const Topology::Package> sockets = {});
+
 namespace {
 struct auto_fd
 {

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -319,13 +319,22 @@ static bool fill_topo_sysfs(struct cpu_info *info)
     f = fopenat(cpufd, "topology/physical_package_id");
     if (!f)
         return false;
-    IGNORE_RETVAL(fscanf(f, "%d", &info->package_id));
+    IGNORE_RETVAL(fscanf(f, "%hd", &info->package_id));
     fclose(f);
+
+    // Linux doesn't appear to have information about tiles
+
+    f = fopenat(cpufd, "topology/cluster_id");
+    if (f) {
+        // Linux calls them modules "clusters"
+        IGNORE_RETVAL(fscanf(f, "%hd", &info->tile_id));
+        fclose(f);
+    }
 
     f = fopenat(cpufd, "topology/core_id");
     if (!f)
         return false;
-    IGNORE_RETVAL(fscanf(f, "%d", &info->core_id));
+    IGNORE_RETVAL(fscanf(f, "%hd", &info->core_id));
     fclose(f);
 
     f = fopenat(cpufd, "topology/thread_siblings_list");
@@ -582,41 +591,105 @@ static bool fill_cache_info_cpuid(struct cpu_info *info)
 
 static bool fill_topo_cpuid(struct cpu_info *info)
 {
+    enum Domain {
+        Invalid = 0,
+        Logical = 1,
+        Core = 2,
+        Module = 3,
+        Tile = 4,
+        Die = 5,
+        DieGrp = 6,
+    };
+    // we only want up to Tile
+    constexpr int Package = int(Domain::Tile) + 1;
+
     int curr_cpu = info->cpu_number;
-    int subleaf = 0;
-    uint32_t a, b, c, d;
-    uint32_t smt_mask = 0,
-             core_shift = 0,
-             core_mask = 0,
-             pkg_shift = 0;
+    uint32_t a, b, c, apicid;
 
     if (curr_cpu < 0)
         return false;
     if (!fill_cache_info_cpuid(info))
         return false;
 
-    do {
-        int lvl_type;
-        __cpuid_count(0xb, subleaf, a, b, c, d);
-        if (!b) break;
-        lvl_type = (c >> 8) & 0xff;
-        switch (lvl_type) {
-            case 1:
-                core_shift = a & 0xf;
-                smt_mask = (1 << core_shift) - 1;
-                info->thread_id = d & smt_mask;
-                break;
-            case 2:
-                pkg_shift = a & 0xf;
-                core_mask = (1 << (pkg_shift - core_shift)) - 1;
-                info->core_id = (d >> core_shift) & core_mask;
-                break;
-            default:
-                break;
+    static int8_t leaf;
+    static std::array<uint8_t, Package> widths;
+
+    if (leaf < 0)
+        return false;
+    if (!leaf) {
+        // We'll try first with V2 Extended Topology
+        int subleaf = 0;
+        leaf = 0x1f;
+        __cpuid_count(leaf, subleaf, a, b, c, apicid);
+        if (!b) {
+            // re-try with V1 Extended Topology
+            leaf = 0xb;
+            __cpuid_count(leaf, subleaf, a, b, c, apicid);
         }
-        subleaf++;
-    } while (1);
-    info->package_id = d >> pkg_shift;
+        if (!b) {
+            leaf = -1;
+            return false;       // failed, leaves unknown
+        }
+
+        // extract the domain levels
+        while (b) {
+            int lvl_type = (c >> 8) & 0xff;
+            a &= 0xf;
+            switch (Domain(lvl_type)) {
+            case Domain::Invalid:
+                // this shouldn't happen...
+                b = 0;
+                continue;
+            case Domain::Logical:
+            case Domain::Core:
+            case Domain::Module:
+            case Domain::Tile:
+                widths[lvl_type - 1] = a;
+                break;
+
+            case Domain::Die:
+            case Domain::DieGrp:
+                // ignore
+                break;
+            }
+
+            // the package shift is implied by the largest shift
+            widths[Package - 1] = std::max(uint8_t(a), widths[Package - 1]);
+
+            // get next level
+            subleaf++;
+            __cpuid_count(leaf, subleaf, a, b, c, apicid);
+        }
+    } else {
+        // just get this processor's APIC ID
+        __cpuid_count(leaf, 0, a, b, c, apicid);
+    }
+
+    // process the widths
+    auto extract = [&](uint32_t start, uint32_t end) {
+        uint32_t value = apicid;
+        if (end < 32)
+            value &= ~(~0U << end);
+        value >>= start;
+        return value;
+    };
+
+    uint32_t next = widths[Domain::Core - 1];
+    if (widths[Domain::Module - 1]) {
+        info->module_id = extract(next, widths[Package - 1]);
+        next = widths[Domain::Module - 1];
+    } else {
+        // if neither CPUID nor cache provide module information, we assume module == core
+        info->module_id = info->core_id;
+    }
+    if (widths[Domain::Tile - 1]) {
+        info->tile_id = extract(next, widths[Package - 1]);
+        next = widths[Domain::Tile - 1];
+    }
+
+    info->package_id = extract(widths[Package - 1], -1);
+    info->core_id = extract(widths[Domain::Logical - 1], widths[Package - 1]);
+    info->thread_id = extract(0, widths[Domain::Logical - 1]);
     return info->core_id != -1;
 }
 
@@ -952,6 +1025,8 @@ static void init_topology_internal(const LogicalProcessorSet &enabled_cpus)
         auto info = cpu_info + i;
         info->cpu_number = curr_cpu;
         info->package_id = -1;
+        info->tile_id = -1;
+        info->module_id = -1;
         info->core_id = -1;
         info->thread_id = -1;
 

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -539,7 +539,7 @@ static bool fill_family_cpuid(struct cpu_info *info)
     return true;
 }
 
-static bool fill_cache_info_cpuid(struct cpu_info *info)
+static bool fill_cache_info_cpuid(struct cpu_info *info, uint32_t *max_cpus_sharing_l2)
 {
     /* since info->cache is statically allocated */
     static int max_levels = sizeof(info->cache) / sizeof(*info->cache);
@@ -566,6 +566,8 @@ static bool fill_cache_info_cpuid(struct cpu_info *info)
         sets = c + 1; /* entire ecx plus 1 */
 
         size = ways * parts * line_sz * sets;
+        if (level == 2 && max_cpus_sharing_l2)
+            *max_cpus_sharing_l2 = ((a >> 14) & ((1 << 11) - 1)) + 1; /* eax 11 bits 25:14 plus 1 */
 
         switch (a & 0xf) { /* first four eax bits are type */
             case 1: /* data */
@@ -605,10 +607,11 @@ static bool fill_topo_cpuid(struct cpu_info *info)
 
     int curr_cpu = info->cpu_number;
     uint32_t a, b, c, apicid;
+    uint32_t max_cpus_sharing_l2 = 0;
 
     if (curr_cpu < 0)
         return false;
-    if (!fill_cache_info_cpuid(info))
+    if (!fill_cache_info_cpuid(info, &max_cpus_sharing_l2))
         return false;
 
     static int8_t leaf;
@@ -678,6 +681,14 @@ static bool fill_topo_cpuid(struct cpu_info *info)
     if (widths[Domain::Module - 1]) {
         info->module_id = extract(next, widths[Package - 1]);
         next = widths[Domain::Module - 1];
+    } else if (max_cpus_sharing_l2) {
+        // CPUID didn't provide module information, we assume that a module is
+        // a group of cores that share L2 cache. That is true for Intel parts,
+        // and is what Linux implements (how Windows determines how to return
+        // RelationProcessorModule is a guess). Intel docs say "the nearest
+        // power-of-2 not smaller than".
+        int l2_sharing_width = 31 - std::countl_zero(max_cpus_sharing_l2);
+        info->module_id = extract(l2_sharing_width, widths[Package - 1]);
     } else {
         // if neither CPUID nor cache provide module information, we assume module == core
         info->module_id = info->core_id;

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -192,8 +192,6 @@ bool pin_to_logical_processors(CpuRange, const char *thread_name);
 
 void apply_cpuset_param(char *param);
 void init_topology(const LogicalProcessorSet &enabled_cpus);
-void update_topology(std::span<const struct cpu_info> new_cpu_info,
-                     std::span<const Topology::Package> sockets = {});
 void restrict_topology(CpuRange range);
 
 #endif /* INC_TOPOLOGY_H */


### PR DESCRIPTION
This PR extends OpenDCDiag's extraction of topology information for CPUs to include the module, tile, and NUMA node IDs. It uses CPUID leaf 0x1f where available and falls back to 0x0b with a supplement of cache information ("modules" are groups of cores that share L2).

With this, my Alder Lake laptop prints:
```
# CPU   PkgID   CoreID  ThrdID  ModId   Microcode       PPIN
0       0       0       0       0       0x36
1       0       0       1       0       0x36
2       0       4       0       1       0x36
3       0       4       1       1       0x36
4       0       8       0       2       0x36
5       0       8       1       2       0x36
6       0       12      0       3       0x36
7       0       12      1       3       0x36
8       0       16      0       4       0x36
9       0       16      1       4       0x36
10      0       20      0       5       0x36
11      0       20      1       5       0x36
12      0       24      0       6       0x36
13      0       24      1       6       0x36
14      0       28      0       7       0x36
15      0       28      1       7       0x36
16      0       36      0       9       0x36
17      0       37      0       9       0x36
18      0       38      0       9       0x36
19      0       39      0       9       0x36
```