### PR TITLE
CPU-separation: use universal name `device_features_t`

### DIFF
--- a/framework/device/cpu/cpu_device.cpp
+++ b/framework/device/cpu/cpu_device.cpp
@@ -8,11 +8,9 @@
 
 #include <cinttypes>
 
-extern constexpr const cpu_features_t minimum_cpu_features = _compilerCpuFeatures;
+extern constexpr const device_features_t minimum_cpu_features = device_compiler_features;
 
-cpu_features_t cpu_features = 0;
-
-std::string cpu_features_to_string(cpu_features_t f)
+std::string device_features_to_string(device_features_t f)
 {
     std::string result;
     const char *comma = "";
@@ -33,17 +31,17 @@ void dump_device_info()
     // find the best matching CPU
     const char *detected = "<unknown>";
     for (const auto &arch : x86_architectures) {
-        if ((arch.features & cpu_features) == arch.features) {
+        if ((arch.features & device_features) == arch.features) {
             detected = arch.name;
             break;
         }
         if (sApp->shmem->verbosity > 1)
             printf("CPU is not %s: missing %s\n", arch.name,
-                   cpu_features_to_string(arch.features & ~cpu_features).c_str());
+                   device_features_to_string(arch.features & ~device_features).c_str());
     }
     printf("Detected CPU: %s; family-model-stepping (hex): %02x-%02x-%02x; CPU features: %s\n",
            detected, sApp->hwinfo.family, sApp->hwinfo.model, sApp->hwinfo.stepping,
-           cpu_features_to_string(cpu_features).c_str());
+           device_features_to_string(device_features).c_str());
     printf("# CPU\tPkgID\tCoreID\tThrdID\tModId\tNUMAId\tApicId\tMicrocode\tPPIN\n");
     for (i = 0; i < num_cpus(); ++i) {
         printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t0x%" PRIx64, cpu_info[i].cpu_number,

--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -120,7 +120,7 @@
 /// may call cpu_has_feature(cpu_feature_avx512f) to determine whether AVX-512 is available.
 /// Normally, cpuid detection is handle automatically by the framework via test's minimum_cpu field.
 /// This macro is provided in case tests need more fine grained control.
-#define cpu_has_feature(f)      ((_compilerCpuFeatures & (f)) == (f) || (cpu_features & (f)) == (f))
+#define cpu_has_feature(f)      ((device_compiler_features & (f)) == (f) || (device_features & (f)) == (f))
 
 /// used as follows: if instruction cache, only cache_instruction is valid; if
 /// data, only data is valid; if unified, both are set to the same value. In all
@@ -182,7 +182,7 @@ inline int cpu_info::cpu() const
     return this - ::cpu_info;
 }
 
-std::string cpu_features_to_string(cpu_features_t f);
+std::string device_features_to_string(device_features_t f);
 
 extern "C" {
 #endif // __cplusplus
@@ -197,7 +197,5 @@ int num_packages() __attribute__((pure));
 #ifdef __cplusplus
 }
 #endif
-
-extern cpu_features_t cpu_features;
 
 #endif // INC_CPU_DEVICE_H

--- a/framework/device/cpu/cpuid_internal.h
+++ b/framework/device/cpu/cpuid_internal.h
@@ -95,10 +95,10 @@ static uint64_t adjusted_xcr0(uint64_t xcr0, uint64_t xcr0_wanted)
 }
 #endif
 
