### PR TITLE
CI/Bats: redirect output of the yq run to /dev/null

### DIFF
--- a/bats/sanity-check/21-slicing.bats
+++ b/bats/sanity-check/21-slicing.bats
@@ -8,7 +8,7 @@ MAX_PROC=`nproc`
 
 function cpuset_unique_modules() {
     # Make a list of cores that are in unique modules
-    sandstone_yq --cpuset=t0 '--disable=*' > /dev/null
+    VALIDATION=0 sandstone_yq --cpuset=t0 '--disable=*' > /dev/null
 
     query_jq -r '."cpu-info" | unique_by(.module)[0:'$1'][]
         | "p" + (.package|tostring) + "c" + (.core|tostring) + "t0"'

--- a/bats/sanity-check/21-slicing.bats
+++ b/bats/sanity-check/21-slicing.bats
@@ -8,7 +8,7 @@ MAX_PROC=`nproc`
 
 function cpuset_two_modules() {
     # Find a different module
-    sandstone_yq --cpuset=t0 '--disable=*'
+    sandstone_yq --cpuset=t0 '--disable=*' > /dev/null
     echo -n 'p0c0t0,'
     query_jq -r '[."cpu-info"[] | select(.module > 0)][0] |
         "p" + (.package|tostring) + "c" + (.core|tostring) + "t0"'


### PR DESCRIPTION
I don't know how this passed before, but I forgot the `sandstone_yq` shell function passes the tool's output to its stdout, so Bats would log it. That is fine when running in the `@test` but not if we are trying to capture another shell function's output.

We were getting a very cryptic
```
opendcdiag/bats/sanity-check/21-slicing.bats: line 123: set: --: invalid option
```

Because the output of the `cpuset_two_modules` function was:
```
--- THIS IS AN UNOPTIMIZED BUILD: DON'T TRUST TEST TIMING! command-line: 'opendcdiag --on-crash=core --on-hang=kill -Y -o - --cpuset=t0 --disable=*' ...
```

Additionally, use make the third test function use the same shell function, since all we need are unique modules anyway.