### PR TITLE
FW/Topology: fix extracting the module_id when Linux doesn't know either

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -306,6 +306,8 @@ tap_negative_check() {
         fi
         test_yaml_numeric "/cpu-info/$i/logical" 'value >= 0'
         test_yaml_numeric "/cpu-info/$i/package" 'value >= 0'
+        test_yaml_numeric "/cpu-info/$i/numa_node" 'value >= -1'
+        test_yaml_numeric "/cpu-info/$i/module" 'value >= 0'
         test_yaml_numeric "/cpu-info/$i/core" 'value >= 0'
         test_yaml_numeric "/cpu-info/$i/thread" 'value >= 0'
         test_yaml_numeric "/cpu-info/$i/family" 'value >= 0'

--- a/bats/yamltest.py
+++ b/bats/yamltest.py
@@ -45,8 +45,10 @@ def validate_thread(name, thr):
     n = thr['thread']
 
     if type(n) is int:
-        #thr['id']['logical'] # waiting on Windows
+        thr['id']['logical']
         thr['id']['package']
+        thr['id']['numa_node']
+        thr['id']['module']
         thr['id']['core']
         thr['id']['thread']
         thr['id']['family']

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -445,7 +445,10 @@ static bool fill_topo_sysfs(struct cpu_info *info)
         // Linux calls them modules "clusters"
         IGNORE_RETVAL(fscanf(f, "%hd", &info->module_id));
         fclose(f);
-    } else {
+    }
+    if (info->module_id < 0) {
+        // Override the missing information. This is probably a VM without
+        // cache info or an architecture where Linux doesn't have cluster_id.
         info->module_id = info->core_id;
     }
 


### PR DESCRIPTION
The topology/cluster_id file is always present (on x86), but it may contain -1. See `parse_topology()`[1] for where it gets first initialized. Includes test to ensure this works.

[1] https://codebrowser.dev/linux/linux/arch/x86/kernel/cpu/topology_common.c.html#parse_topology