### PR TITLE
CI/Bats: set PATH to something non-empty and for a single command.

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1511,7 +1511,7 @@ selftest_crash_common() {
     # Ensure we can use this option even if gdb isn't found
     # (can't use run_sandstone_yaml here because we empty $PATH)
     if ! $is_windows; then (
-        PATH=
+        PATH=/
         run $SANDSTONE -Y --selftests -e selftest_sigsegv --retest-on-failure=0 --on-crash=context -o -
         [[ $status -eq 1 ]]     # instead of 64 (EX_USAGE)
         [[ "$output" = *"level: info"*"Registers:"* ]]

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1510,9 +1510,8 @@ selftest_crash_common() {
 
     # Ensure we can use this option even if gdb isn't found
     # (can't use run_sandstone_yaml here because we empty $PATH)
-    if ! $is_windows; then (
-        PATH=/
-        run $SANDSTONE -Y --selftests -e selftest_sigsegv --retest-on-failure=0 --on-crash=context -o -
+    if ! $is_windows; then
+        run env PATH=/ $SANDSTONE -Y --selftests -e selftest_sigsegv --retest-on-failure=0 --on-crash=context -o -
         [[ $status -eq 1 ]]     # instead of 64 (EX_USAGE)
         [[ "$output" = *"level: info"*"Registers:"* ]]
         ! [[ "$output" = *Backtrace:* ]]
@@ -1521,10 +1520,10 @@ selftest_crash_common() {
         local opts=($SANDSTONE)         # split on space
         opts=(${opts/--on-crash=*})     # remove --on-crash
         SANDSTONE="${opts[@]}"          # rejoin with spaces
-        run $SANDSTONE -Y --selftests -e selftest_sigsegv --retest-on-failure=0 -o -
+        run env PATH=/ $SANDSTONE -Y --selftests -e selftest_sigsegv --retest-on-failure=0 -o -
         [[ "$output" = *"level: info"*"Registers:"* ]]
         ! [[ "$output" = *Backtrace:* ]]
-    ); fi
+    fi
 }
 
 @test "crash backtrace" {


### PR DESCRIPTION
Because our code does handle the empty case:
```c++
    if (const char *env = getenv("PATH"); env && *env)
        path = env;
    else
        path = _PATH_DEFPATH;
```

In which case we may have found GDB when we didn't mean to. Don't ask me how this is passing in the CI. Of course, now that I've shown it shouldn't be, it'll prompty break everywhere[1].

And set it for a single command, instead of setting it in the shell and making our lives harder in using shell tools.

[1] https://en.wikipedia.org/wiki/Schr%C3%B6dinbug