### PR TITLE
FW: provide C-based interface for reschedule

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -918,6 +918,12 @@ void test_loop_end() noexcept
     assembly_marker<TestLoop, End>(sApp->test_thread_data(thread_num)->inner_loop_count);
 }
 
+void reschedule()
+{
+    if (sApp->device_scheduler)
+        sApp->device_scheduler->reschedule_to_next_device();
+}
+
 #ifndef _WIN32
 #  pragma GCC visibility pop
 #endif

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -459,6 +459,8 @@ static inline bool write_msr(int cpu, uint32_t msr, uint64_t value)
 }
 #endif
 
+/// Interface for C-based tests
+void reschedule();
 
 /// Calls aligned_alloc but first checks to see whether size is a multiple
 /// of alignment.  If it is not, the requested size of the allocation is increased


### PR DESCRIPTION
It was a mistake to remove it in the first place.