### PR TITLE
FW/CPU-Topology: add `--cpuset=type=[ep]`

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1406,6 +1406,25 @@ void apply_deviceset_param(char *param)
                 if (cpu.cpu_number % 2 == desired_remainder)
                     apply_to_set(cpu);
             }
+        } else if (p.starts_with("type=")) {
+            NativeCoreType expected = [&]() {
+                std::string_view type = p;
+                type.remove_prefix(strlen("type="));
+                if (type == "e")
+                    return core_type_efficiency;
+                else if (type == "p")
+                    return core_type_performance;
+
+                fprintf(stderr, "%s: error: Invalid CPU set parameter: %s (unknown core type)\n",
+                        program_invocation_name, orig_arg);
+                exit(EX_USAGE);
+                return core_type_unknown;    // unreachable
+            }();
+
+            for (const struct cpu_info &cpu : old_cpu_info) {
+                if (cpu.native_core_type == expected)
+                    apply_to_set(cpu);
+            }
         } else if (c >= 'a' && c <= 'z') {
             // topology search
             auto set_if_unset = [orig_arg](int n, int &where, const char *what) {


### PR DESCRIPTION
For example, on my Alder Lake:
```yaml
command-line: 'opendcdiag.exe -o - --disable=* --cpuset=type=e'
version: opendcdiag-8aac9457c9a7
os: Windows v10.0.22631
runtime: UCRT
openssl: null
timing: { duration: 1000.000, timeout: 300000.000 }
cpu-info:
- { logical-group:  0, logical: 16, package: 0, numa_node: 0, module:  9, core: 36, thread: 0, core_type: e, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 0
- { logical-group:  0, logical: 17, package: 0, numa_node: 0, module:  9, core: 37, thread: 0, core_type: e, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 1
- { logical-group:  0, logical: 18, package: 0, numa_node: 0, module:  9, core: 38, thread: 0, core_type: e, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 2
- { logical-group:  0, logical: 19, package: 0, numa_node: 0, module:  9, core: 39, thread: 0, core_type: e, family: 6, model: 0x97, stepping: 2, microcode: 0x38, ppin: null }   # 3
```

[ChangeLog][Framework] Added `--cpuset=type=e` and `type=p` command-line options. This allows one to select only the Efficiency or Performance cores in a hybrid system. On non-hybrid systems, this will probably match nothing, even if all the cores are of the type requested.