### PR TITLE
BATS: fix skip condition as we're checking for directory, not file.

### DIFF
--- a/bats/sanity-check/25-cpu-topology.bats
+++ b/bats/sanity-check/25-cpu-topology.bats
@@ -100,7 +100,7 @@ test_fail_socket1() {
         v=`cat topology/thread_siblings_list`
         (
             bats::on_failure() { echo thread_siblings_list: $v; }
-            if [[ "$v" == "$n" ]] || [[ "$v" == "$n",* ]]; then
+            if [[ "$v" == "$n" ]] || [[ "$v" == "$n"[,-]* ]]; then
                 test_yaml_expr "/cpu-info/$i/thread" = 0
             else
                 test_yaml_expr "/cpu-info/$i/thread" = 1


### PR DESCRIPTION
The test was incorrectly skipping on the physical Linux system.