### PR TITLE
FW: bail out early with an error message if we can't get our affinity

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -996,6 +996,11 @@ static LogicalProcessorSet init_cpus()
 {
     LogicalProcessorSet result = ambient_logical_processor_set();
     sApp->thread_count = result.count();
+    if (sApp->thread_count == 0) [[unlikely]] {
+        fprintf(stderr, "%s: internal error: ambient logical processor set appears to be empty!\n",
+                program_invocation_name);
+        exit(EX_OSERR);
+    }
     sApp->user_thread_data.resize(sApp->thread_count);
 #ifdef M_ARENA_MAX
     mallopt(M_ARENA_MAX, sApp->thread_count * 2);


### PR DESCRIPTION
This is not likely to ever happen, assuming our implementations of `ambient_logical_processor_set()` are correct (the Darwin one isn't! it fakes the result). But in case it does, print an error to the user instead of crashing on some null-pointer dereference or accessing elements in a zero-length vector.