### PR TITLE
FW: fix release-mode warning about use of uninitialised `res`

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1752,12 +1752,14 @@ static void run_one_test_init_in_parent(ChildrenList &children, const struct tes
                "Internal error: init-in-parent returned a skip but did not call log_skip()");
         res = TestResult::Skipped;
     } else if (ret == EXIT_SUCCESS) [[likely]] {
-        if (main->has_skipped())
+        if (main->has_skipped()) {
             res = TestResult::Skipped;
-        else if (main->has_failed())
+        } else if (main->has_failed()) {
             res = TestResult::Failed;
-        else
+        } else {
             assert(!"Internal error: init-in-parent succeeded");
+            __builtin_unreachable();
+        }
     } else {
         assert(main->has_failed() &&
                "Internal error: init-in-parent returned an error but did not call log_error()");


### PR DESCRIPTION
In release mode (`NDEBUG`), `assert` becomes empty, so the compiler rightfully thinks there's a control path that could lead to uninitialised use.

We really need to stop using `assert()` and provide one that provides the `__builtin_unreachable()` on failure, for release mode.

```
stl_construct.h:110:16: warning: 'res' may be used uninitialized [-Wmaybe-uninitialized]
  110 |         return ::new(__loc) _Tp(std::forward<_Args>(__args)...);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sandstone.cpp: In function 'TestResult run_one_test_once(const test*)':
sandstone.cpp:1770:16: note: 'res' was declared here
```