### PR TITLE
CPU-separation: use `device_info` alias in common code

### DIFF
--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -167,6 +167,9 @@ struct cpu_info
 #endif
 };
 
+// Alias for use in common framework code
+typedef struct cpu_info device_info;
+
 /// cpu_info is an array of cpu_info structures.  Each element of the array
 /// contains information about a logical CPU that will be used to
 /// execute a test's test_run function.  The size of this array is

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1820,7 +1820,7 @@ void KeyValuePairLogger::print_thread_header(int fd, int cpu, const char *prefix
         return;
     }
 
-    struct cpu_info *info = cpu_info + cpu;
+    device_info *info = cpu_info + cpu;
     const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(info->package_id);
     PerThreadData::Test *thr = sApp->test_thread_data(cpu);
     if (std::string time = format_duration(thr->fail_time); time.size()) {
@@ -2077,7 +2077,7 @@ void TapFormatLogger::print_thread_header(int fd, int cpu, int verbosity)
         return;
     }
 
-    struct cpu_info *info = cpu_info + cpu;
+    device_info *info = cpu_info + cpu;
     std::string line = stdprintf("  Thread %d on CPU %d (pkg %d, core %d, thr %d", cpu,
             info->cpu_number, info->package_id, info->core_id, info->thread_id);
 
@@ -2147,7 +2147,7 @@ void YamlLogger::maybe_print_messages_header(int fd)
 
 std::string YamlLogger::thread_id_header(int cpu, int verbosity)
 {
-    struct cpu_info *info = cpu_info + cpu;
+    device_info *info = cpu_info + cpu;
     std::string line;
 #ifdef _WIN32
     line = stdprintf("{ logical-group: %2u, logical: %2u, ",

--- a/framework/random.cpp
+++ b/framework/random.cpp
@@ -545,7 +545,7 @@ void random_init_thread(int thread_num)
     // Create a pattern based exclusively on the topology that we'll use
     // to seed the thread's generator. Algorithm very loosely inspired by
     // https://en.wikipedia.org/wiki/MurmurHash version 3.
-    struct cpu_info &info = cpu_info[thread_num];
+    device_info &info = cpu_info[thread_num];
     auto scramble = [](uint32_t k) {
         k *= 0xcc9e2d51;
         k = (k << 15) | (k >> 17);              // rotl(mixin, 15);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -498,7 +498,7 @@ struct SandstoneApplication::SharedMemory
     // per-thread & variable length
     int main_thread_count = 0;
     int total_cpu_count = 0;
-    alignas(64) struct cpu_info cpu_info[];         // C99 Flexible Array Member
+    alignas(64) device_info cpu_info[];         // C99 Flexible Array Member
 
 #if 0
     // in/out per-thread data allocated dynamically;

--- a/framework/sandstone_unittests_utils.cpp
+++ b/framework/sandstone_unittests_utils.cpp
@@ -8,7 +8,7 @@
 #define UNITTESTS_NUM_CPUS 16
 
 /* Define dummy setup struct that can be used by unittests when needed */
-struct cpu_info *cpu_info = nullptr;
+device_info *cpu_info = nullptr;
 
 /* Define dummy number of dummy cpus */
 int num_cpus() { return UNITTESTS_NUM_CPUS; }

--- a/tests/ifs/unit/ifs_unittests.cpp
+++ b/tests/ifs/unit/ifs_unittests.cpp
@@ -274,7 +274,7 @@ TEST(IFSTrigger, AllCoresPass)
 
     // Setup dummy cpu_info array
     int cpu_num = 2;
-    cpu_info = new struct cpu_info[cpu_num];
+    cpu_info = new device_info[cpu_num];
     cpu_info[1].cpu_number = 1;
 
     // Loop over each cpu


### PR DESCRIPTION
Other devices would introduce their own struct representing a device (GPU)