### PR TITLE
FW: update the "dumb" test plan to round up

### DIFF
--- a/bats/sanity-check/21-slicing.bats
+++ b/bats/sanity-check/21-slicing.bats
@@ -68,7 +68,7 @@ function cpuset_two_modules() {
 @test "no slicing if too few cores per socket" {
     declare -A yamldump
 
-    export SANDSTONE_MOCK_TOPOLOGY=`seq 0 $MAX_PROC | xargs`
+    export SANDSTONE_MOCK_TOPOLOGY=`seq 0 $((MAX_PROC - 1))| xargs`
     echo "SANDSTONE_MOCK_TOPOLOGY=\"$SANDSTONE_MOCK_TOPOLOGY\""
     sandstone_yq --disable=\*
 
@@ -77,6 +77,7 @@ function cpuset_two_modules() {
 
     local sockets=`query_jq -r '[ ."cpu-info"[].package ] | unique | length'`
     if $is_debug; then
+        # check that the tool reported as many sockets as we expect it to
         [[ ${sockets-0} = $MAX_PROC ]]
     fi
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1234,6 +1234,8 @@ static void slice_plan_init(int max_cores_per_slice)
         plan.reserve(slice_count);
 
         int slice_size = max_cpu / slice_count;
+        if (max_cpu % slice_count)
+            ++slice_size;       // round up the slice size
         int cpu = 0;
         for ( ; cpu < max_cpu - slice_size; cpu += slice_size)
             plan.push_back(DeviceRange{ cpu, slice_size });


### PR DESCRIPTION
There was an off-by-one error between the test and the plan, observed on an 86-core Intel Xeon 6P: the 172 threads become 172 "packages" in debug mode, which should produce 6 slices. However, because we rounded the `slice_size` down to 28 instead of 29, that added a 7th slice.