### PR TITLE
Revert "FW: reorganize current_max_loop_count assignment"

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2182,20 +2182,19 @@ run_one_test(const test_cfg_info &test_cfg, SandstoneApplication::PerCpuFailures
         );
     }
 
-    if (test->fracture_loop_count) {
-        // handled first, not overridable by --max-test-loop-count
-        sApp->shmem->current_max_loop_count = test->fracture_loop_count;
+    if (sApp->max_test_loop_count) {
+        sApp->shmem->current_max_loop_count = sApp->max_test_loop_count;
     } else if (test->desired_duration == -1) {
         sApp->shmem->current_max_loop_count = -1;
     } else if (sApp->test_tests_enabled()) {
         // don't fracture in the test-the-test mode
         sApp->shmem->current_max_loop_count = -1;
-    } else if (sApp->max_test_loop_count) {
-        sApp->shmem->current_max_loop_count = sApp->max_test_loop_count;
-    } else {
+    } else if (test->fracture_loop_count == 0) {
         /* for automatic fracture mode, do a 40 loop count */
         sApp->shmem->current_max_loop_count = 40;
         auto_fracture = true;
+    } else {
+        sApp->shmem->current_max_loop_count = test->fracture_loop_count;
     }
 
     assert(sApp->retest_count >= 0);


### PR DESCRIPTION
This reverts commit bcb56fc858d28c08da11a9730497e46c57f607d7.

The change being reverted has an unintended consequence of increasing runtime for the tests that specify .fracture_loop_count = -1 (no fracture) and not honoring command-line-specified --max-test-loop-count value. While exactly the intention of the previous change, it is unacceptable to have the test hard-coded, unflexible logic. Thus reverting it back. The tests must honor --max-test-loop-count on the command-line if they can.