### PR TITLE
FW: remove unused constant `SecondaryMaxCoresPerSlice` from header

### DIFF
--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -347,7 +347,6 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     struct SlicePlans {
         static constexpr int MinimumCpusPerSocket = 8;
         static constexpr int DefaultMaxCoresPerSlice = 32;
-        static constexpr int SecondaryMaxCoresPerSlice = DefaultMaxCoresPerSlice * 3 / 4;
         enum Type : int8_t {
             FullSystem = -1,
             IsolateSockets,


### PR DESCRIPTION
Amends commit 4b2b1068fc64180a06e3ed52e6444c089a47a6fd, which removed the use of this constant.