-static cpu_features_t parse_register(enum X86CpuidLeaves leaf, uint32_t reg)
+static device_features_t parse_register(enum X86CpuidLeaves leaf, uint32_t reg)
 {
     size_t i;
-    cpu_features_t features = 0;
+    device_features_t features = 0;
     for (i = 0; i < x86_locator_count; ++i) {
         uint32_t locator = x86_locators[i];
         if (locator < leaf * 32 || locator >= (leaf + 1) * 32)
@@ -123,11 +123,11 @@ static void detect_cpu_not_supported(const char *msg)
 }
 
 __attribute__((noinline))
-static cpu_features_t detect_cpu()
+static device_features_t detect_cpu()
 {
     uint32_t eax, ebx, ecx, edx;
     uint32_t max_level = 0;
-    cpu_features_t features = 0;
+    device_features_t features = 0;
 
     __cpuid(0, max_level, ebx, ecx, edx);
 
@@ -220,9 +220,9 @@ static cpu_features_t detect_cpu()
 }
 
 __attribute__((unused))
-static void check_missing_features(cpu_features_t features, cpu_features_t minimum_cpu_features)
+static void check_missing_features(device_features_t features, device_features_t minimum_cpu_features)
 {
-    cpu_features_t missing = minimum_cpu_features & ~features;
+    device_features_t missing = minimum_cpu_features & ~features;
     if (!missing)
         return;
 
@@ -240,12 +240,12 @@ static void check_missing_features(cpu_features_t features, cpu_features_t minim
 #undef cpuid_errmsg
 
 #else // ! x86-64
-static cpu_features_t detect_cpu()
+static device_features_t detect_cpu()
 {
     return 0;
 }
 
-static void check_missing_features(cpu_features_t features, cpu_features_t minimum_cpu_features)
+static void check_missing_features(device_features_t features, device_features_t minimum_cpu_features)
 {
     (void) features;
     (void) minimum_cpu_features;

--- a/framework/device/cpu/premain.cpp
+++ b/framework/device/cpu/premain.cpp
@@ -23,7 +23,7 @@
 #include "cpuid_internal.h"
 
 // from cpu_device.cpp
-extern const cpu_features_t minimum_cpu_features;
+extern const device_features_t minimum_cpu_features;
 
 #if defined(AT_EXECPATH) && !defined(AT_EXECFN)
 // FreeBSD uses AT_EXECPATH instead of AT_EXECFN
@@ -116,9 +116,9 @@ static void premain(int argc, char **argv, char **envp)
     (void) envp;
 
     // initialize CPU detection
-    cpu_features = detect_cpu();
-    if (minimum_cpu_features & ~cpu_features)
+    device_features = detect_cpu();
+    if (minimum_cpu_features & ~device_features)
         fallback_exec(argv);
-    check_missing_features(cpu_features, minimum_cpu_features);
+    check_missing_features(device_features, minimum_cpu_features);
 }
 }

--- a/framework/device/cpu/scripts/x86simd_generate.pl
+++ b/framework/device/cpu/scripts/x86simd_generate.pl
@@ -126,8 +126,8 @@ if ($headername = shift @ARGV) {
     $debug = 1;
 }
 
-printf "typedef %s cpu_features_t;\n", $feature_type;
-printf "#define CPU_FEATURE_CONSTANT(bit) (((cpu_features_t) 1) << (bit))\n\n";
+printf "typedef %s device_features_t;\n", $feature_type;
+printf "#define CPU_FEATURE_CONSTANT(bit) (((device_features_t) 1) << (bit))\n\n";
 
 # Print the feature list
 my $lastleaf;
@@ -196,7 +196,7 @@ for (@architecture_names) {
 }
 
 print q{
-static const cpu_features_t _compilerCpuFeatures = 0};
+static const device_features_t device_compiler_features = 0};
 
 # And print the compiler-enabled features part:
 for (my $i = 0; $i < scalar @features; ++$i) {
@@ -212,7 +212,7 @@ print '        ;';
 if ($headerguard ne "") {
     print q|
 #if (defined __cplusplus) && __cplusplus >= 201103L
-enum X86CpuFeatures : cpu_features_t {|;
+enum X86CpuFeatures : device_features_t {|;
 
     for (@features) {
         my $line = sprintf "CpuFeature%s = cpu_feature_%s,", $_->{id}, lc($_->{id});
@@ -225,7 +225,7 @@ enum X86CpuFeatures : cpu_features_t {|;
 
 print qq|}; // enum X86CpuFeatures
 
-enum X86CpuArchitectures : cpu_features_t {|;
+enum X86CpuArchitectures : device_features_t {|;
 
     for (@architecture_names) {
         my $arch = $architectures{$_};
@@ -293,7 +293,7 @@ for (@architecture_names) {
 print qq|
 struct X86Architecture
 {
-    cpu_features_t features;
+    device_features_t features;
     char name[$maxarchnamelen + 1];
 };
 
@@ -328,7 +328,7 @@ for my $state (@xsaveStates) {
     my @required_for = split /,/, $state->{required_for};
     next unless scalar @required_for;
 
-    my $prefix = sprintf "\n// List of features requiring %s%s\nstatic const cpu_features_t %s%s = 0",
+    my $prefix = sprintf "\n// List of features requiring %s%s\nstatic const device_features_t %s%s = 0",
         $xsaveEnumPrefix, $state->{id}, $xsaveReqPrefix, $state->{id};
 
     # match either the feature name or one of its requirements against list
@@ -357,8 +357,8 @@ for my $state (@xsaveStates) {
 printf qq|
 struct XSaveRequirementMapping
 {
-    cpu_features_t cpu_features;
-    cpu_features_t xsave_state;
+    device_features_t cpu_features;
+    device_features_t xsave_state;
 };
 
 static const struct XSaveRequirementMapping xsave_requirements[] = {

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -26,7 +26,6 @@
 
 #include "device/device.h"
 
-#include "cpu_features.h"
 #include "sandstone_config.h"
 #include "sandstone_data.h"
 #include <sandstone_test_groups.h>
@@ -158,7 +157,7 @@ typedef enum TestQuality {
 #define DECLARE_TEST_INNER2(test_id, test_description) \
     __attribute__((aligned(alignof(void*)), used, section(SANDSTONE_SECTION_PREFIX "tests"))) \
     struct test _test_ ## test_id = {                   \
-        .compiler_minimum_cpu = _compilerCpuFeatures,   \
+        .compiler_minimum_device = device_compiler_features,   \
         .id = SANDSTONE_STRINGIFY(test_id),             \
         .description = test_description,
 #define DECLARE_TEST_INNER(test_id, test_description)   DECLARE_TEST_INNER2(test_id, test_description)
@@ -323,7 +322,7 @@ typedef const kvm_config_t *(*kvmconfigfunc)(void);
 struct test {
     /* metadata */
     /// filled in by the DECLARE_TEST macro
-    cpu_features_t compiler_minimum_cpu;
+    device_features_t compiler_minimum_device;
 
     /// Identifier of the test.  Each test must have a unique string identifier
     const char *id;
@@ -345,7 +344,7 @@ struct test {
     /* filled in by framework, used by framework and tests */
 
     /// minimum CPU required to be run, skipped if too old
-    cpu_features_t minimum_cpu;
+    device_features_t minimum_cpu; // we need to keep that name for legacy reasons, ideally should be `minimum_device_to_run`
 
     /// duration (in ms) the test wants to run for
     /// Special values:
@@ -528,6 +527,8 @@ static inline long double frandoml()
 /// set_random_bits(2, 8) would return a uint64_t in which 2 of the
 /// least significant 8 bits are randomly set and all other bits are 0.
 uint64_t set_random_bits(unsigned num_bits_to_set, uint32_t bitwidth);
+
+extern device_features_t device_features;
 
 /// thread_num always contains the integer identifier for the executing
 /// thread.  It can be used to index the cpu_info array and is equivalent

--- a/framework/scripts/generate_test_list.py
+++ b/framework/scripts/generate_test_list.py
@@ -122,7 +122,7 @@ def main():
             f.write('{\n')
             f.write('#ifdef SANDSTONE\n')
             f.write('    if ((name == nullptr) || (strcmp(name, "auto") == 0)) {\n')
-            f.write('        return (test_set->features & cpu_features) == test_set->features;\n')
+            f.write('        return (test_set->features & device_features) == test_set->features;\n')
             f.write('    }\n')
             f.write('#endif\n')
             f.write('    return (name != nullptr) && (strcmp(name, test_set->name) == 0);\n')
@@ -154,7 +154,7 @@ def main():
 
         # per-gen list definition
         f.write('typedef struct BuiltinTestSet {\n')
-        f.write('    cpu_features_t features;\n')
+        f.write('    device_features_t features;\n')
         f.write('    const char* name;\n')
         f.write('    const std::optional<std::vector<struct test *>> tests;\n')
         f.write('} BuiltinTestSet ;\n\n')


### PR DESCRIPTION
This commit also brings back definition of `device_features` (former `cpu_features`) variable back to the common code.