### PR TITLE
sandstone_data: Enable Float32 and Float64

### DIFF
--- a/framework/sandstone_data.h
+++ b/framework/sandstone_data.h
@@ -214,6 +214,8 @@ template<> struct TypeToDataType<__int128_t> : TypeToDataType_helper<Int128Data>
 
 template<> struct TypeToDataType<Float16> : TypeToDataType_helper<Float16Data> {};
 template<> struct TypeToDataType<BFloat16> : TypeToDataType_helper<BFloat16Data> {};
+template<> struct TypeToDataType<Float32> : TypeToDataType_helper<Float32Data> {};
+template<> struct TypeToDataType<Float64> : TypeToDataType_helper<Float64Data> {};
 template<> struct TypeToDataType<float> : TypeToDataType_helper<Float32Data> {};
 template<> struct TypeToDataType<double> : TypeToDataType_helper<Float64Data> {};
 template<> struct TypeToDataType<long double> :


### PR DESCRIPTION
This change adds trait specializations for Float32 and Float64, allowing these types to be used with memcmp_or_fail and similar comparison utilities.