### PR TITLE
FW: re-disable stdout in debug builds

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -143,6 +143,10 @@ framework_config.set10(
     'SANDSTONE_RESTRICTED_CMDLINE',
     get_option('framework_options').contains('restricted-cmdline'),
 )
+framework_config.set10(
+    'SANDSTONE_ALLOW_STDOUT_FROM_TESTS',
+    get_option('framework_options').contains('allow-stdout-from-tests')
+)
 if get_option('framework_options').contains('no-child-debug')
     framework_config.set10('SANDSTONE_CHILD_DEBUG_CRASHES', false)
     framework_config.set10('SANDSTONE_CHILD_DEBUG_HANGS', false)

--- a/framework/sandstone_config.h.in
+++ b/framework/sandstone_config.h.in
@@ -26,6 +26,7 @@
 #mesondefine SANDSTONE_SSL_BUILD
 #mesondefine SANDSTONE_SSL_LINKED
 
+#mesondefine SANDSTONE_ALLOW_STDOUT_FROM_TESTS
 #mesondefine SANDSTONE_DEFAULT_LOGGING
 #mesondefine SANDSTONE_NO_LOGGING
 #mesondefine SANDSTONE_RESTRICTED_CMDLINE
@@ -45,6 +46,7 @@ static constexpr bool Debug = DEBUG;
 static constexpr bool StaticLink = SANDSTONE_STATIC;
 
 // keep alphabetical order, please
+static constexpr bool AllowStdoutFromTests = SANDSTONE_ALLOW_STDOUT_FROM_TESTS;
 static constexpr bool ChildBacktrace = SANDSTONE_CHILD_BACKTRACE;
 static constexpr bool ChildDebug = SANDSTONE_CHILD_DEBUG;
 static constexpr bool ChildDebugCrashes = SANDSTONE_CHILD_DEBUG_CRASHES;

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,7 +7,8 @@ option('march_base', type : 'string', value : '',
     description : 'Build framework with this base optimization -march= value (default: "haswell").')
 option('framework_options', type : 'array', value : [],
     description : 'Configuration options for the framework. ' +
-    'Possible options: restricted-cmdline, no-child-debug{,-crashes,-hangs}, no-child-backtrace, no-triage')
+    'Possible options: restricted-cmdline, no-child-debug{,-crashes,-hangs}, no-child-backtrace, ' +
+    'allow-stdout-from-tests')
 option('dependency_link', type : 'combo', choices : ['dynamic', 'static'], value : 'dynamic',
     description : 'Link preference for dependencies: dynamic (default) or static')
 option('docdir', type : 'string', value : 'doc/dcdiag',


### PR DESCRIPTION
Updates 40f2b76248dd974948979a505fe66eac25702cd2, which allowed `printf()` and family to print to stdout in debug builds, because printf-debugging was useful with some libraries we had to use.

This retains that capability, but makes it an explicit opt-in, not conditional in simply being a debug-mode build.

Drive-by remove the "no-triage" framework option.