### PR TITLE
FW/Win32: fix reporting of crashes outside of the first slice

### DIFF
--- a/framework/sysdeps/windows/child_debug.cpp
+++ b/framework/sysdeps/windows/child_debug.cpp
@@ -123,7 +123,7 @@ static LONG WINAPI handler(EXCEPTION_POINTERS *info)
 
     // copy the context's fixed portions
     CrashContext *ctx = preallocatedContext;
-    ctx->header.thread_num = thread_num;
+    ctx->header.thread_num = thread_num + sApp->main_thread_data()->device_range.starting_device;
     ctx->exceptionRecord = *info->ExceptionRecord;
     ptrdiff_t context_size = sizeof(*ctx);
     if (CopyContext(&ctx->fixedContext, CrashContext::DesiredContextFlags, info->ContextRecord))


### PR DESCRIPTION
Amends commit 70002c70907e0526471ffafcf7171bd30e6646cf. We forgot to add the offset for any other slice, causing this incorrect result:
```yaml
   - test: selftest_sigsegv_socket1
     time-at-start: { elapsed:      0.000, now: !!timestamp '2025-10-09T20:24:29Z' }
     result: crash
     result-details: { crashed: true, core-dump: false, code: 0xc0000005, reason: 'Access violation' }
     fail: { cpu-mask: '.X:..', time-to-fail: null, seed: 'LCG:757483370'}
     time-at-end:   { elapsed:     61.752, now: !!timestamp '2025-10-09T20:24:29Z' }
     test-runtime: 58.475
     threads:
     - thread: main 1
       resource-usage: { utime: 0.000, stime: 0.000, cpuavg: 0.0, maxrss: 5562368, majflt: 1622 }
     - thread: 1
       id: { logical-group:  0, logical:  1, package: 0, numa_node: 0, module: 0, core: 1, thread: 0, family: 6, model: 0x97, stepping: 2, microcode: null, ppin: null }
```

It was correctly producing the usage report for "main 1", but the failing CPU mask and the reported thread ID were wrong.

Don't ask me how this test was passing.

```
not ok 134 crash context socket1 --max-cores-per-slice
```

[ChangeLog][Framework] Fixed a bug that caused the tool to mis-attribute which thread crashed, on Windows systems with 32 cores or more.