### PR TITLE
FW: fix performance issue found by static analysis tool

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2267,7 +2267,7 @@ static void list_tests(const ProgramOptions& opts)
     if (opts.list_tests_include_groups && !groups.empty()) {
         if (opts.list_tests_include_descriptions)
             printf("\nGroups:\n");
-        for (auto pair : groups) {
+        for (const auto &pair : groups) {
             const auto &g = pair.second;
             if (opts.list_tests_include_descriptions) {
                 printf("@%-21s \"%s\"\n", g.definition->id, g.definition->description);


### PR DESCRIPTION
The tool says that use of `auto` causes a copy here. That's correct and `collate_test_groups()::Group` has a `std::vector` member.