### PR TITLE
FW: mark as skipped threads that EXIT_SKIP but don't `log_skip()`

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -779,7 +779,7 @@ void logging_mark_thread_failed(int thread_num)
     }
 }
 
-static void logging_mark_thread_skipped(int thread_num)
+void logging_mark_thread_skipped(int thread_num)
 {
     PerThreadData::Common *thr = sApp->thread_data(thread_num);
     if (thr->has_failed())

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -937,6 +937,8 @@ static uintptr_t thread_runner(int thread_number)
             if (sApp->shmem->ud_on_failure)
                 ud2();
             logging_mark_thread_failed(thread_number);
+        } else if (new_state == thread_skipped) {
+            logging_mark_thread_skipped(thread_number);
         }
         test_end(new_state);
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -648,6 +648,7 @@ void logging_print_log_file_name();
 void logging_restricted(int level, const char *fmt, ...);
 void logging_printf(int level, const char *msg, ...) ATTRIBUTE_PRINTF(2, 3);
 void logging_mark_thread_failed(int thread_num);
+void logging_mark_thread_skipped(int thread_num);
 void logging_report_mismatched_data(enum DataType type, const uint8_t *actual, const uint8_t *expected,
                                     size_t size, ptrdiff_t offset, const char *fmt, va_list);
 void logging_print_header(int argc, char **argv, ShortDuration test_duration, ShortDuration test_timeout);


### PR DESCRIPTION
We do set the state, which is what logging.cpp needed, but `has_skipped()` was returning false.