### PR TITLE
FW: permit whitespaces in the test list files when specifying duration

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1030,7 +1030,8 @@ test_list_file() {
 }
 
 @test "--test-list-file with duration" {
-    test_list_file selftest_pass:default selftest_timedpass:250 selftest_timedpass:10
+    test_list_file selftest_pass:default selftest_timedpass:250 selftest_timedpass:10 \
+        '' 'selftest_timedpass: 10' '' "$(printf "selftest_timedpass:\t10")"
 }
 
 @test "--test-list-file with comments and empty lines" {

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -177,6 +177,9 @@ static line_type parse_test_list_line(std::string line, SandstoneTestSet *test_s
     while (is_ignored(*it)) ++it;
     if (*it == '#' || it == line.end()) return LT_EMPTY;
     for (; ; ++it) {
+        // skip ignored characters before token contents
+        while (it != line.end() && is_ignored(*it)) ++it;
+        if (it == line.end()) break;
         auto cit = it;
         /* scroll while it's valid token contents: till end of line, a
          * terminator, or a space. */


### PR DESCRIPTION
In test list files, whitespaces between terminator and duration are producing syntax error as described in #672.
These changes fix the issue by skipping the whitespaces before encountering token contents.

Fixes #672 