### PR TITLE
FW/Floats: add missing header for contrived compilation

### DIFF
--- a/framework/fp_vectors/Floats.h
+++ b/framework/fp_vectors/Floats.h
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
+#include <cfloat>
 #include <limits>
 #endif
 


### PR DESCRIPTION
In contrived code where framework FP types are used-- by including fp_vector/Floats.h-- said code will not compile due to a missing FLT_MANT_DIG macro. The cfloat header has that macro.

Contrived code (referenced as `xyz.cpp`) used:
```
#include <array>
#include <bit>
#include <print>
#include <stdfloat>

#include <fp_vectors/Floats.h>

int main(int, char**)
{
    static const std::array<BFloat16, 2> arr { BFloat16 {1, 0x78, 0}, {0, 0x78, 0} };

    for (const auto& val : arr)
        std::println("{}", std::bit_cast<std::bfloat16_t>(val));

    return 0;
}
```

Compiled from top-level of checkout using:
```
g++ -Iframework -std=gnu++23 -pipe -o xyz xyz.cpp
```