### PR TITLE
FW/CPU: add new test group for SMT tests, remove `test_requires_smt` flag

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1418,20 +1418,6 @@ static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
 
         sApp->test_tests_init(test);
 
-        auto has_smt = []() -> bool {
-            for(int idx = 0; idx < num_cpus() - 1; idx++) {
-                if (cpu_info[idx].core_id == cpu_info[idx + 1].core_id)
-                    return true;
-            }
-            return false;
-        };
-
-        if (test->flags & test_requires_smt && !has_smt()) {
-            log_skip(CpuTopologyIssueSkipCategory, "Test requires SMT (hyperthreading)");
-            state = TestResult::Skipped;
-            break;
-        }
-
         if (test->test_init) {
             // ensure the init function is run pinned to a specific logical
             // processor but its pinning doesn't affect this control thread

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -297,10 +297,6 @@ typedef enum test_flag {
     /// command line
     test_is_optional                = 0x2000,
 
-    /// Indicates test requires to have Simultaneous Multi-Threading(SMT)/Hyperthreading(HT)
-    /// support
-    test_requires_smt               = 0x4000,
-
     /// Indicates the test's init function should be run in the parent, to log
     /// the state. Do not cause a "memory" effect between tests, and do not use
     /// the random generator.

--- a/framework/sandstone_test_groups.cpp
+++ b/framework/sandstone_test_groups.cpp
@@ -33,3 +33,33 @@ constexpr struct test_group group_kvm = {
     .group_init = group_kvm_init,
 };
 #endif
+
+#if SANDSTONE_DEVICE_CPU
+namespace {
+initfunc group_smt_init() noexcept
+{
+    auto has_smt = []() -> bool {
+        for(int idx = 0; idx < thread_count() - 1; idx++) {
+            if (cpu_info[idx].core_id == cpu_info[idx + 1].core_id)
+                return true;
+        }
+        return false;
+    };
+
+    if (has_smt()) {
+        return nullptr;
+    }
+
+    return [](struct test *) {
+        log_skip(CpuTopologyIssueSkipCategory, "Test requires SMT (hyperthreading)");
+        return -EPERM;
+    };
+}
+}
+
+constexpr struct test_group group_smt = {
+    TEST_GROUP("smt",
+               "Tests that utilize Simultaneous Multi-Threading(SMT)/Hyperthreading(HT)"),
+    .group_init = group_smt_init,
+};
+#endif

--- a/framework/sandstone_test_groups.h
+++ b/framework/sandstone_test_groups.h
@@ -16,7 +16,8 @@ struct test_group;
 extern const struct test_group
         group_compression,
         group_math,
-        group_fuzzing;
+        group_fuzzing,
+        group_smt;
 
 #if defined(SANDSTONE_DEVICE_CPU) && defined(__x86_64__)
 extern const struct test_group

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -1454,12 +1454,11 @@ static struct test selftests_array[] = {
 },
 {
     .id = "selftest_requires_smt",
-    .description = "Test the flag test_requires_smt",
-    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .description = "Test the group_smt test group",
+    .groups = DECLARE_TEST_GROUPS(&group_positive, &group_smt),
     .test_run = selftest_pass_run,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
-    .flags = test_requires_smt,
 },
 {
     .id = "selftest_timedpass_busywait",


### PR DESCRIPTION
Delegate checking from `child_run` to this group's `group_init`, as it's a more appropriate place.