### PR TITLE
FW/Opts: do not pass `ProgramOptions&` to `parse` member fn

### DIFF
--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -1052,10 +1052,10 @@ struct ProgramOptionsParser {
 };
 } /* anonymous namespace */
 
-int ProgramOptions::parse(int argc, char** argv, SandstoneApplication* app, ProgramOptions& opts) {
+int ProgramOptions::parse(int argc, char** argv, SandstoneApplication* app) {
     ProgramOptionsParser parser;
     if constexpr (SandstoneConfig::RestrictedCommandLine) {
-        return parser.parse_restricted_command_line(argc, argv, app, opts);
+        return parser.parse_restricted_command_line(argc, argv, app, *this);
     }
     auto ret = parser.collect_args(argc, argv);
     if (ret != EXIT_SUCCESS) {
@@ -1065,5 +1065,5 @@ int ProgramOptions::parse(int argc, char** argv, SandstoneApplication* app, Prog
     if (ret != EXIT_SUCCESS) {
         return ret;
     }
-    return parser.parse_args(app, opts, argv);
+    return parser.parse_args(app, *this, argv);
 }

--- a/framework/sandstone_opts.hpp
+++ b/framework/sandstone_opts.hpp
@@ -45,7 +45,7 @@ struct ProgramOptions {
     };
     const char *builtin_test_list_name = nullptr;
 
-    int parse(int argc, char** argv, SandstoneApplication* app, ProgramOptions& opts);
+    int parse(int argc, char** argv, SandstoneApplication* app);
 
     // for RestrictedCommandLine put it here to enable code elimination
     void apply_restrictions() {
@@ -60,7 +60,7 @@ struct ProgramOptions {
 };
 
 inline int parse_cmdline(int argc, char** argv, SandstoneApplication* app, ProgramOptions& opts) {
-    auto ret = opts.parse(argc, argv, app, opts);
+    auto ret = opts.parse(argc, argv, app);
     if constexpr (SandstoneConfig::RestrictedCommandLine) {
         opts.apply_restrictions(); // enable code elimination
     }


### PR DESCRIPTION
It's a non-static member function, so we can just pass `*this` instead.