### PR TITLE
FW: add flag `test_init_in_parent` to execute init() in the parent

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -297,6 +297,11 @@ typedef enum test_flag {
     /// Indicates test requires to have Simultaneous Multi-Threading(SMT)/Hyperthreading(HT)
     /// support
     test_requires_smt               = 0x4000,
+
+    /// Indicates the test's init function should be run in the parent, to log
+    /// the state. Do not cause a "memory" effect between tests, and do not use
+    /// the random generator.
+    test_init_in_parent             = 0x10000,
 } test_flags;
 
 struct test_data_per_thread


### PR DESCRIPTION
This allows certain tests that always, deterministically and with little overhead skip or fail to be run in the parent process, avoiding the need to create a child process and waiting on it. This is going to be useful for the placeholder tests that cannot be implemented in a given OS or configuration, especially so for Windows where `CreateProcess` is rather expensive.