### PR TITLE
FW/Win32: Add strerror function.

### DIFF
--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -17,6 +17,7 @@ framework_files += \
         'ucrt-mapping.c',
         'unistd.c',
         'win32_perror.c',
+        'win32_strerror.cpp',
         '../generic/kvm.c',
         '../generic/memfpt.c',
         '../generic/msr.c',

--- a/framework/sysdeps/windows/win32_stdlib.h
+++ b/framework/sysdeps/windows/win32_stdlib.h
@@ -13,6 +13,8 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
+#include <string>
+using last_error_t = unsigned;
 extern "C" {
 #endif
 
@@ -35,6 +37,9 @@ void *valloc(size_t size);
 void win32_perror(const char *s);
 
 #ifdef __cplusplus
+/* not stdlib.h, but injected here because we're lazy;
+ * returns last-error code value as a std:string. */
+std::string win32_strerror(last_error_t last_err);
 }
 #endif
 

--- a/framework/sysdeps/windows/win32_strerror.cpp
+++ b/framework/sysdeps/windows/win32_strerror.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <windows.h>
+
+std::string win32_strerror(last_error_t last_err)
+{
+    DWORD dwFlags = FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS |
+            FORMAT_MESSAGE_ARGUMENT_ARRAY | FORMAT_MESSAGE_ALLOCATE_BUFFER;
+    LPCVOID lpSource = nullptr;
+    DWORD dwLanguageId = 0;
+    LPSTR lpBuffer = nullptr;
+    DWORD nSize = 0;
+    FormatMessage(dwFlags, lpSource, last_err, dwLanguageId, (LPTSTR)&lpBuffer, nSize, NULL);
+    std::string strerror(lpBuffer);
+    LocalFree(lpBuffer);
+
+    return strerror;
+}


### PR DESCRIPTION
The function returns a last-error code as a string.