### PR TITLE
FW/CPU-Logging: only print the family/model/number on x86

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -224,6 +224,7 @@ tap_negative_check() {
     test_yaml_numeric "/timing/timeout" 'value == 12345'
 
     # just verify these exist
+    local machine=`uname -m`
     for ((i = 0; i < MAX_PROC; ++i)); do
         if $is_windows; then
             test_yaml_numeric "/cpu-info/$i/logical-group" 'value >= 0'
@@ -234,11 +235,13 @@ tap_negative_check() {
         test_yaml_numeric "/cpu-info/$i/module" 'value >= 0'
         test_yaml_numeric "/cpu-info/$i/core" 'value >= 0'
         test_yaml_numeric "/cpu-info/$i/thread" 'value >= 0'
-        test_yaml_numeric "/cpu-info/$i/family" 'value >= 0'
-        test_yaml_numeric "/cpu-info/$i/model" 'value >= 0'
-        test_yaml_numeric "/cpu-info/$i/stepping" 'value >= 0'
-        test_yaml_regexp "/cpu-info/$i/microcode" '(None|[0-9]+)'
-        test_yaml_regexp "/cpu-info/$i/ppin" '(None|[0-9a-f]{16})'
+        if [[ $machine = x86_64 ]]; then
+            test_yaml_numeric "/cpu-info/$i/family" 'value >= 0'
+            test_yaml_numeric "/cpu-info/$i/model" 'value >= 0'
+            test_yaml_numeric "/cpu-info/$i/stepping" 'value >= 0'
+            test_yaml_regexp "/cpu-info/$i/microcode" '(None|[0-9]+)'
+            test_yaml_regexp "/cpu-info/$i/ppin" '(None|[0-9a-f]{16})'
+        fi
     done
 
     # check some more timing parse

--- a/bats/sanity-check/25-cpu-topology.bats
+++ b/bats/sanity-check/25-cpu-topology.bats
@@ -88,6 +88,7 @@ test_fail_socket1() {
     # Get the NUMA node assignments
     eval local -A numa=`numa_nodes`
 
+    local machine=`uname -m`
     local i
     for ((i=0; i < ${yamldump[/cpu-info@len]}; ++i)); do (
         local v
@@ -109,13 +110,15 @@ test_fail_socket1() {
 
         # Our module ID from CPUID differs from what Linux reports in topology/cluster_id
 
-        if v=`cat microcode/version 2>/dev/null`; then
-            test_yaml_numeric "/cpu-info/$i/microcode" "value == $v"
-        fi
-        if v=`cat topology/ppin 2>/dev/null`; then
-            test_yaml_expr "/cpu-info/$i/ppin" = "${v#0x}"
-        else
-            test_yaml_expr "/cpu-info/$i/ppin" = None
+        if [[ $machine = x86_64 ]]; then
+            if v=`cat microcode/version 2>/dev/null`; then
+                test_yaml_numeric "/cpu-info/$i/microcode" "value == $v"
+            fi
+            if v=`cat topology/ppin 2>/dev/null`; then
+                test_yaml_expr "/cpu-info/$i/ppin" = "${v#0x}"
+            else
+                test_yaml_expr "/cpu-info/$i/ppin" = None
+            fi
         fi
 
         v=${numa[$n]}

--- a/bats/yamltest.py
+++ b/bats/yamltest.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import yaml
+import platform
 import sys
 
 def fail(msg):
@@ -50,12 +51,14 @@ def validate_thread(name, thr):
         thr['id']['numa_node']
         thr['id']['module']
         thr['id']['core']
-        thr['id']['thread']
-        thr['id']['family']
-        thr['id']['model']
-        thr['id']['stepping']
-        thr['id']['microcode']
-        thr['id']['ppin']
+
+        if platform.uname().machine == 'x86-64':
+            thr['id']['thread']
+            thr['id']['family']
+            thr['id']['model']
+            thr['id']['stepping']
+            thr['id']['microcode']
+            thr['id']['ppin']
     elif not n.startswith('main'):
         fail('found unknown thread "{}" for test {}'.format(n, name))
 

--- a/docs/opendcdiag-cpu.schema.yaml
+++ b/docs/opendcdiag-cpu.schema.yaml
@@ -111,11 +111,6 @@ $defs:
       - module
       - core
       - thread
-      - family
-      - model
-      - stepping
-      - microcode
-      - ppin
 
   test-plan-entry:
     type: array

--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -275,6 +275,7 @@ void TapFormatLogger::print_thread_header(int fd, int device, int verbosity)
             info->cpu_number, info->package_id, info->core_id, info->thread_id);
 
     const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(info->package_id);
+#ifdef __x86_64__
     line += stdprintf(", family/model/stepping %02x-%02x-%02x, microcode ", sApp->hwinfo.family, sApp->hwinfo.model,
                       sApp->hwinfo.stepping);
     if (info->microcode)
@@ -285,6 +286,9 @@ void TapFormatLogger::print_thread_header(int fd, int device, int verbosity)
         line += stdprintf(", PPIN %016" PRIx64 "):", pkg->ppin);
     else
         line += ", PPIN N/A):";
+#else
+    (void) pkg;
+#endif
 
     writeln(fd, line);
 
@@ -383,11 +387,16 @@ std::string thread_id_header_for_device(int cpu, int verbosity)
                 line += "null";
         };
         const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(info->package_id);
+#ifdef __x86_64__
         line += stdprintf(", family: %d, model: %#02x, stepping: %d, microcode: ",
                           sApp->hwinfo.family, sApp->hwinfo.model, sApp->hwinfo.stepping);
         add_value_or_null("%#" PRIx64, info->microcode);
         line += ", ppin: ";
         add_value_or_null("\"%016" PRIx64 "\"", pkg ? pkg->ppin : 0);   // string to prevent loss of precision
+#else
+        (void) pkg;
+        (void) add_value_or_null;
+#endif
     }
     line += " }";
     return line;


### PR DESCRIPTION
On other architectures, this is pointless.