### PR TITLE
Prevent clang "built-in" malloc() optimization

### DIFF
--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -790,7 +790,8 @@ static int selftest_malloc_fail(struct test *test, int cpu)
 {
     // ask for a very, very silly allocation size, which malloc can't possibly honor
     size_t size = size_t(1) << 62;
-    void *ptr = malloc(size);
+    // prevent malloc() from being optimized-out as a "built-in" function (clang issue)
+    void* volatile ptr = malloc(size);
     int ret = (ptr == NULL ? EXIT_SUCCESS : EXIT_FAILURE);
     free(ptr);
     return ret;


### PR DESCRIPTION
Clang assumes some pre-optimizations for some compile-time conditions. One of these are extremely large allocations. As the framework overrides default implementation, one of the tests (selftest_malloc_fail) doesn't work as expected. The optimization must be forced out in this particular case.