### PR TITLE
Partially revert "Meson: set dependencies' includes to "system""

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -196,7 +196,6 @@ if framework_config.get('SANDSTONE_SSL_BUILD') == 1
   crypto_dep = dependency('libcrypto',
                         version: '>= 3.0',
                         required: false,
-                        include_type: 'system',
                         static: get_option('ssl_link_type') == 'static')
   if crypto_dep.found()
       framework_files += ['sandstone_ssl.cpp', 'sandstone_ssl_rand.cpp']

--- a/meson.build
+++ b/meson.build
@@ -229,7 +229,7 @@ default_cpp_warn = [
 # Subdirs can add target dependencies if they wish
 target_deps = []
 
-boost_dep = dependency('boost', version : '>=1.69', required : false, include_type : 'system')
+boost_dep = dependency('boost', version : '>=1.69', required : false)
 # Check for required headers
 # (Also accomodates distributions which do not package a pkg-config file for boost)
 boost_has_hdrs = cpp.check_header('boost/algorithm/string.hpp') and cpp.check_header('boost/type_traits/is_complex.hpp')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -90,7 +90,7 @@ tests_set_skx.add(
     )
 )
 
-zstd_dep = dependency('libzstd', include_type : 'system', static : dep_static)
+zstd_dep = dependency('libzstd', static : dep_static)
 tests_set_base.add(
     when : zstd_dep,
     if_true : files(
@@ -98,7 +98,7 @@ tests_set_base.add(
     )
 )
 
-zlib_dep = dependency('zlib', include_type : 'system', static : dep_static)
+zlib_dep = dependency('zlib', static : dep_static)
 tests_set_base.add(
     when : zlib_dep,
     if_true : files(


### PR DESCRIPTION
This partially reverts commit 1cbbaf151c202f13de4ddfac342444d5975a30bc.

Unfortunately, Meson is too stupid to realise it should not pass `-isystem` for /usr/include if pkg-config reported it. That causes GCC to reorder the system includes, which in turn causes build errors:
```
cstdlib:75:15: fatal error: stdlib.h: No such file or directory
```

I've found that Boost, zlib, and Zstandard tend to have their headers directly in /usr/include. Other dependencies are less likely, so I've kept system mode for Eigen, which is what was generating warnings. Hopefully we can get away with it.
