### PR TITLE
CPU-separation: move `num_packages` declaration to common code

### DIFF
--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -190,10 +190,6 @@ extern "C" {
 /// Keep num_cpus() defined for legacy reasons
 int num_cpus() __attribute__((pure));
 
-/// Returns the number of physical CPU packages (a.k.a. sockets) available to a
-/// test.
-int num_packages() __attribute__((pure));
-
 #ifdef __cplusplus
 }
 #endif

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -644,6 +644,10 @@ memcmp_or_fail(const T *actual, const T *expected, size_t count)
 /// restricts the number of CPUs sandstone can see.
 int thread_count() __attribute__((pure));
 
+/// Returns the number of physical CPU packages (a.k.a. sockets) available to a
+/// test.
+int num_packages() __attribute__((pure));
+
 // Static C++ test runner to instantiate appropriate test class or always skipping one
 #ifdef __cplusplus
 template<class T>


### PR DESCRIPTION
Idea is that since it's used in selftest.cpp, we may want to define it for other devices as well, but with fixed value 1, for example.