### PR TITLE
FW/InterruptMonitor: add `observed_mce_events()`

### DIFF
--- a/framework/interrupt_monitor.hpp
+++ b/framework/interrupt_monitor.hpp
@@ -37,6 +37,8 @@ public:
         return get_total_interrupt_counts(MCE);
     }
 
+    static bool observed_mce_events();
+
     static uint64_t count_thermal_events() {
         return get_total_interrupt_counts(Thermal);
     }
@@ -62,6 +64,11 @@ inline std::vector<uint32_t> InterruptMonitor::get_interrupt_counts(InterruptTyp
 {
     static_assert(!InterruptMonitorWorks);
     return {};
+}
+
+inline bool InterruptMonitor::observed_mce_events()
+{
+    return false;
 }
 #endif
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2682,7 +2682,6 @@ int main(int argc, char **argv)
         sApp->shmem->verbosity = (sApp->requested_quality < SandstoneApplication::DefaultQualityLevel) ? 1 : 0;
 
     if (InterruptMonitor::InterruptMonitorWorks && test_set->contains(&mce_test)) {
-        sApp->mce_counts_start = InterruptMonitor::get_mce_interrupt_counts();
         if (sApp->current_fork_mode() == SandstoneApplication::exec_each_test) {
             test_set->remove(&mce_test);
         } else if (InterruptMonitor::get_mce_interrupt_counts().empty()) {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -423,7 +423,6 @@ struct SandstoneApplication : public test_the_test_data<SandstoneConfig::Debug>
     static constexpr int DefaultTemperatureThreshold = -1;
     int thermal_throttle_temp = DefaultTemperatureThreshold;
     int threshold_time_remaining = 30000;
-    std::vector<uint32_t> mce_counts_start;
 
     HardwareInfo hwinfo;
 

--- a/tests/mce_check/mce_check.cpp
+++ b/tests/mce_check/mce_check.cpp
@@ -108,6 +108,10 @@ int mce_check_run(struct test *test, int cpu)
 }
 }
 
+bool InterruptMonitor::observed_mce_events()
+{
+    return get_mce_interrupt_counts() != mce_counts_start;
+}
 
 // The MCE test is special in that it is not handled like a normal test
 // We do not use the macros to specify it because we do not want it to

--- a/tests/mce_check/mce_check.cpp
+++ b/tests/mce_check/mce_check.cpp
@@ -36,6 +36,7 @@
 
 namespace {
 // we can use globals as it's run for 0th cpu only (data won't be shared accross >1 threads)
+std::vector<uint32_t> mce_counts_start;
 uint64_t mce_count_last;
 uint64_t last_thermal_event_count;
 
@@ -43,8 +44,8 @@ int mce_check_preinit(struct test *test)
 {
     (void) test;
     last_thermal_event_count = InterruptMonitor::count_thermal_events();
-    sApp->mce_counts_start = InterruptMonitor::get_mce_interrupt_counts();
-    mce_count_last = std::accumulate(sApp->mce_counts_start.begin(), sApp->mce_counts_start.end(), uint64_t(0));
+    mce_counts_start = InterruptMonitor::get_mce_interrupt_counts();
+    mce_count_last = std::accumulate(mce_counts_start.begin(), mce_counts_start.end(), uint64_t(0));
     return EXIT_SUCCESS;
 }
 
@@ -57,18 +58,18 @@ int mce_check_run(struct test *test, int cpu)
 
     std::vector<uint32_t> counts = InterruptMonitor::get_mce_interrupt_counts();
 
-    if (counts.size() != sApp->mce_counts_start.size()) {
+    if (counts.size() != mce_counts_start.size()) {
         report_fail_msg("Number of CPUs changed during execution, test is not valid.");
         return EXIT_FAILURE;
     }
 
     std::vector<uint32_t> differences(counts.size());
     for (int i = 0; i < counts.size(); ++i)
-        differences[i] = counts[i] - sApp->mce_counts_start[i];
+        differences[i] = counts[i] - mce_counts_start[i];
 
     // set up for the next iteration (in case there's one)
     mce_count_last = std::accumulate(counts.begin(), counts.end(), uint64_t(0));
-    sApp->mce_counts_start = std::move(counts);
+    mce_counts_start = std::move(counts);
     counts.clear();
 
     // check the CPUs we were running tests on


### PR DESCRIPTION
This allows us to get access to the local variable `mce_counts_start`.

This PR includes a revert of #797.