### PR TITLE
meson: bump minimum to v1.3, cpp_std=gnu++23

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,9 +7,9 @@ project(
     default_options: [
         'b_ndebug=if-release',
         'c_std=gnu17',
-        'cpp_std=gnu++20',
+        'cpp_std=gnu++23',
     ],
-    meson_version: '>=0.57',
+    meson_version : '>=1.3',
 )
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
GitHub-hosted Actions OS images, namely `ubuntu-latest`, is based on 24.04 today. In that distro, the version of meson is v1.3.x. With that version, you can specify the C++23 language standard. But, C23 is not an option yet.

I wanted to bump c_std=gnu23 as well, but that's not introduced until v1.4, so I'll wait until hosted runners get upgraded.