### PR TITLE
FW/Test: preinit the tests in the main process

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -329,6 +329,14 @@ selftest_pass() {
     test_yaml_regexp "/tests/2/result" skip
 }
 
+@test "selftest_preinit" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_preinit
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/test" selftest_preinit
+}
+
 @test "selftest_cxxthrowcatch" {
     # Note: we want to test with the crash handler enabled (--on-crash)
     declare -A yamldump
@@ -377,6 +385,10 @@ function selftest_log_skip_init_common() {
 
 @test "selftest_log_skip_init" {
     selftest_log_skip_init_common selftest_log_skip_init
+}
+
+@test "selftest_log_skip_preinit" {
+    selftest_log_skip_init_common selftest_log_skip_preinit '.*skip from preinit'
 }
 
 @test "selftest_log_skip_init_mainproc" {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -727,7 +727,7 @@ static void apply_group_inits(/*nonconst*/ struct test *test)
     }
 }
 
-void prepare_test(/*nonconst*/ struct test *test)
+static void prepare_test(/*nonconst*/ struct test *test)
 {
     if (test->test_preinit) {
         test->test_preinit(test);
@@ -747,6 +747,13 @@ void prepare_test(/*nonconst*/ struct test *test)
 #endif
 }
 
+
+static void preinit_tests()
+{
+    for (test_cfg_info &cfg : *test_set) {
+        prepare_test(cfg.test);
+    }
+}
 
 static void init_internal(const struct test *test)
 {
@@ -1423,8 +1430,6 @@ static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
         signals_init_child();
         debug_init_child();
     }
-
-    prepare_test(test);
 
     TestResult state = TestResult::Passed;
 
@@ -2734,6 +2739,7 @@ int main(int argc, char **argv)
     int total_tests_run = 0;
     TestResult lastTestResult = TestResult::Skipped;
 
+    preinit_tests();
     for (auto it = get_first_test(); it != test_set->end(); it = get_next_test(it)) {
         if (lastTestResult != TestResult::Skipped) {
             if (sApp->service_background_scan) {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2132,6 +2132,7 @@ static bool should_start_next_iteration(void)
 static SandstoneTestSet::EnabledTestList::iterator get_first_test()
 {
     logging_print_iteration_start();
+    test_set->maybe_reshuffle();
     auto it = test_set->begin();
     while (it != test_set->end() && (it->test->quality_level < 0 && sApp->requested_quality >= 0))
         ++it;

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -79,7 +79,7 @@ public:
     SandstoneTestSet(struct test_set_cfg cfg, unsigned int flags);
 
     // note: not idempotent, we may shuffle every time! */
-    EnabledTestList::iterator begin() noexcept
+    EnabledTestList::iterator maybe_reshuffle() noexcept
     {
         if (cfg.randomize) {
             /* Do not shuffle mce_check if present. */
@@ -90,6 +90,7 @@ public:
         return test_set.begin();
     };
 
+    EnabledTestList::iterator begin() noexcept { return test_set.begin(); }
     EnabledTestList::iterator end() noexcept { return test_set.end(); }
 
     int remove(const char *name);

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -110,6 +110,33 @@ static int selftest_timedpass_noloop_run(struct test *test, int cpu)
     return EXIT_SUCCESS;
 }
 
+static int selftest_preinit_preinit(struct test *test)
+{
+    check_is_main_process();
+    test->desired_duration = -1;
+    test->maximum_duration = 1; // 1ms only
+    return EXIT_SUCCESS;
+}
+
+static int selftest_preinit_init(struct test *test)
+{
+    // If this is an -fexec run, we can only check things in sApp->shmem for
+    // side-effects from the preinit function.
+
+    // test->desired_duration influences the loop counter (though
+    // --max-test-loop-count takes precedence...)
+    if (sApp->shmem->current_max_loop_count == INT_MAX)
+        report_fail_msg("test->desired_duration does not appear to have been taken into account");
+
+    // test->maximum_duration influences sApp->current_test_duration (so long
+    // as --force-test-time isn't used), but we can't access that so we check a
+    // side effect of the duration: the test end time
+    if (sApp->shmem->current_test_endtime - MonotonicTimePoint::clock::now() > 1ms)
+        report_fail_msg("test->maximum_duration appears not to have been taken into account");
+
+    return EXIT_SUCCESS;
+}
+
 static int selftest_logs_init(struct test *test)
 {
     log_debug("This is a debug message from init function");
@@ -304,6 +331,17 @@ static int selftest_skip_cleanup(struct test *test)
 {
     log_info("SKIP returned silently from cleanup");
     return EXIT_SKIP;
+}
+
+static int selftest_log_skip_preinit(struct test *test)
+{
+    check_is_main_process();
+    test->test_init = [](struct test *) {
+        log_skip(SelftestSkipCategory, "This is a skip from preinit");
+        return EXIT_SUCCESS;
+    };
+    test->flags = test->flags | test_init_in_parent;
+    return EXIT_SUCCESS;
 }
 
 static int selftest_errno_cleanup(struct test *test)
@@ -1164,6 +1202,16 @@ static struct test selftests_array[] = {
 },
 #endif
 {
+    .id = "selftest_preinit",
+    .description = "Changes some test configs in the preinit function",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_preinit = selftest_preinit_preinit,
+    .test_init = selftest_preinit_init,
+    .test_run = selftest_pass_run,
+    .desired_duration = INT_MAX,        // we change to -1 in the preinit
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
     .id = "selftest_logs",
     .description = "Adds some debug, info and warning messages",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
@@ -1265,6 +1313,16 @@ static struct test selftests_array[] = {
     .description = "Skips using log_skip() in the init function",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_init = selftest_log_skip_init,
+    .test_run = selftest_noreturn_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_log_skip_preinit",
+    .description = "SKIP in the init function set from the test's preinit",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_preinit = selftest_log_skip_preinit,
+    .test_init = selftest_failinit_init,
     .test_run = selftest_noreturn_run,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,


### PR DESCRIPTION
This is how it was meant to be, how it was designed back in day (commit 7c2b9cd8cc03828503da1526825dc5944ad1a3b6 in the internal repository prior to open-sourcing), but was lost in refactoring with PR #495 (commit 7c2b9cd8cc03828503da1526825dc5944ad1a3b6).

This new design is stricter in that the preinit function can only affect things that the parent process will see, for example, the timing and looping constraints or replacing the init function (so long as it runs in the parent).

No self-test for group inits because in the current design doesn't allow the selftests to have group init, therefore we can't test the side- effect.