### PR TITLE
FW: fix slice planning of when a later socket has less than 32 cores

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1194,7 +1194,7 @@ static void slice_plan_init(int max_cores_per_slice)
             push_to(isolate_socket, p.cores.begin(), p.cores.end());
             if (p.cores.size() <= max_cores_per_slice) {
                 // easy case: package has fewer than max_cores_per_slice
-                split = isolate_socket;
+                push_to(split, p.cores.begin(), p.cores.end());
                 continue;
             }
 


### PR DESCRIPTION
Assigning
```c++
                split = isolate_socket;
```
was only correct for the first socket. When a later socket had less than 32 cores, we were overwriting the heuristic planning with the current socket-isolation planning.

Thanks to @rsagashe03 for finding this.