### PR TITLE
FW/KVM: add a global `group_kvm` for KVM tests

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -728,7 +728,6 @@ static void preinit_tests()
                 test->flags = test->flags | test_init_in_parent;
             }
         }
-
     }
 }
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -588,6 +588,11 @@ void debug_init_global(const char *on_hang_arg, const char *on_crash_arg);
 void debug_crashed_child(std::span<const pid_t> children);
 void debug_hung_child(pid_t child, std::span<const pid_t> children);
 
+#if defined(SANDSTONE_DEVICE_CPU) && defined(__x86_64__)
+/* kvm.c */
+extern "C" initfunc group_kvm_init(void) noexcept;
+#endif
+
 /* logging.cpp */
 void log_message_preformatted(int thread_num, int level, std::string_view msg);
 int logging_stdout_fd(void);

--- a/framework/sandstone_test_groups.cpp
+++ b/framework/sandstone_test_groups.cpp
@@ -27,8 +27,9 @@ constexpr struct test_group group_fuzzing = {
 };
 
 #if defined(SANDSTONE_DEVICE_CPU) && defined(__x86_64__)
-extern constexpr struct test_group group_kvm = {
+constexpr struct test_group group_kvm = {
     TEST_GROUP("kvm",
                "Tests that create virtual machines using Linux's KVM support"),
+    .group_init = group_kvm_init,
 };
 #endif

--- a/framework/sandstone_test_groups.cpp
+++ b/framework/sandstone_test_groups.cpp
@@ -25,3 +25,10 @@ constexpr struct test_group group_fuzzing = {
     TEST_GROUP("fuzzing",
                "Tests that fuzz framework functions using AFL++ persistent mode"),
 };
+
+#if defined(SANDSTONE_DEVICE_CPU) && defined(__x86_64__)
+extern constexpr struct test_group group_kvm = {
+    TEST_GROUP("kvm",
+               "Tests that create virtual machines using Linux's KVM support"),
+};
+#endif

--- a/framework/sandstone_test_groups.h
+++ b/framework/sandstone_test_groups.h
@@ -6,6 +6,8 @@
 #ifndef SANDSTONE_TEST_GROUPS_H
 #define SANDSTONE_TEST_GROUPS_H
 
+#include "sandstone_config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -15,6 +17,12 @@ extern const struct test_group
         group_compression,
         group_math,
         group_fuzzing;
+
+#if defined(SANDSTONE_DEVICE_CPU) && defined(__x86_64__)
+extern const struct test_group
+        group_kvm;
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -1166,13 +1166,6 @@ const static test_group group_test_is_optional = {
     .description = "Self-tests used to test test_is_optional flag"
 };
 
-#if SANDSTONE_DEVICE_CPU
-const static test_group group_kvm = {
-    .id = "kvm",
-    .description = "Self-tests that launch virtual machines"
-};
-#endif
-
 static struct test selftests_array[] = {
 {
     .id = "selftest_pass",

--- a/framework/sysdeps/generic/kvm.c
+++ b/framework/sysdeps/generic/kvm.c
@@ -45,3 +45,9 @@ int kvm_generic_cleanup(struct test *)
 }
 
 #endif
+
+initfunc group_kvm_init(void) __attribute__((nothrow));
+initfunc group_kvm_init(void)
+{
+    return kvm_generic_init;
+}


### PR DESCRIPTION
This is used in both selftests and regular tests. Its group init function will check at start time if /dev/kvm is usable, and if not will just cause the tests to skip.
