### PR TITLE
Tests/x86: remove `-mrtm` from the AVX2 & AVX512 builds

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -136,12 +136,10 @@ if host_machine.cpu_family() == 'x86_64'
     march_hsw = [
         '-march=haswell',
         '-mtune=skylake',
-        '-mrtm',
     ]
     march_skx = [
         '-march=skylake-avx512',
         '-mtune=skylake-avx512',
-        '-mrtm',
     ]
 
     # Check if march_base has a higher CPU target, in which case


### PR DESCRIPTION
Client CPUs with AVX512 don't have it, such as my Tiger Lake laptop and a lot of other systems where the kernel or BIOS disables TSX due to the TSX Async Abort (TAA) mitigation.
```yaml
tests:
- test: eigen_svd_cdouble
  details: { quality: production, description: "Eigen SVD (Singular Value Decomposition) solving payload, which issues a bunch of matrix multiplies underneath, now operating on std::complex<double>" }
  state: { seed: 'LCG:570756152', iteration: 0, retry: false }
  time-at-start: { elapsed:      0.000, now: !!timestamp '2025-09-05T22:52:46Z' }
  result: skip
  skip-category: CpuNotSupported
  skip-reason: 'test requires rtm'
  time-at-end:   { elapsed:      0.000, now: !!timestamp '2025-09-05T22:52:46Z' }
  test-runtime: 0.036
```

Amends commit 379d52b0c5223004eae599633e6b5a2a4eefc4d5, which claimed "There's no harm, because the compiler never emits TSX code." Well, the compiler never emits TSX code, but it does set `__RTM__` and we set it in `_compilerCpuFeatures`:
```c
#ifdef __RTM__
         | cpu_feature_rtm
#endif
```