### PR TITLE
FW/Logging: fix unexpected closing of stdout in `-fexec` mode

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -616,7 +616,7 @@ void logging_init_global(void)
             !SandstoneConfig::AllowStdoutFromTests) {
         // replace stdout with /dev/null
         close(STDOUT_FILENO);
-        int devnull = open(_PATH_DEVNULL, O_RDWR | O_CLOEXEC);
+        int devnull = open(_PATH_DEVNULL, O_RDWR);
         assert(devnull >= 0);
         if (devnull != STDOUT_FILENO) {
             dup2(devnull, STDOUT_FILENO);


### PR DESCRIPTION
Amends commit 3994e19308d9b170ee5d62514d27234d368efccc, which introduced this problem by opening "/dev/null" with `O_CLOEXEC`. I don't think this affected Windows because the three standard handles are special.