### PR TITLE
Meson: set dependencies' includes to "system"

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -115,6 +115,7 @@ if framework_config.get('SANDSTONE_SSL_BUILD') == 1
   crypto_dep = dependency('libcrypto',
                         version: '>= 3.0',
                         required: false,
+                        include_type: 'system',
                         static: get_option('ssl_link_type') == 'static')
   if crypto_dep.found()
       framework_files += ['sandstone_ssl.cpp', 'sandstone_ssl_rand.cpp']

--- a/meson.build
+++ b/meson.build
@@ -216,7 +216,7 @@ default_cpp_warn = [
 # Subdirs can add target dependencies if they wish
 target_deps = []
 
-boost_dep = dependency('boost', version : '>=1.69', required : false)
+boost_dep = dependency('boost', version : '>=1.69', required : false, include_type : 'system')
 # Check for required headers
 # (Also accomodates distributions which do not package a pkg-config file for boost)
 boost_has_hdrs = \

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -63,7 +63,7 @@ elif target_machine.system() == 'windows'
     )
 endif
 
-eigen3_dep = dependency('eigen3', static : dep_static)
+eigen3_dep = dependency('eigen3', include_type : 'system', static : dep_static)
 tests_set_base.add(
     when : eigen3_dep,
     if_true : files(
@@ -90,7 +90,7 @@ tests_set_skx.add(
     )
 )
 
-zstd_dep = dependency('libzstd', static : dep_static)
+zstd_dep = dependency('libzstd', include_type : 'system', static : dep_static)
 tests_set_base.add(
     when : zstd_dep,
     if_true : files(
@@ -98,7 +98,7 @@ tests_set_base.add(
     )
 )
 
-zlib_dep = dependency('zlib', static : dep_static)
+zlib_dep = dependency('zlib', include_type : 'system', static : dep_static)
 tests_set_base.add(
     when : zlib_dep,
     if_true : files(


### PR DESCRIPTION
We don't need warnings from system headers.