### PR TITLE
FW/Topology: reorganize helper classes from topology.cpp

### DIFF
--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -31,27 +31,6 @@ static void update_topology(std::span<const struct cpu_info> new_cpu_info,
                             std::span<const Topology::Package> sockets = {});
 
 namespace {
-struct auto_fd
-{
-    int fd = -1;
-    auto_fd(int fd = -1) : fd(fd) {}
-    ~auto_fd() { if (fd != -1) close(fd); }
-
-    // make it movable but not copyable
-    auto_fd(const auto_fd &) = delete;
-    auto_fd &operator=(const auto_fd &) = delete;
-
-    auto_fd(auto_fd &&other) : fd(std::exchange(other.fd, -1)) {}
-    auto_fd &operator=(auto_fd &&other)
-    {
-        auto_fd tmp(std::move(other));
-        std::swap(tmp.fd, fd);
-        return *this;
-    }
-
-    operator int() const { return fd; }
-};
-
 struct linux_cpu_info
 {
     using Fields = std::map<std::string, std::string>;

--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -30,6 +30,15 @@
 static void update_topology(std::span<const struct cpu_info> new_cpu_info,
                             std::span<const Topology::Package> sockets = {});
 
+struct cpu_info *cpu_info = nullptr;
+
+static Topology &cached_topology()
+{
+    static Topology cached_topology = Topology({});
+    return cached_topology;
+}
+
+#ifdef __linux__
 namespace {
 struct linux_cpu_info
 {
@@ -61,15 +70,6 @@ struct linux_cpu_info
 };
 }
 
-struct cpu_info *cpu_info = nullptr;
-
-static Topology &cached_topology()
-{
-    static Topology cached_topology = Topology({});
-    return cached_topology;
-}
-
-#ifdef __linux__
 static auto_fd open_sysfs_cpu_dir(int cpu)
 {
     char buf[sizeof("/sys/devices/system/cpu/cpu2147483647")];


### PR DESCRIPTION
This moves `auto_fd` class to sandstone_utils.h, right next to `AutoClosingFile` class, and moves the `linux_cpu_info` class into the `__linux__` block.