### PR TITLE
OpenSSL tests: use the sandstone_config.h macro

### DIFF
--- a/tests/openssl/openssl_sha.cpp
+++ b/tests/openssl/openssl_sha.cpp
@@ -14,7 +14,7 @@
 
 #include "sandstone.h"
 
-#if defined(__linux__)
+#if SANDSTONE_SSL_BUILD
 
 #include "sandstone_ssl.h"
 
@@ -153,7 +153,7 @@ static int ssl_sha_run(struct test* test, int cpu)
     return EXIT_SUCCESS;
 }
 
-#else // !__linux__
+#else // !SANDSTONE_SSL_BUILD
 
 static int ssl_sha_init(struct test *test)
 {


### PR DESCRIPTION
Instead of assuming that all Linux builds have OpenSSL (they don't have to) and that none of non-Linux don't (they may, FreeBSD for example).
