### PR TITLE
Tests/x86: don't downgrade CPU target from what the user asked

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -133,6 +133,17 @@ sandstone_tests += [
 ]
 
 if host_machine.cpu_family() == 'x86_64'
+    march_hsw = [
+        '-march=haswell',
+        '-mtune=skylake',
+        '-mrtm',
+    ]
+    march_skx = [
+        '-march=skylake-avx512',
+        '-mtune=skylake-avx512',
+        '-mrtm',
+    ]
+
     tests_config_hsw = tests_set_hsw.apply(tests_config)
 
     tests_hsw_a = static_library(
@@ -145,15 +156,11 @@ if host_machine.cpu_family() == 'x86_64'
         ],
         c_args : [
             tests_common_c_args,
-            '-march=haswell',
-            '-mtune=skylake',
-            '-mrtm',
+            march_hsw,
         ],
         cpp_args : [
             tests_common_cpp_args,
-            '-march=haswell',
-            '-mtune=skylake',
-            '-mrtm',
+            march_hsw,
             '-DEigen=EigenAVX2',
         ],
     )
@@ -173,13 +180,11 @@ if host_machine.cpu_family() == 'x86_64'
         ],
         c_args : [
             tests_common_c_args,
-            '-march=skylake-avx512',
-            '-mtune=skylake-avx512',
+            march_skx,
         ],
         cpp_args : [
             tests_common_cpp_args,
-            '-march=skylake-avx512',
-            '-mtune=skylake-avx512',
+            march_skx,
             '-DEigen=EigenAVX512',
         ],
     )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -144,6 +144,16 @@ if host_machine.cpu_family() == 'x86_64'
         '-mrtm',
     ]
 
+    # Check if march_base has a higher CPU target, in which case
+    # we should not downgrade
+    if cc.has_define('__AVX512F__', args: tests_common_c_args)
+        # We're already targetting AVX512
+        march_skx = []
+        march_hsw = []
+    elif cc.has_define('__AVX2__', args: tests_common_c_args)
+        march_hsw = []
+    endif
+
     tests_config_hsw = tests_set_hsw.apply(tests_config)
 
     tests_hsw_a = static_library(


### PR DESCRIPTION
The -Dmarch_base= config option sets a minimum CPU for the whole build. So far, we've only used "westmere" (a.k.a. "x86-64-v2") and "haswell" (a.k.a. "x86-64-v3"), which was ok. But if someone used a later version like "x86-64-v4" or "diamondrapids", some or all of the tests would downgrade to a lesser CPU.
