### PR TITLE
FW/Topology (fake): make the module_id match the core_id

### DIFF
--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -216,8 +216,11 @@ static std::vector<struct cpu_info> create_mock_topology(const char *topo)
 
         if (!parse_int_and_advance(&info->package_id))
             continue;
-        if (!parse_int_and_advance(&info->core_id))
+        if (!parse_int_and_advance(&info->core_id)) {
+            info->module_id = info->core_id;
             continue;
+        }
+        info->module_id = info->core_id;
         if (!parse_int_and_advance(&info->thread_id))
             continue;
         if (!parse_int_and_advance(&info->model))


### PR DESCRIPTION
Like we do for real topologies when `module_id`s are not known, otherwise every core ends up in the same module and we will never split them.

Setting the IDs is a task for the future