### PR TITLE
FW/logging: don't include the average freq time of skipped threads

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2472,11 +2472,15 @@ void YamlLogger::print_fixed()
                    format_duration(test_duration, FormatDurationOptions::WithoutUnit).c_str());
 
     double freqs = 0.0;
-    for_each_test_thread([&freqs](const PerThreadData::Test *data, int) {
-        freqs += data->effective_freq_mhz;
+    int cpus_measured = 0;
+    for_each_test_thread([&](const PerThreadData::Test *data, int) {
+        if (!data->has_skipped()) {
+            freqs += data->effective_freq_mhz;
+            ++cpus_measured;
+        }
     });
 
-    const double freq_avg = freqs / num_cpus();
+    const double freq_avg = freqs / cpus_measured;
     if (std::isfinite(freq_avg) && freq_avg != 0.0)
         logging_printf(LOG_LEVEL_VERBOSE(1), "  avg-freq-mhz: %.1f\n", freq_avg);
 


### PR DESCRIPTION
Presumably, those didn't do any useful work. More importantly, we have some tests that simply skip on entry, which means the measurement is over an extremely short period of time (about 100 ns), so the precision is very low and thus the average gets skewed.

For example, for a test that runs for 1 second in half the threads and exit-skips immediately on the other half, we report:
```yaml
  test-runtime: 1010.439
  avg-freq-mhz: 3359.3
```
whereas perf (over the entire tool) reports:
```
    31,436,443,589      instructions                     #    0.84  insn per cycle
    37,386,903,866      cycles                           #    3.097 GHz
     2,662,757,462      branches                         #  220.579 M/sec
       142,626,515      branch-misses                    #    5.36% of all branches

       1.022079038 seconds time elapsed

```

now:
```yaml
  test-runtime: 1013.791
  avg-freq-mhz: 3096.0
```
```
    31,430,507,800      instructions                     #    0.84  insn per cycle
    37,443,212,614      cycles                           #    3.097 GHz
     2,689,104,551      branches                         #  222.415 M/sec
       139,435,949      branch-misses                    #    5.19% of all branches

       1.027483410 seconds time elapsed
```

Requires #702.