### PR TITLE
FW/CPU: detect the native core type in hybrid x86 systems

### DIFF
--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -160,6 +160,12 @@ struct cpu_info
     /// On x86, it's the APICID or x2APICID, if known; -1 if not.
     int hwid;
 
+    /// On x86 with hybrid parts, contains the native core type (CPUID leaf
+    /// 0x1A, EAX bits 24-31).
+    uint8_t native_core_type;
+
+    // 3 bytes of padding
+
     struct cache_info cache[3]; ///! Cache info from OS
 
 #ifdef __cplusplus


### PR DESCRIPTION
On non-hybrid systems, this doesn't change anything. For hybrid systems, it will include:
```yaml
- { logical-group:  0, logical: 14, package: 0, numa_node: 0, module:  7, core: 28, thread: 0, core_type: p-core, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 14
- { logical-group:  0, logical: 15, package: 0, numa_node: 0, module:  7, core: 28, thread: 1, core_type: p-core, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 15
- { logical-group:  0, logical: 16, package: 0, numa_node: 0, module:  9, core: 36, thread: 0, core_type: e-core, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 16
- { logical-group:  0, logical: 17, package: 0, numa_node: 0, module:  9, core: 37, thread: 0, core_type: e-core, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 17
- { logical-group:  0, logical: 18, package: 0, numa_node: 0, module:  9, core: 38, thread: 0, core_type: e-core, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 18
- { logical-group:  0, logical: 19, package: 0, numa_node: 0, module:  9, core: 39, thread: 0, core_type: e-core, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 19
```

[ChangeLog][Framework] The YAML and TAP log outputs now include the core type of hybrid systems ("p-core" or "e-core").