### PR TITLE
FW/Topology/Win32: also handle `RelationNumaNode`

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -773,6 +773,7 @@ static bool detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP relationships)
             break;
         }
 
+        case RelationNumaNode:
         case RelationNumaNodeEx: {
             // this only works for Windows 20H2 or later, otherwise GroupCount = 0
             auto &numa = *reinterpret_cast<NUMA_NODE_RELATIONSHIP_2 *>(&lpi->NumaNode);


### PR DESCRIPTION
The documentation for `GetLogicalProcessorInformationEx()`[1] is vague on what gets returned. It says:

> Requests for `RelationNumaNodeEx` or `RelationAll` will return
> `NUMA_NODE_RELATIONSHIP` structures that contain an array of affinities
> for the node over all groups.

But doesn't explain that the `Relationship` member will still contain `RelationNumaNode`. Testing on my workstation (Windows 11) and on a Windows 2022 server shows that Windows returns `RelationNumaNode` with a non-zero `GroupCount`.

After this, the `cpu_info::numa_id` field gets populated. Testing on the server with multiple sockets confirms it:
```yaml
command-line: 'opendcdiag.exe --disable=* -Y -o - --cpuset=c0'
version: opendcdiag-479c4adea2e1
os: Windows Server v10.0.20348
runtime: UCRT
openssl: null
timing: { duration: 1000.000, timeout: 300000.000 }
cpu-info:
- { logical-group:  0, logical:  0, package: 0, numa_node: 0, module: 0, core: 0, thread: 0, family: 6, model: 0x8f, stepping: 8, microcode: 0x2b000601, ppin: null }   # 0
- { logical-group:  0, logical:  1, package: 0, numa_node: 0, module: 0, core: 0, thread: 1, family: 6, model: 0x8f, stepping: 8, microcode: 0x2b000601, ppin: null }   # 1
- { logical-group:  2, logical:  0, package: 1, numa_node: 1, module: 0, core: 0, thread: 0, family: 6, model: 0x8f, stepping: 8, microcode: 0x2b000601, ppin: null }   # 2
- { logical-group:  2, logical:  1, package: 1, numa_node: 1, module: 0, core: 0, thread: 1, family: 6, model: 0x8f, stepping: 8, microcode: 0x2b000601, ppin: null }   # 3
```

[1] https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex