### PR TITLE
FW/Topology/Win32: don't use GetLogicalProcessorInformationEx if CPUID works

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -804,6 +804,8 @@ static bool detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP relationships)
 bool TopologyDetector::detect_via_os(Topology::Thread *info)
 {
     detect_ucode_via_os(info);
+    if (info->core_id >= 0)
+        return true;                // detect_via_cpuid() has succeeded
     if (info != &cpu_info[0])
         return info->core_id != -1; // we only need to run once
 


### PR DESCRIPTION
Amends commit 41a6995874eb504fef18f259ad4b8ed4a4dda830, which refactored the Windows code and made us call the Win32 API in spite of getting information from CPUID. We don't need it for the processors' information if CPUID works, only for NUMA.