### PR TITLE
FW/SSL: filter the "dynamic" OpenSSL engine out

### DIFF
--- a/framework/sandstone_ssl.cpp
+++ b/framework/sandstone_ssl.cpp
@@ -185,8 +185,19 @@ static void add_engines(std::string &info)
         return;
 
     std::vector<std::string_view> engines;
-    for (ENGINE *e = s_ENGINE_get_first(); e; e = s_ENGINE_get_next(e))
-       engines.emplace_back(s_ENGINE_get_id(e));
+    for (ENGINE *e = s_ENGINE_get_first(); e; e = s_ENGINE_get_next(e)) {
+        std::string_view id = s_ENGINE_get_id(e);
+#ifdef NDEBUG
+        // skip uninteresting engines (we keep in debug mode so we can check
+        // the code is working)
+        if (id == "dynamic")
+            continue;
+#endif
+        engines.emplace_back(id);
+    }
+
+    if (engines.size() == 0)
+        return;
 
     std::ranges::sort(engines);
     info += ", engines: ['";


### PR DESCRIPTION
And don't print anything if no engine is found.