### PR TITLE
FW/CPU: add `cpu_features_t` alias

### DIFF
--- a/framework/device/cpu/cpuid_internal.h
+++ b/framework/device/cpu/cpuid_internal.h
@@ -252,3 +252,6 @@ static void check_missing_features(device_features_t features, device_features_t
 }
 
 #endif // ! x86-64
+
+// Keep an alias for compatibility
+typedef device_features_t cpu_features_t;


### PR DESCRIPTION
Too many things may rely on that legacy name.