### PR TITLE
FW/Logging: fix capturing of ps output on Linux for hung tests

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1286,6 +1286,22 @@ function selftest_logerror_common() {
     done
 }
 
+@test "ps on selftest_freeze" {
+    local psver=`LC_ALL=C.UTF-8 ps --version`
+    if [[ "$psver" != *procps* ]]; then
+        skip "Test requires procps (Linux)"
+    fi
+
+    local newline=$'\n'
+    declare -A yamldump
+    sandstone_selftest -vvv --on-crash=kill --on-hang=ps -e selftest_freeze --timeout=500
+    [[ "$status" -eq 2 ]]
+    test_yaml_regexp "/exit" invalid
+    test_yaml_regexp "/tests/0/result" 'timed out'
+    test_yaml_regexp "/tests/0/threads/0/messages/0/level" 'info'
+    test_yaml_regexp "/tests/0/threads/0/messages/0/text" ".*\bPID\b.*\bCOMMAND\b.*${newline}.*\bcontrol\b.*"
+}
+
 @test "selftest_freeze_exit_on_termination" {
     if $is_windows; then
         skip "Unix-only test"


### PR DESCRIPTION
Fixes commit f1d4860465f228bc9e60c856eeefc86018339bb5, which made this use `std::string`: it opens a temporary file (memfd on Linux) for the child process and then reads from it. But a temporary file is not a pipe and the child process will sync its read/write position with the the parent. Therefore, we must `lseek()` prior to reading from the fd.

And of course we must add the number of bytes read to `total_read`.