### PR TITLE
FW: decouple `InterruptMonitor` and `SandstoneApplication`

### DIFF
--- a/framework/interrupt_monitor.hpp
+++ b/framework/interrupt_monitor.hpp
@@ -6,8 +6,9 @@
 #ifndef SANDSTONE_INTERRUPTS_MONITOR_HPP
 #define SANDSTONE_INTERRUPTS_MONITOR_HPP
 #include <sandstone.h>
-#include <stdint.h>
-#include <numeric>      // for std::accummulate
+
+#include <cstdint>
+#include <numeric> // for std::accummulate
 #include <optional>
 #include <vector>
 
@@ -18,8 +19,8 @@ class InterruptMonitor
         MCE,
         Thermal,
     };
-    static uint64_t get_total_interrupt_counts(InterruptType type)
-    {
+
+    static uint64_t get_total_interrupt_counts(InterruptType type) {
         std::vector<uint32_t> counts = get_interrupt_counts(type);
         return std::accumulate(counts.begin(), counts.end(), uint64_t(0));
     }
@@ -28,16 +29,19 @@ class InterruptMonitor
     static std::vector<uint32_t> get_interrupt_counts(InterruptType type);
 
 public:
-    std::vector<uint32_t> get_mce_interrupt_counts() const
-    { return get_interrupt_counts(MCE); }
+    static std::vector<uint32_t> get_mce_interrupt_counts() {
+        return get_interrupt_counts(MCE);
+    }
 
-    uint64_t count_mce_events() const
-    { return get_total_interrupt_counts(MCE); }
+    static uint64_t count_mce_events() {
+        return get_total_interrupt_counts(MCE);
+    }
 
-    uint64_t count_thermal_events() const
-    { return get_total_interrupt_counts(Thermal); }
+    static uint64_t count_thermal_events() {
+        return get_total_interrupt_counts(Thermal);
+    }
 
-    std::optional<uint64_t> count_smi_events(int cpu)
+    static std::optional<uint64_t> count_smi_events(int cpu)
     {
         uint64_t msi_count = 0;
         if (read_msr(cpu, MSR_SMI_COUNT, &msi_count))

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2694,17 +2694,12 @@ int main(int argc, char **argv)
         sApp->shmem->verbosity = (sApp->requested_quality < SandstoneApplication::DefaultQualityLevel) ? 1 : 0;
 
     if (InterruptMonitor::InterruptMonitorWorks && test_set->contains(&mce_test)) {
-        sApp->last_thermal_event_count = sApp->count_thermal_events();
-        sApp->mce_counts_start = sApp->get_mce_interrupt_counts();
-
         if (sApp->current_fork_mode() == SandstoneApplication::exec_each_test) {
             test_set->remove(&mce_test);
-        } else if (sApp->mce_counts_start.empty()) {
+        } else if (InterruptMonitor::get_mce_interrupt_counts().empty()) {
             logging_printf(LOG_LEVEL_QUIET, "# WARNING: Cannot detect MCE events - you may be running in a VM - MCE checking disabled\n");
             test_set->remove(&mce_test);
         }
-
-        sApp->mce_count_last = std::accumulate(sApp->mce_counts_start.begin(), sApp->mce_counts_start.end(), uint64_t(0));
     }
 
 #if SANDSTONE_FREQUENCY_MANAGER

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -327,7 +327,7 @@ struct HardwareInfo
 #endif
 };
 
-struct SandstoneApplication : public InterruptMonitor, public test_the_test_data<SandstoneConfig::Debug>
+struct SandstoneApplication : public test_the_test_data<SandstoneConfig::Debug>
 {
     enum class OutputFormat : int8_t {
         no_output   = 0,
@@ -423,10 +423,6 @@ struct SandstoneApplication : public InterruptMonitor, public test_the_test_data
     static constexpr int DefaultTemperatureThreshold = -1;
     int thermal_throttle_temp = DefaultTemperatureThreshold;
     int threshold_time_remaining = 30000;
-    uint64_t last_thermal_event_count;
-    uint64_t mce_count_last;
-    std::vector<uint32_t> mce_counts_start;
-    std::vector<uint64_t> smi_counts_start;
 
     HardwareInfo hwinfo;
 


### PR DESCRIPTION
There seems to be no need to pollute `SandstoneApplication`'s interface with
MCE related stuff.