### PR TITLE
FW/Topology: fix NUMA detection when missing the first portion of a node

### DIFF
--- a/framework/topology.cpp
+++ b/framework/topology.cpp
@@ -401,9 +401,7 @@ static bool fill_numa()
             } else {
                 // no such luck, scan forward from the last cpu we marked
                 for ( ; cpu < end; ++cpu) {
-                    if (cpu->cpu_number >= stop)
-                        cpu = end;  // we're past the end already
-                    else if (cpu->cpu_number >= start)
+                    if (cpu->cpu_number >= start)
                         break;
                 }
             }


### PR DESCRIPTION
On a system with:
```
/sys/devices/system/node/node0/cpulist:0-23,48-71
/sys/devices/system/node/node1/cpulist:24-47,72-95
```

If we ran without CPUs 0-23, then when parsing node1's first range 24-47, we'd find that `cpu->cpu_number == 48` and skip the entire node. What we meant to do was to skip only this range. This commit fixes that.

Thanks to @AthenasJimenez for finding this case.