### PR TITLE
FW: update the test planning to take modules and NUMA nodes into account

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1142,57 +1142,25 @@ static void slice_plan_init(int max_cores_per_slice)
 
     // The heuristic is enabled by max_cores_per_slice == 0 and a valid
     // topology:
-    // - if the CPU Set has less than or equal toMinimumCpusPerSocket (8)
+    // - if the CPU Set has less than or equal to MinimumCpusPerSocket (8)
     //   logical processors per socket (on average), we ignore the topology and
     //   will instead run in slices of up to DefaultMaxCoresPerSlice (32)
     //   logical processors.
-    // - otherwise, we'll have at least one slice per socket, and maybe more
-    //   for sockets with more than 32 cores per socket.
-    //   * hardware threads of a given core are always sliced together, so a
-    //     2-thread core system will have up to 64 logical processors in a
-    //     slice (a hypothetical 4-thread system would have up to 128).
-    //
-    // The heuristic slices will be balanced as follows:
-    // - if the number of cores in the socket is not a multiple of
-    //   DefaultMaxCoresPerSlice (32) but is of SecondaryMaxCoresPerSlice (24),
-    //   we'll use the secondary maximum
-    // - the number of cores per slice is kept as a multiple of 4; that is, a
-    //   60-core socket will have a slice of 32 cores and one of 28 cores,
-    //   instead of 30+30.
-    // - other than that, the number of cores per slice is balanced; that is,
-    //   a 40-core socket is split as two 20-core slices instead of 32+8.
+    // - otherwise, we'll have at least one slice per socket
+    //   * if the socket has more than 32 cores, we'll attempt to slice it
+    //     at NUMA node boundaries
+    //   * if a NUMA node has more than 32 cores, we'll attempt to split it
+    //     evenly so each slice has 32 cores (64 threads on a system with 2
+    //     threads per core)
+    // - we always keep the cores of a given module and threads of a core
+    //   in the same slice
+    //   * this means on some situations the slices may have more than 32 cores
+    //     (i.e. the 32nd and 33rd core were part of the same module)
     //
     // If the user specifies a --max-cores-per-slice option in the
     // command-line, it will bypass the heuristic but keep the slice balancing
-    // as described above, including keeping the multiple-of-4 sliceing, if the
-    // requested target is also a multiple of 4. Be aware bypasses the minimum
-    // average processor per socket check.
-    //
-    // As a result, expect the following sliceing:
-    //  Topology            slices
-    //  invalid             everything
-    //  1 x 32              [32]
-    //  1 x 36              [20 + 16]
-    //  1 x 40              [20 + 20]
-    //  1 x 60              [32 + 28]
-    //  1 x 64              [32 + 32]
-    //  1 x 96              [32 + 32 + 32]
-    //  1 x 120             [24 + 24 + 24 + 24 + 24] (uses secondary max)
-    //  1 x 124             [32 + 32 + 32 + 28]
-    //  1 x 128             [32 + 32 + 32 + 32]
-    //  1 x 143             [32 + 32 + 32 + 32 + 15]
-    //  1 x 144             [24 + 24 + 24 + 24 + 24 + 24] (uses secondary max)
-    //  1 x 192             [32 + 32 + 32 + 32 + 32 + 32] (does not use secondary max)
-    //  2 x 8               [16]
-    //  2 x 16              [16] + [16]
-    //  2 x 32              [32] + [32]
-    //  2 x 40              [20 + 20] + [20 + 20]
-    //  4 x 8               [32]
-    //  4 x 16              [16] + [16] + [16] + [16]
-    //  8 x 8               [32] + [32]
-    //  16 x 4              [32] + [32]
-    //  16 x 8              [32] + [32] + [32] + [32]
-    // etc.
+    // as described above. Be aware bypasses the minimum average processor per
+    // socket check.
 
     int max_cpu = num_cpus();
     const Topology &topology = Topology::topology();
@@ -1200,12 +1168,9 @@ static void slice_plan_init(int max_cores_per_slice)
         using SlicePlans = SandstoneApplication::SlicePlans;
         static constexpr int MinimumCpusPerSocket = SlicePlans::MinimumCpusPerSocket;
         static constexpr int DefaultMaxCoresPerSlice = SlicePlans::DefaultMaxCoresPerSlice;
