### PR TITLE
CPU-separation: decouple XSaveBits used for dumping

### DIFF
--- a/framework/sandstone_child_debug_common.h
+++ b/framework/sandstone_child_debug_common.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 #ifdef __x86_64__
-#  include "cpu_features.h"
+#  include "xsave_states.h"
 
 #  include <algorithm>
 #  include <cpuid.h>
@@ -29,8 +29,8 @@ inline int xsave_size_for_bitvector(uint64_t xsave_bv)
     if (cpuid_bv & ~xsave_bv) {
         // yes, find the end of the highest state that we *are* transferring
         int bit = 2;
-        uint64_t mask = XSave_Ymm_Hi128;
-        xsave_bv &= ~(XSave_SseState | XSave_X87);  // included in FXSAVE
+        uint64_t mask = XSave::Ymm_Hi128;
+        xsave_bv &= ~(XSave::SseState | XSave::X87);  // included in FXSAVE
         for ( ; xsave_bv; ++bit, mask <<= 1) {
             if ((xsave_bv & mask) == 0)
                 continue;

--- a/framework/xsave_states.h
+++ b/framework/xsave_states.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef XSAVE_STATES_H
+#define XSAVE_STATES_H
+
+// These are only states used for dumping
+enum XSave
+{
+    X87          = 0x0001,            // X87 and MMX state
+    SseState     = 0x0002,            // SSE: 128 bits of XMM registers
+    Ymm_Hi128    = 0x0004,            // AVX: high 128 bits in YMM registers
+    OpMask       = 0x0020,            // AVX512: k0 through k7
+    Zmm_Hi256    = 0x0040,            // AVX512: high 256 bits of ZMM0-15
+    Hi16_Zmm     = 0x0080,            // AVX512: all 512 bits of ZMM16-31
+    Xtilecfg     = 0x20000,           // AMX: XTILECFG register
+    Xtiledata    = 0x40000,           // AMX: data in the tiles
+    ApxState     = 0x80000,           // APX Extended GPRs
+    AvxState     = SseState | Ymm_Hi128,
+    Avx512State  = AvxState | OpMask | Zmm_Hi256 | Hi16_Zmm,
+    AmxState     = Xtilecfg | Xtiledata,
+};
+
+#endif /* XSAVE_STATES_H */


### PR DESCRIPTION
So that `sandstone_context_dump.cpp` does not depend on `cpu_features.h` file