### PR TITLE
Tests/x86: remove `-mtune=skylake-avx512`

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -140,7 +140,6 @@ if host_machine.cpu_family() == 'x86_64'
     ]
     march_skx = [
         '-march=skylake-avx512',
-        '-mtune=skylake-avx512',
         '-mrtm',
     ]
 


### PR DESCRIPTION
The original SKX from nearly 10 years ago had a much worse performance profile in AVX512 than current processors do, so the compiler decisions implemented by the compiler do not reflect best reality.  This is causing the compiler to emit 256-bit AVX512 instead of 512-bit in tests, so we need to think a little more if we want to keep this or not.

A future patch may change this to something like
```
   '-mtune=graniterapids',
   '-mprefer-vector-width=512',
```