### PR TITLE
FW/Topology/Win32: fix bug for affinity masks bits set above 32nd

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -700,7 +700,7 @@ static bool detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP relationships)
             KAFFINITY mask = ga.Mask;
             while (mask) {
                 int n = std::countr_zero(mask);
-                mask &= ~(1 << n);
+                mask &= ~(KAFFINITY(1) << n);
 
                 // find the CPU matching this number in this group
                 for ( ; info < std::to_address(infos.end()); ++info) {


### PR DESCRIPTION
It's UB to do `1 << 32` and that will in any case never match `0x1'0000'0000`.

Amends commit f74847bb1a9434621803239ee09b77597c15990b from nearly 2 years ago.