### PR TITLE
FW/Topology: move the ppin information to HardwareInfo

### DIFF
--- a/framework/device/cpu/cpu_device.cpp
+++ b/framework/device/cpu/cpu_device.cpp
@@ -50,8 +50,9 @@ void dump_device_info()
                cpu_info[i].package_id, cpu_info[i].core_id, cpu_info[i].thread_id,
                cpu_info[i].module_id, cpu_info[i].numa_id, cpu_info[i].hwid,
                cpu_info[i].microcode);
-        if (cpu_info[i].ppin)
-            printf("\t%016" PRIx64, cpu_info[i].ppin);
+        const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(cpu_info[i].package_id);
+        if (pkg && pkg->ppin)
+            printf("\t%016" PRIx64, pkg->ppin);
         puts("");
     }
 }

--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -137,7 +137,6 @@ struct cache_info
 /// cpu_info contains information about a logical CPU
 struct cpu_info
 {
-    uint64_t ppin;          ///! Processor ID read from MSR
     uint64_t microcode;     ///! Microcode version read from /sys
 
     /// Logical OS processor number.

--- a/framework/device/cpu/topology_cpu.h
+++ b/framework/device/cpu/topology_cpu.h
@@ -54,11 +54,6 @@ public:
 
     std::vector<Package> packages;
 
-    Topology(std::vector<Package> pkgs)
-    {
-        packages = std::move(pkgs);
-    }
-
     bool isValid() const
     {
         return !packages.empty();

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -244,8 +244,6 @@ static_assert(NARGS(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
 /// Macro to build mask value for particular number of bits.
 #define MASK(bits) (((bits) == 64) ? 0xffffffffffffffffULL : ((1ULL << ((bits == 64) ? 0 : (bits))) - 1))
 
-
-
 struct test;
 
 typedef int (*initfunc)(struct test *test);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -302,10 +302,27 @@ struct SandstoneBackgroundScan
 
 struct HardwareInfo
 {
+#ifdef SANDSTONE_DEVICE_CPU
     // information for CPUs
+    struct PackageInfo {
+        int id;
+        uint64_t ppin;
+    };
+
+    std::vector<PackageInfo> package_infos;
     uint16_t model = 0;
     uint8_t family = 0;
     uint8_t stepping = 0;
+
+    const PackageInfo *find_package_id(int pkgid) const
+    {
+        auto it = std::find_if(package_infos.cbegin(), package_infos.cend(),
+                               [pkgid](const PackageInfo &pi) { return pkgid == pi.id; });
+        return it == package_infos.cend() ? nullptr : std::to_address(it);
+    }
+#endif
+#ifdef SANDSTONE_DEVICE_GPU
+#endif
 };
 
 struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>


### PR DESCRIPTION
Instead of `struct cpu_info`, as it is the same for every single CPU. Plus, tests shouldn't ever need to know the PPIN to operate.