### PR TITLE
FW/opts: remove dead code

### DIFF
--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -1029,7 +1029,7 @@ struct ProgramOptionsParser {
             case 'h':
                 usage(argv);
                 opts.action = Action::exit;
-                return opt == 'h' ? EXIT_SUCCESS : EX_USAGE;
+                return EXIT_SUCCESS;
             default:
                 suggest_help(argv);
                 opts.action = Action::exit;


### PR DESCRIPTION
Inside `case 'h'`, `opt` is definitely `'h'`.

Amends commit 324758092282f08f02aea80a7f951493b71eb6d1.