### PR TITLE
FW/child_debug: don't print C++ static members

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -172,6 +172,7 @@ static int xsave_size = 0;
 
 static const char gdb_preamble_commands[] = R"(set prompt
 set pagination off
+set print static-members off
 set confirm off
 python handle = %#tx; print("\1")
 )";


### PR DESCRIPTION
They're usually not useful, especially the constant ones.