-        static constexpr int SecondaryMaxCoresPerSlice = SlicePlans::SecondaryMaxCoresPerSlice;
 
-        bool using_defaults = false;
         if (max_cores_per_slice == 0) {
             // apply defaults
-            using_defaults = true;
             int average_cpus_per_socket = max_cpu / topology.packages.size();
             max_cores_per_slice = DefaultMaxCoresPerSlice;
             if (average_cpus_per_socket <= MinimumCpusPerSocket)
@@ -1215,7 +1180,7 @@ static void slice_plan_init(int max_cores_per_slice)
         // set up proper plans
         std::vector<CpuRange> &fullsocket = sApp->slice_plans.plans[SlicePlans::IsolateSockets];
         std::vector<CpuRange> &split = sApp->slice_plans.plans[SlicePlans::Heuristic];
-        auto push_to = [](std::vector<CpuRange> &to, const Topology::Core *start, const Topology::Core *end) {
+        auto push_to = [](std::vector<CpuRange> &to, auto start, auto end) {
             int start_cpu = start[0].threads.front().cpu();
             int end_cpu = end[-1].threads.back().cpu();
             assert(end_cpu >= start_cpu);
@@ -1226,27 +1191,37 @@ static void slice_plan_init(int max_cores_per_slice)
             if (p.cores.size() == 0)
                 continue;       // untested socket
 
-            const Topology::Core *c = p.cores.data();
-            const Topology::Core *end = c + p.cores.size();
-            push_to(fullsocket, c, end);
-
-            ptrdiff_t slice_count = p.cores.size() / max_cores_per_slice;
-            if (p.cores.size() % max_cores_per_slice) {
-                if (using_defaults && (p.cores.size() % SecondaryMaxCoresPerSlice) == 0) {
-                    // use the secondary count
-                    slice_count = p.cores.size() / SecondaryMaxCoresPerSlice;
-                } else {
-                    ++slice_count;  // round up (also makes at least 1)
-                }
+            push_to(fullsocket, p.cores.begin(), p.cores.end());
+            if (p.cores.size() <= max_cores_per_slice) {
+                // easy case: package has fewer than max_cores_per_slice
+                split = fullsocket;
+                continue;
             }
 
-            ptrdiff_t slice_size = p.cores.size() / slice_count;
-            if ((max_cores_per_slice & 3) == 0 && (slice_size & 3))
-                slice_size = ((slice_size >> 2) + 1) << 2;  // make it multiple of 4
+            // if we have to split, we'll try to split along NUMA node lines
+            for (const Topology::NumaNode &n : p.numa_domains) {
+                if (n.cores.size() == 0)
+                    continue;   // untested node (shouldn't happen!)
 
-            for ( ; end - c > slice_size; c += slice_size)
-                push_to(split, c, c + slice_size);
-            push_to(split, c, end);
+                auto begin = n.cores.begin();
+                const auto end = n.cores.end();
+                ptrdiff_t slice_count = n.cores.size() / max_cores_per_slice;
+                if (n.cores.size() % max_cores_per_slice)
+                    ++slice_count;  // round up (also makes at least 1)
+                ptrdiff_t slice_size = n.cores.size() / slice_count;
+
+                // populate slices of roughly slice_size cores, but keep
+                // modules within the same slice
+                while (end - begin > slice_size) {
+                    auto e = begin + slice_size;
+                    while (e != end && e[-1].threads[0].module_id == e[0].threads[0].module_id)
+                        ++e;
+                    push_to(split, begin, e);
+                    begin = e;
+                }
+                if (begin != end)
+                    push_to(split, begin, end);
+            }
         }
         return;
     }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1178,7 +1178,7 @@ static void slice_plan_init(int max_cores_per_slice)
         }
 
         // set up proper plans
-        std::vector<CpuRange> &fullsocket = sApp->slice_plans.plans[SlicePlans::IsolateSockets];
+        std::vector<CpuRange> &isolate_socket = sApp->slice_plans.plans[SlicePlans::IsolateSockets];
         std::vector<CpuRange> &split = sApp->slice_plans.plans[SlicePlans::Heuristic];
         auto push_to = [](std::vector<CpuRange> &to, auto start, auto end) {
             int start_cpu = start[0].threads.front().cpu();
@@ -1191,10 +1191,10 @@ static void slice_plan_init(int max_cores_per_slice)
             if (p.cores.size() == 0)
                 continue;       // untested socket
 
-            push_to(fullsocket, p.cores.begin(), p.cores.end());
+            push_to(isolate_socket, p.cores.begin(), p.cores.end());
             if (p.cores.size() <= max_cores_per_slice) {
                 // easy case: package has fewer than max_cores_per_slice
-                split = fullsocket;
+                split = isolate_socket;
                 continue;
             }
 

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -161,11 +161,15 @@ static linux_cpu_info &proc_cpuinfo()
 
 static bool cpu_compare(const struct cpu_info &cpu1, const struct cpu_info &cpu2)
 {
+    static_assert(offsetof(struct cpu_info, numa_id) + 2 == offsetof(struct cpu_info, package_id));
+    static_assert(offsetof(struct cpu_info, tile_id) + 4 == offsetof(struct cpu_info, package_id));
+    static_assert(offsetof(struct cpu_info, module_id) + 6 == offsetof(struct cpu_info, package_id));
+    static_assert(offsetof(struct cpu_info, thread_id) + 2 == offsetof(struct cpu_info, core_id));
+    static_assert(offsetof(struct cpu_info, cpu_number) + 6 == offsetof(struct cpu_info, core_id));
     static auto cpu_tuple = [](const struct cpu_info &c) {
-        uint64_t h = (uint64_t(c.package_id) << 32) +
-                unsigned(c.core_id);
-        uint64_t l = ((uint64_t(c.thread_id)) << 32) +
-                unsigned(c.cpu_number);
+        uint64_t h, l;
+        memcpy(&h, &c.module_id, sizeof(h));
+        memcpy(&l, &c.cpu_number, sizeof(l));
         return std::make_tuple(h, l);
     };
 

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -30,9 +30,22 @@ public:
     struct Core {
         std::span<const Thread> threads;
     };
+    struct Module {
+        std::span<const Thread> threads;
+    };
 
-    struct Package {
+    struct CoreGrouping {
         std::vector<Core> cores;
+        // std::vector<Module> modules;
+    };
+
+    struct NumaNode : CoreGrouping {
+        int id() const
+        { return cores.size() ? cores.front().threads.front().numa_id : -1; }
+    };
+
+    struct Package : CoreGrouping {
+        std::vector<NumaNode> numa_domains;
         int id() const
         { return cores.size() ? cores.front().threads.front().package_id : -1; }
     };


### PR DESCRIPTION
This was the objective all along when I wrote this code in 2023, but we didn't have the information populated to achieve it. Therefore, it only made a token attempt by checking if the core count in the package was a multiple of 24 and by trying to keep things as a multiple of 4. This is no longer needed.

Instead, the rules now are:
1. (unchanged) if we have 32 cores are under test or less, then no slicing happens, otherwise we slice at the package/socket level
2. (unchanged) if the package has 32 cores or less, the `isolate_socket` mode equals `heuristic`
3. otherwise, we split at the NUMA node boundaries
4. if the NUMA node has more than 32 cores, we subdivide again on roughly equally-sized slices
5. we keep all cores and threads of a given module inside of one slice

Keeping rules 1 and 2 unchanged means most older systems are unchanged too[^1]. The first system with more than 32 cores were the double-die Cascade and Cooper Lakes and later the Ice Lake on the same die, for which were splitting at exactly half but now will split at the NUMA boundary (if any).

Splitting at NUMA node boundaries changes more recent processors with 3 nodes or more. For example, Granite Rapids has a part with 120, which was being split into 5x24-core slices and crossing NUMA boundaries; now it's split 6 ways.

Ideally we'd split at the tile level too, but I don't have access to any system that reports tiles. Until I do, I can't tell whether it should sort above the NUMA node or below, in splitting.

[^1]: except for the re-sorting of threads according to their NUMA node IDs, which may affect timing as well as stack and heap pointers, but does not affect the random generator nor slicing.