### PR TITLE
Revert "FW/Logging: disable the loggers for the NO_LOGGING mode"

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -9,8 +9,6 @@
 
 #include <cinttypes>
 
-#if !SANDSTONE_NO_LOGGING
-
 void KeyValuePairLogger::prepare_line_prefix()
 {
     timestamp_prefix = log_timestamp();
@@ -350,7 +348,7 @@ auto thread_core_spacing()
     }();
     return spacing;
 }
-} // end unnamed namespace
+} // end anonymous namespace
 
 std::string thread_id_header_for_device(int cpu, int verbosity)
 {
@@ -383,5 +381,3 @@ std::string thread_id_header_for_device(int cpu, int verbosity)
     line += " }";
     return line;
 }
-
-#endif // !SANDSTONE_NO_LOGGING

--- a/framework/device/cpu/logging_cpu.h
+++ b/framework/device/cpu/logging_cpu.h
@@ -2,12 +2,8 @@
  * Copyright 2025 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef LOGGING_CPU_H
-#define LOGGING_CPU_H
 
 #include "logging.h"
-
-#if !SANDSTONE_NO_LOGGING
 
 class KeyValuePairLogger : public YamlLogger
 {
@@ -48,7 +44,3 @@ private:
     void print_child_stderr();
     std::string format_status_code();
 };
-
-#endif // !SANDSTONE_NO_LOGGING
-
-#endif // LOGGING_CPU_H

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2146,13 +2146,7 @@ void YamlLogger::print_tests_header(TestHeaderTime mode)
 TestResult logging_print_results(std::span<const ChildExitStatus> status, const struct test *test)
 {
     switch (current_output_format()) {
-#if SANDSTONE_NO_LOGGING
-    case SandstoneApplication::OutputFormat::key_value:
-    case SandstoneApplication::OutputFormat::tap:
-    case SandstoneApplication::OutputFormat::yaml:
-        __builtin_unreachable();
-#else
-#  if SANDSTONE_DEVICE_CPU
+#if SANDSTONE_DEVICE_CPU
     case SandstoneApplication::OutputFormat::key_value: {
         KeyValuePairLogger l(test, status);
         l.print(sApp->current_test_count);
@@ -2164,19 +2158,12 @@ TestResult logging_print_results(std::span<const ChildExitStatus> status, const 
         l.print(sApp->current_test_count);
         return l.testResult;
     }
-#  else
-    // only YAML logging supported
-    case SandstoneApplication::OutputFormat::key_value:
-    case SandstoneApplication::OutputFormat::tap:
-        __builtin_unreachable();
-#  endif // SANDSTONE_DEVICE_CPU
-
+#endif
     case SandstoneApplication::OutputFormat::yaml: {
         YamlLogger l(test, status);
         l.print();
         return l.testResult;
     }
-#endif // SANDSTONE_NO_LOGGING
 
     case SandstoneApplication::OutputFormat::no_output:
         break;

--- a/framework/logging.h
+++ b/framework/logging.h
@@ -7,7 +7,6 @@
 #define INC_LOGGING_H
 
 #include "sandstone_chrono.h"
-#include "sandstone_config.h"
 #include "sandstone_p.h"
 
 #include "gitid.h"
@@ -89,12 +88,6 @@ std::string format_duration(MonotonicTimePoint tp, FormatDurationOptions opts = 
 [[gnu::pure]] const char *crash_reason(const ChildExitStatus &status);
 [[gnu::pure]] const char *sysexit_reason(const ChildExitStatus &status);
 
-#if !SANDSTONE_DEVICE_CPU || SANDSTONE_NO_LOGGING
-// there's only one use of this, in logging.cpp, so let the compiler
-// eliminate anything not used
-namespace {
-#endif
-
 enum class Iso8601Format : unsigned {
     WithoutMs           = 0,
     WithMs              = 1,
@@ -103,13 +96,5 @@ enum class Iso8601Format : unsigned {
 const char *iso8601_time_now(Iso8601Format format);
 
 std::string thread_id_header_for_device(int device, int verbosity);
-#if SANDSTONE_NO_LOGGING
-inline std::string thread_id_header_for_device(int device, int verbosity)
-{ __builtin_unreachable(); return {}; }
-#endif
-
-#if !SANDSTONE_DEVICE_CPU || SANDSTONE_NO_LOGGING
-} // unnamed namespace
-#endif
 
 #endif /* INC_LOGGING_H */


### PR DESCRIPTION
This reverts commit 672e6c48fac03a2342071663c04b427d1ab15d35.

This commit is incomplete and causes problems when trying to build in `NO_LOGGING` mode.