### PR TITLE
CI: fix matching of the "os" entry on Windows

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -291,11 +291,14 @@ tap_negative_check() {
     test_yaml_regexp "/command-line" ".* $args"
     test_yaml_regexp "/version" '.*'
 
-    local os=`uname -sr`
-    if [[ "$SANDSTONE" = "wine "* ]] || [[ "$os" = MINGW* ]]; then
-        os=`wine cmd /c ver | sed -n "s/\r$//;s/.*Windows /Windows v/p"`
+    if $is_windows; then
+        test_yaml_regexp "/os" 'Windows (Server )?v[0-9.]+'
+        test_yaml_regexp "/runtime" 'MSVCRT|UCRT'
+    else
+        test_yaml_regexp "/os" "`uname -s` .*"
+        [[ "${yamldump[/os]}" = "`uname -sr`" ]]    # exact match
+        test_yaml_regexp "/runtime" '.*'            # free form, but must exist
     fi
-    [[ "${yamldump[/os]}" = "$os"* ]]
     test_yaml_regexp "/openssl" "{'version':.*|None"
     test_yaml_numeric "/timing/duration" 'value == 1234'
     test_yaml_numeric "/timing/timeout" 'value == 12345'


### PR DESCRIPTION
This code was there from the days we were using WINE, which means the CI has been producing:
```
/d/a/opendcdiag/opendcdiag/bats/sanity-check/20-selftests.bats: line 296: wine: command not found
```
and therefore `os=""`, so it matched anything.

Extracting the actual version from the ver cmd.exe command is too difficult and we don't need to know that exactly anyway.