### PR TITLE
FW/Logging: include the resource usage even for slices that didn't fail

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1536,7 +1536,8 @@ selftest_crash_common() {
 @test "crash context" {
     declare -A yamldump
     selftest_crash_context_common -n1 -e selftest_sigsegv --on-crash=context
-    test_yaml_regexp "/tests/0/threads/0/thread" '[0-9]+'       # not 'main'
+    test_yaml_regexp "/tests/0/threads/0/thread" 'main'
+    test_yaml_regexp "/tests/0/threads/1/thread" '[0-9]+'       # not 'main'
 
     # Ensure we can use this option even if gdb isn't found
     # (can't use run_sandstone_yaml here because we empty $PATH)
@@ -1631,7 +1632,7 @@ selftest_interrupt_common() {
     fi
 
     # Confirm the grandchild died too
-    local msg=/tests/0/threads/0/messages/0/text
+    local msg=/tests/0/threads/1/messages/0/text
     test_yaml_regexp "$msg" '.*Child pid:.*'
     pid=${yamldump[$msg]#I> Child pid: }
     if status=`ps ho s $pid`; then

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1745,16 +1745,14 @@ void YamlLogger::print_thread_header(int fd, int device, int verbosity)
     writeln(fd, indent_spaces(), "    messages:");
 }
 
-void YamlLogger::maybe_print_slice_resource_usage(int fd, int slice)
+bool YamlLogger::want_slice_resource_usage(int slice)
 {
     switch (slices[slice].result) {
     case TestResult::Skipped:
     case TestResult::Passed:
     case TestResult::Failed:
     case TestResult::OperatingSystemError:
-        if (sApp->shmem->verbosity >= 3)
-            break;
-        return;
+        return sApp->shmem->verbosity >= 3;
 
     case TestResult::Killed:
     case TestResult::CoreDumped:
@@ -1763,6 +1761,13 @@ void YamlLogger::maybe_print_slice_resource_usage(int fd, int slice)
     case TestResult::Interrupted:
         break;
     }
+    return true;
+}
+
+void YamlLogger::maybe_print_slice_resource_usage(int fd, int slice)
+{
+    if (!want_slice_resource_usage(slice))
+        return;
 
     auto runtime = slices[slice].endtime - sApp->current_test_starttime;
     writeln(fd, indent_spaces(), "    runtime: ", format_duration(runtime, FormatDurationOptions::WithoutUnit));
@@ -2038,11 +2043,17 @@ void YamlLogger::print_thread_messages()
     // print the thread messages
     auto doprint = [this](PerThreadData::Common *data, int s_tid) {
         struct mmap_region r = maybe_mmap_log(data);
+        bool want_print = data->has_failed() || sApp->shmem->verbosity >= 3;
+        ssize_t min_size = 0;
 
         /* for main threads (negative ids) adjust the message size to account
          * for skip message. this is to avoid empty messages printed to the log.
          */
-        if (r.size - (s_tid < 0 ? init_skip_message_bytes : 0) == 0 && !data->has_failed() && sApp->shmem->verbosity < 3) {
+        if (s_tid < 0 && !want_print) {
+            min_size = init_skip_message_bytes;
+            want_print = want_slice_resource_usage(~s_tid);
+        }
+        if (r.size <= min_size && !want_print) {
             munmap_and_truncate_log(data, r);
             return;             /* nothing to be printed, on any level */
         }

--- a/framework/logging.h
+++ b/framework/logging.h
@@ -70,6 +70,7 @@ private:
     void print_fixed();
     void print_thread_messages();
     void print_thread_header(int fd, int device, int verbosity);
+    bool want_slice_resource_usage(int slice);
     void maybe_print_slice_resource_usage(int fd, int slice);
     static int print_test_knobs(int fd, mmap_region r);
     static void format_and_print_skip_reason(int fd, std::string_view message);


### PR DESCRIPTION
We would get to `maybe_print_slice_resource_usage()` only if the main thread had messages or had failed, which may not always be. This is applicable for when the child crashes without writing anything and our crash handler didn't run.

[ChangeLog][Logging] Updated the logging framework to include the `resource-usage` entry (YAML output format) for crashing child processes even when the crash handler didn't run, such as when running with `--on-crash=core` or in the case of a SIGKILL signal.

Now:
```yaml
- test: selftest_sigkill
  details: { quality: production, description: "Raises SIGKILL" }
  state: { seed: 'AES:38a1dca1212b075a9ae16b2a9cda7347c75e235eded4f8a5651e94d563258cb8', iteration: 0, retry: false }
  time-at-start: { elapsed:      0.000, now: !!timestamp '2025-09-17T15:08:44Z' }
  result: crash
  result-details: { crashed: true, core-dump: false, code: 9, reason: 'Killed' }
  fail: { cpu-mask: null, time-to-fail: null, seed: 'AES:38a1dca1212b075a9ae16b2a9cda7347c75e235eded4f8a5651e94d563258cb8'}
  time-at-end:   { elapsed:     14.000, now: !!timestamp '2025-09-17T15:08:44Z' }
  test-runtime: 13.069
  threads:
  - thread: main
    runtime: 13.064
    resource-usage: { utime: 0.000, stime: 1.055, cpuavg: 8.1, maxrss: 5504, majflt: 0, minflt: 83, voluntary-cs: 11, involutary-cs: 7 }
    messages:
```