### PR TITLE
FW/CPU: exit with `_exit()` when the CPU check fails

### DIFF
--- a/framework/device/cpu/cpuid_internal.h
+++ b/framework/device/cpu/cpuid_internal.h
@@ -250,7 +250,7 @@ static void check_missing_features(cpu_features_t features, cpu_features_t minim
             fputs(features_string + features_indices[i], stderr);
     }
     fputs("\nexit: invalid\n", stderr);
-    exit(EX_CONFIG);
+    _exit(EX_CONFIG);
 }
 
 #undef cpuid_errmsg


### PR DESCRIPTION
Because `exit()` will run static destructors, which may have code compiled for later CPU generations and thus crash.

I noticed this when trying to run a build designed for the upcoming Diamond Rapids processor (APX-F + AVX10.2):
```
./opendcdiag --version
This application requires certain features not found in your CPU: sha waitpkg gfni vaes vpclmulqdq movdiri movdir64b uintr serialize pconfig sha512 avxvnni cmpccxadd avxifma avxvnniint8 avxneconvert avxvnniint16 apx-f
exit: invalid
zsh: illegal hardware instruction (core dumped)
```

GDB said:
```
Program received signal SIGILL, Illegal instruction.
0x00000000004c1c20 in ?? ()
(gdb) bt
#0  0x00000000004c1c20 in ?? ()
#1  0x00007ffff7fc9c92 in _dl_call_fini () at dl-call_fini.c:43
#2  0x00007ffff7fcced4 in _dl_fini () at dl-fini.c:120
#3  0x00007ffff7c5de81 in __run_exit_handlers () at exit.c:118
#4  0x00007ffff7c5df5a in __GI_exit () at exit.c:148
#5  0x00000000004c2417 in ?? ()
#6  0x00000000056adcbd in ?? ()
#7  0x00007ffff7c3cc1f in __libc_start_main_impl () at ../csu/libc-start.c:343
(gdb) disass/r $pc,+3
Dump of assembler code from 0x4c1c20 to 0x4c1c23:
=> 0x00000000004c1c20:  d5 08 53                pushp  %rbx
```

That's the new PPX-Accelerated PUSH that indicates it's paired with a POPP. These are not the "push a pair" instructions, that's PUSH2 (there's also PUSH2P). See the APX Specification[1] chapter 9.

[1] https://cdrdv2.intel.com/v1/dl/getContent/784266