### PR TITLE
FW/child_debug: rewrite the GDB communication to handle large outputs

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -173,7 +173,7 @@ static int xsave_size = 0;
 static const char gdb_preamble_commands[] = R"(set prompt
 set pagination off
 set confirm off
-python handle = %#tx; print('ok')
+python handle = %#tx; print("\1")
 )";
 static const char gdb_bt_commands[] =
 #ifndef __x86_64__
@@ -203,7 +203,7 @@ if thr is not None:
         gdb.execute("x/i $pc")
     except gdb.MemoryError as e:
         print(e)
-print("..Done..")
+print("\1")
 end
 )gdb";
 
@@ -612,14 +612,14 @@ static auto communicate_gdb_backtrace(int in, int out, uintptr_t handle)
     if (!read_until(in, buf, std::string_view()))
         return result;
 
-    bool send_python = handle && (buf == "ok\n");
+    bool send_python = handle && (buf == "\1\n");
     if (send_python) {
         ret = write(out, gdb_python_commands, strlen(gdb_python_commands));
         if (ret != ssize_t(strlen(gdb_python_commands)))
             return result;
 
         // read and accumulate until the Python reply is complete
-        static const char needle[] = "\n..Done..\n";
+        constexpr std::string_view needle = "\n\1\n";
         if (!read_until(in, buf, needle))
             return result;
 


### PR DESCRIPTION
This code has been mostly unmodified since I wrote it in 2021, including the "###" comment indicating that "gdb writes only a handful of bytes".

Unfortunately, that's not really true. On attaching to a running process, the GDB preamble can actually be quite long and overflow our 4096-byte buffer. GDB prints the "[New LWP xxxxxx]" line for each thread it detects (of which we can easily see more than 256 these days), the current frame, and, on some systems, a long list of system packages that it thinks are missing. The initial frame after attaching is usually `syscall` or something equivalent inside of libc, but if our Python script is successful at finding the actual crashing frame, its name may be arbitrarily long. For example, I can see a 3958-character-long C++ function name from Eigen in our binaries.

This commit removes any limitation by reading straight into the heap-allocated `std::string`, which we grow as needed.

Fixes #707.