### PR TITLE
Expose test_requires_smt flag to tests

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1584,7 +1584,6 @@ static void wait_for_children(ChildrenList &children, const struct test *test)
     }
 }
 
-
 static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
 {
     if (sApp->current_fork_mode() != SandstoneApplication::no_fork) {
@@ -1610,7 +1609,7 @@ static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
 
         auto has_smt = []() -> bool {
             for(int idx = 0; idx < num_cpus() - 1; idx++) {
-                if(cpu_info[idx].thread_id + 1 == cpu_info[idx + 1].thread_id)
+                if (cpu_info[idx].core_id == cpu_info[idx + 1].core_id)
                     return true;
             }
             return false;

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -294,8 +294,9 @@ typedef enum test_flag {
     /// package and not to threads or cores.
     test_failure_package_only       = 0x1000,
 
+    /// Indicates test requires to have Simultaneous Multi-Threading(SMT)/Hyperthreading(HT)
+    /// support
     test_requires_smt               = 0x4000,
-
 } test_flags;
 
 struct test_data_per_thread

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -1343,7 +1343,15 @@ static struct test selftests_array[] = {
     .desired_duration = 750,
     .quality_level = TEST_QUALITY_PROD,
 },
-
+{
+    .id = "selftest_requires_smt",
+    .description = "Test the flag test_requires_smt",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_run = selftest_pass_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+    .flags = test_requires_smt,
+},
 {
     .id = "selftest_timedpass_busywait",
     .description = "Runs for the requested time, but busy-waiting", // or practically so


### PR DESCRIPTION
Why is this required?

Many tests in Sandstone need hyperthreading(smt) to be effective.
These tests need to write extra code to detect if there is a sibling
thread in the same core(HT). If no sibling thread present, they skip.
This flag will ease test writer's job where they can specify this flag
in test details and framework will skip this test if there are no hyperthreads.
If there is "atleast" 1 hyperthread, the test runs.

bats output:

```
SANDSTONE_BIN=build/opendcdiag bats -t -f "selftest test smt" bats/sanity-check
1..2
ok 1 selftest test smt skip
ok 2 selftest test smt run
```

This is still a draft PR since more tests which consider cases like slicing and Dual Core Module(DCM) needs to be added.
