### PR TITLE
FW: move the family/model/stepping to a global

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1821,7 +1821,7 @@ void KeyValuePairLogger::print_thread_header(int fd, int cpu, const char *prefix
     }
     dprintf(fd, "%s_messages_thread_%d_cpu = %d\n", prefix, cpu, info->cpu_number);
     dprintf(fd, "%s_messages_thread_%d_family_model_stepping = %02x-%02x-%02x\n", prefix, cpu,
-            info->family, info->model, info->stepping);
+            sApp->hwinfo.family, sApp->hwinfo.model, sApp->hwinfo.stepping);
     dprintf(fd, "%s_messages_thread_%d_topology = phys %d, core %d, thr %d\n",
             prefix, cpu, info->package_id, info->core_id, info->thread_id);
     dprintf(fd, "%s_messages_thread_%d_microcode =", prefix, cpu);
@@ -2069,8 +2069,8 @@ void TapFormatLogger::print_thread_header(int fd, int cpu, int verbosity)
     std::string line = stdprintf("  Thread %d on CPU %d (pkg %d, core %d, thr %d", cpu,
             info->cpu_number, info->package_id, info->core_id, info->thread_id);
 
-    line += stdprintf(", family/model/stepping %02x-%02x-%02x, microcode ", info->family, info->model,
-                      info->stepping);
+    line += stdprintf(", family/model/stepping %02x-%02x-%02x, microcode ", sApp->hwinfo.family, sApp->hwinfo.model,
+                      sApp->hwinfo.stepping);
     if (info->microcode)
         line += stdprintf("%#" PRIx64, info->microcode);
     else
@@ -2154,7 +2154,7 @@ std::string YamlLogger::thread_id_header(int cpu, int verbosity)
                 line += "null";
         };
         line += stdprintf(", family: %d, model: %#02x, stepping: %d, microcode: ",
-                          info->family, info->model, info->stepping);
+                          sApp->hwinfo.family, sApp->hwinfo.model, sApp->hwinfo.stepping);
         add_value_or_null("%#" PRIx64, info->microcode);
         line += ", ppin: ";
         add_value_or_null("\"%016" PRIx64 "\"", info->ppin);    // string to prevent loss of precision

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1286,7 +1286,7 @@ static void dump_cpu_info()
                    cpu_features_to_string(arch.features & ~cpu_features).c_str());
     }
     printf("Detected CPU: %s; family-model-stepping (hex): %02x-%02x-%02x; CPU features: %s\n",
-           detected, cpu_info[0].family, cpu_info[0].model, cpu_info[0].stepping,
+           detected, sApp->hwinfo.family, sApp->hwinfo.model, sApp->hwinfo.stepping,
            cpu_features_to_string(cpu_features).c_str());
     printf("# CPU\tPkgID\tCoreID\tThrdID\tModId\tNUMAId\tApicId\tMicrocode\tPPIN\n");
     for (i = 0; i < num_cpus(); ++i) {

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -386,9 +386,6 @@ struct cpu_info {
     int hwid;
 
     struct cache_info cache[3]; ///! Cache info from OS
-    uint8_t family;         ///! CPU family (usually 6)
-    uint8_t stepping;       ///! CPU stepping
-    uint16_t model;         ///! CPU model
 
 #ifdef __cplusplus
     int cpu() const;        ///! Internal CPU number

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -303,6 +303,14 @@ protected:
     }
 };
 
+struct HardwareInfo
+{
+    // information for CPUs
+    uint16_t model = 0;
+    uint8_t family = 0;
+    uint8_t stepping = 0;
+};
+
 struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>
 {
     enum class OutputFormat : int8_t {
@@ -402,6 +410,8 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     uint64_t mce_count_last;
     std::vector<uint32_t> mce_counts_start;
     std::vector<uint64_t> smi_counts_start;
+
+    HardwareInfo hwinfo;
 
     int thread_count;
     ForkMode current_fork_mode() const


### PR DESCRIPTION
It doesn't need to be in `struct cpu_info` for each CPU, since this can't be different (at least, for x86 CPUs). This now creates a `HardwareInfo` global in `sApp` that we can use to populate other hardware info, for when we have them.