### PR TITLE
FW: rename rescheduler class and objects

### DIFF
--- a/framework/device/cpu/topology_cpu.h
+++ b/framework/device/cpu/topology_cpu.h
@@ -81,7 +81,7 @@ struct Topology::Data
 
 bool pin_thread_to_logical_processor(LogicalProcessor n, tid_t thread_id, const char *thread_name = nullptr);
 
-class BarrierDeviceSchedule : public DeviceSchedule
+class BarrierDeviceScheduler : public DeviceScheduler
 {
 public:
     void reschedule_to_next_device() override;
@@ -112,7 +112,7 @@ private:
     std::mutex groups_mutex;
 };
 
-class QueueDeviceSchedule : public DeviceSchedule
+class QueueDeviceScheduler : public DeviceScheduler
 {
 public:
     void reschedule_to_next_device() override;
@@ -126,7 +126,7 @@ private:
     std::mutex q_mutex;
 };
 
-class RandomDeviceSchedule : public DeviceSchedule
+class RandomDeviceScheduler : public DeviceScheduler
 {
 public:
     void reschedule_to_next_device() override;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -951,8 +951,8 @@ static uintptr_t thread_runner(int thread_number)
         test_end(new_state);
 
         // If rescheduling, do cleanup
-        if (sApp->device_schedule)
-            sApp->device_schedule->finish_reschedule();
+        if (sApp->device_scheduler)
+            sApp->device_scheduler->finish_reschedule();
     });
 
     // indicate to SIGQUIT handler that we're running
@@ -2680,7 +2680,7 @@ int main(int argc, char **argv)
                     program_invocation_name);
             return EX_USAGE;
         }
-        if (sApp->device_schedule) {
+        if (sApp->device_scheduler) {
             fprintf(stderr, "%s: error: --reschedule is not supported in this configuration\n",
                     program_invocation_name);
             return EX_USAGE;

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -843,8 +843,8 @@ struct ProgramOptionsParser {
                 return EX_USAGE;
             }
 
-            sApp->device_schedule = make_rescheduler(value);
-            if (!sApp->device_schedule) {
+            sApp->device_scheduler = make_rescheduler(value);
+            if (!sApp->device_scheduler) {
                 fprintf(stderr, "%s: unknown reschedule option: %s\n", argv[0], value);
                 return EX_USAGE;
             }

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -450,7 +450,7 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
 
     SandstoneBackgroundScan background_scan;
 
-    std::unique_ptr<DeviceSchedule> device_schedule = nullptr;
+    std::unique_ptr<DeviceScheduler> device_scheduler = nullptr;
 
 private:
     SandstoneApplication() = default;

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -211,8 +211,8 @@ static int selftest_logs_reschedule_run(struct test *test, int cpu)
     if (cpu > 0)
         sem_wait(&semaphores[cpu-1]);
 
-    if (sApp->device_schedule)
-        sApp->device_schedule->reschedule_to_next_device();
+    if (sApp->device_scheduler)
+        sApp->device_scheduler->reschedule_to_next_device();
 
     // When we finish, instruct next thread it can proceed
     // unless we are the last one

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -21,14 +21,14 @@
 
 #include "gettid.h"
 
-class DeviceSchedule {
+class DeviceScheduler {
 public:
-    virtual ~DeviceSchedule() = default;
+    virtual ~DeviceScheduler() = default;
     virtual void reschedule_to_next_device() = 0;
     virtual void finish_reschedule() = 0;
 };
 
-std::unique_ptr<DeviceSchedule> make_rescheduler(std::string_view mode);
+std::unique_ptr<DeviceScheduler> make_rescheduler(std::string_view mode);
 
 struct DeviceRange
 {


### PR DESCRIPTION
Actor, not a state.

---------
- parent: https://github.com/opendcdiag/opendcdiag/pull/736