### PR TITLE
FW: make some variables in SandstoneApplication static constexpr

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -214,8 +214,6 @@ private:
 
 static SandstoneApplication::OutputFormat current_output_format()
 {
-    if (SandstoneConfig::NoLogging)
-        return SandstoneApplication::OutputFormat::no_output;
     return sApp->shmem->output_format;
 }
 

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -543,6 +543,7 @@ int parse_cmdline(int argc, char** argv, SandstoneApplication* app, ParsedCmdLin
     int coptind = -1;
 
     if constexpr (!SandstoneConfig::RestrictedCommandLine) {
+#if !SANDSTONE_RESTRICTED_CMDLINE
         while ((opt = simple_getopt(argc, argv, long_options, &coptind)) != -1) {
             switch (opt) {
             case disable_option:
@@ -940,6 +941,7 @@ int parse_cmdline(int argc, char** argv, SandstoneApplication* app, ParsedCmdLin
                 return EX_USAGE;
             }
         }
+#endif // !SANDSTONE_RESTRICTED_CMDLINE
     } else {
         // Default options for the simplified OpenDCDiag cmdline
         static struct option restricted_long_options[] = {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -453,6 +453,9 @@ struct SandstoneApplication::SharedMemory
     int verbosity = -1;
     int max_messages_per_thread = 5;
     unsigned max_logdata_per_thread = 128;
+#if SANDSTONE_RESTRICTED_CMDLINE
+    static constexpr
+#endif
     OutputFormat output_format = DefaultOutputFormat;
     uint8_t output_yaml_indent = 0;
     bool log_test_knobs = false;


### PR DESCRIPTION
When compiled in restricted command-line mode, as they can't be changed.

Because they are read-only, we have to hide their assignment with a preprocessor #if instead of an `if` or `if constexpr` statement.