### PR TITLE
FW/SSL: suppress loading of an OpenSSL config file

### DIFF
--- a/framework/sandstone_ssl.cpp
+++ b/framework/sandstone_ssl.cpp
@@ -83,7 +83,8 @@ void sandstone_ssl_init()
 
     SANDSTONE_SSL_GENERIC_FUNCTIONS(CHECK_SSL_POINTERS)
     if (!failed) {
-        s_OPENSSL_init();
+        s_OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, nullptr);
+        s_OPENSSL_config(SANDSTONE_EXECUTABLE_NAME);
         OpenSSLWorking = true;
     }
 }

--- a/framework/sandstone_ssl.h
+++ b/framework/sandstone_ssl.h
@@ -1137,7 +1137,7 @@
     /**/
 
 #define SANDSTONE_SSL_GENERIC_FUNCTIONS(F)      \
-    F(OPENSSL_init)                             \
+    F(OPENSSL_config)                           \
     F(OPENSSL_init_crypto)                      \
     F(OPENSSL_INIT_free)                        \
     F(OPENSSL_INIT_new)                         \


### PR DESCRIPTION
This removes the variability found with non-standard providers and SW bugs that they may have.