### PR TITLE
FW: isolate `SandstoneApplication` fraction parsed with `ProgramOptionsParser`

### DIFF
--- a/framework/device/cpu/cpu_device.cpp
+++ b/framework/device/cpu/cpu_device.cpp
@@ -35,7 +35,7 @@ void dump_device_info()
             detected = arch.name;
             break;
         }
-        if (sApp->shmem->verbosity > 1)
+        if (sApp->shmem->cfg.verbosity > 1)
             printf("CPU is not %s: missing %s\n", arch.name,
                    device_features_to_string(arch.features & ~device_features).c_str());
     }

--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -126,15 +126,15 @@ void KeyValuePairLogger::print_thread_messages()
     auto doprint = [this](PerThreadData::Common *data, int i) {
         struct mmap_region r = maybe_mmap_log(data);
 
-        if (r.size == 0 && !data->has_failed() && sApp->shmem->verbosity < 3)
+        if (r.size == 0 && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
             return;           /* nothing to be printed, on any level */
 
         print_thread_header(file_log_fd, i, timestamp_prefix.c_str());
         int lowest_level = print_one_thread_messages_tdata(file_log_fd, data, r, INT_MAX);
 
-        if (lowest_level <= sApp->shmem->verbosity && file_log_fd != real_stdout_fd) {
+        if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
             print_thread_header(real_stdout_fd, i, test->id);
-            print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->verbosity);
+            print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->cfg.verbosity);
         }
 
         munmap_and_truncate_log(data, r);
@@ -219,7 +219,7 @@ void TapFormatLogger::print(int tc)
     logging_printf(loglevel(), "%s\n", tap_line.c_str());
 
     print_thread_messages();
-    if (sApp->shmem->verbosity >= 1)
+    if (sApp->shmem->cfg.verbosity >= 1)
         print_child_stderr();
 
     if (file_terminator)
@@ -326,15 +326,15 @@ void TapFormatLogger::print_thread_messages()
     auto doprint = [this](PerThreadData::Common *data, int i) {
         struct mmap_region r = maybe_mmap_log(data);
 
-        if (r.size == 0 && !data->has_failed() && sApp->shmem->verbosity < 3)
+        if (r.size == 0 && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
             return;             /* nothing to be printed, on any level */
 
         print_thread_header(file_log_fd, i, INT_MAX);
         int lowest_level = print_one_thread_messages_tdata(file_log_fd, data, r, INT_MAX);
 
-        if (lowest_level <= sApp->shmem->verbosity && file_log_fd != real_stdout_fd) {
-            print_thread_header(real_stdout_fd, i, sApp->shmem->verbosity);
-            print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->verbosity);
+        if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
+            print_thread_header(real_stdout_fd, i, sApp->shmem->cfg.verbosity);
+            print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->cfg.verbosity);
         }
 
         munmap_and_truncate_log(data, r);

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1530,7 +1530,7 @@ void slice_plan_init(int max_cores_per_slice)
     for (std::vector<DeviceRange> &plan : sApp->slice_plans.plans)
         plan.clear();
 
-    if (sApp->current_fork_mode() == SandstoneApplication::no_fork || max_cores_per_slice < 0)
+    if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::no_fork || max_cores_per_slice < 0)
         return set_to_full_system();
 
     // The heuristic is enabled by max_cores_per_slice == 0 and a valid

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -116,7 +116,7 @@ static SandstoneApplication::OutputFormat current_output_format()
 {
     if (SandstoneConfig::NoLogging)
         return SandstoneApplication::OutputFormat::no_output;
-    return sApp->shmem->output_format;
+    return sApp->shmem->cfg.output_format;
 }
 
 std::string_view AbstractLogger::indent_spaces()
@@ -124,7 +124,7 @@ std::string_view AbstractLogger::indent_spaces()
     if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
         return {};
 
-    static const std::string spaces(sApp->shmem->output_yaml_indent, ' ');
+    static const std::string spaces(sApp->shmem->cfg.output_yaml_indent, ' ');
     return spaces;
 }
 
@@ -342,7 +342,7 @@ int logging_stdout_fd(void)
 
 static inline int open_new_log()
 {
-    if (sApp->current_fork_mode() == SandstoneApplication::exec_each_test)
+    if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::exec_each_test)
         return open_memfd(MemfdInheritOnExec);
     else
         return open_memfd(MemfdCloseOnExec);
@@ -373,7 +373,7 @@ void AbstractLogger::munmap_and_truncate_log(PerThreadData::Common *data, mmap_r
 
 void logging_init_global_child()
 {
-    assert(sApp->current_fork_mode() == SandstoneApplication::child_exec_each_test);
+    assert(sApp->current_fork_mode() == SandstoneApplication::ForkMode::child_exec_each_test);
 
     AbstractLogger::file_log_fd = AbstractLogger::real_stdout_fd = STDOUT_FILENO;
 #ifndef NDEBUG
@@ -536,7 +536,7 @@ int logging_close_global(int exitcode)
         const char *exitline = [&] {
             switch (exitcode) {
             case EXIT_SUCCESS:
-                if (sApp->shmem->verbosity >= 0)
+                if (sApp->shmem->cfg.verbosity >= 0)
                     return "pass";
                 return (const char *)nullptr;
             case EXIT_FAILURE:
@@ -647,7 +647,7 @@ void log_message_preformatted(int thread_num, int level, std::string_view msg)
         return;
 
     std::atomic<int> &messages_logged = sApp->thread_data(thread_num)->messages_logged;
-    if (messages_logged.load(std::memory_order_relaxed) >= sApp->shmem->max_messages_per_thread)
+    if (messages_logged.load(std::memory_order_relaxed) >= sApp->shmem->cfg.max_messages_per_thread)
         return;
 
     if (msg[msg.size() - 1] == '\n')
@@ -709,7 +709,7 @@ void logging_printf(int level, const char *fmt, ...)
     if (msg.empty())
         return;     // can happen if fmt was "%s" and the string ended up empty
 
-    if (level <= sApp->shmem->verbosity && AbstractLogger::file_log_fd != AbstractLogger::real_stdout_fd) {
+    if (level <= sApp->shmem->cfg.verbosity && AbstractLogger::file_log_fd != AbstractLogger::real_stdout_fd) {
         progress_bar_flush();
         int fd = AbstractLogger::real_stdout_fd;
         if (level < 0)
@@ -884,7 +884,7 @@ void logging_print_iteration_start()
         return;                 // short-circuit
 
     std::string random_seed = random_format_seed();
-    switch (sApp->shmem->output_format) {
+    switch (sApp->shmem->cfg.output_format) {
     case SandstoneApplication::OutputFormat::key_value:
         return logging_printf(LOG_LEVEL_QUIET, "random_generator_state = %s\n", random_seed.c_str());
     case SandstoneApplication::OutputFormat::tap:
@@ -932,7 +932,7 @@ void logging_flush(void)
 
 void logging_init(const struct test *test)
 {
-    if (sApp->shmem->verbosity <= 0)
+    if (sApp->shmem->cfg.verbosity <= 0)
         progress_bar_update();
 
     switch (current_output_format()) {
@@ -1067,7 +1067,7 @@ static void log_data_common(const char *message, const uint8_t *ptr, size_t size
 
     switch (current_output_format()) {
     case SandstoneApplication::OutputFormat::yaml:
-        spaces.resize(sApp->shmem->output_yaml_indent + 4 + (from_memcmp ? 3 : 0), ' ');
+        spaces.resize(sApp->shmem->cfg.output_yaml_indent + 4 + (from_memcmp ? 3 : 0), ' ');
         if (from_memcmp) {
             // no escaping, the message is proper YAML
             buffer = message;
@@ -1130,9 +1130,9 @@ void log_data(const char *message, const void *data, size_t size)
 
     std::atomic<int> &messages_logged = sApp->thread_data(thread_num)->messages_logged;
     std::atomic<unsigned> &data_bytes_logged = sApp->thread_data(thread_num)->data_bytes_logged;
-    if (messages_logged.load(std::memory_order_relaxed) >= sApp->shmem->max_messages_per_thread)
+    if (messages_logged.load(std::memory_order_relaxed) >= sApp->shmem->cfg.max_messages_per_thread)
         return;
-    if (data_bytes_logged.fetch_add(size, std::memory_order_relaxed) > sApp->shmem->max_logdata_per_thread)
+    if (data_bytes_logged.fetch_add(size, std::memory_order_relaxed) > sApp->shmem->cfg.max_logdata_per_thread)
         return;
 
     log_data_common(message, static_cast<const uint8_t *>(data), size, false);
@@ -1141,7 +1141,7 @@ void log_data(const char *message, const void *data, size_t size)
 static void logging_format_data(DataType type, std::string_view description, const uint8_t *data1,
                                 const uint8_t *data2, ptrdiff_t offset)
 {
-    std::string spaces(sApp->shmem->output_yaml_indent + 7, ' ');
+    std::string spaces(sApp->shmem->cfg.output_yaml_indent + 7, ' ');
     std::string buffer;
     switch (current_output_format()) {
     case SandstoneApplication::OutputFormat::tap:
@@ -1241,14 +1241,14 @@ void logging_report_mismatched_data(DataType type, const uint8_t *actual, const 
     // Log the data that failed. We have two buffers of size bytes to log, but
     // we'll obey the max_logdata_per_thread limit (shared with log_data()).
     // Note: this didn't need to be atomic...
-    //   size_t avail = sApp->shmem->max_logdata_per_thread - bytes_logged;
+    //   size_t avail = sApp->shmem->cfg.max_logdata_per_thread - bytes_logged;
     //   size_t len = std::min(size, avail / 2);
     auto &bytes_logged = sApp->thread_data(thread_num)->data_bytes_logged;
     size_t len = size;
     if (size_t old_total = bytes_logged.fetch_add(2 * size, std::memory_order_relaxed);
-            sApp->shmem->max_logdata_per_thread - old_total < 2 * size) {
+            sApp->shmem->cfg.max_logdata_per_thread - old_total < 2 * size) {
         // trim how much data we'll print so we stick to the limit
-        len = (sApp->shmem->max_logdata_per_thread - old_total) / 2;
+        len = (sApp->shmem->cfg.max_logdata_per_thread - old_total) / 2;
     }
 
     ptrdiff_t start;
@@ -1299,7 +1299,7 @@ void logging_mark_knob_used(std::string_view key, TestKnobValue value, KnobOrigi
     }
 #endif
 
-    if (!sApp->shmem->log_test_knobs)
+    if (!sApp->shmem->cfg.log_test_knobs)
         return;
 
     struct Visitor {
@@ -1474,7 +1474,7 @@ void AbstractLogger::print_child_stderr_common(std::function<void(int)> header)
 
     header(AbstractLogger::file_log_fd);
     print_content_indented(AbstractLogger::file_log_fd, indent, contents);
-    if (AbstractLogger::file_log_fd != AbstractLogger::real_stdout_fd && sApp->shmem->verbosity > 0) {
+    if (AbstractLogger::file_log_fd != AbstractLogger::real_stdout_fd && sApp->shmem->cfg.verbosity > 0) {
         header(AbstractLogger::real_stdout_fd);
         print_content_indented(AbstractLogger::real_stdout_fd, indent, contents);
     }
@@ -1715,7 +1715,7 @@ bool YamlLogger::want_slice_resource_usage(int slice)
     case TestResult::Passed:
     case TestResult::Failed:
     case TestResult::OperatingSystemError:
-        return sApp->shmem->verbosity >= 3;
+        return sApp->shmem->cfg.verbosity >= 3;
 
     case TestResult::Killed:
     case TestResult::CoreDumped:
@@ -1861,7 +1861,7 @@ inline int YamlLogger::print_one_thread_messages(int fd, mmap_region r, int leve
             break;
 
         case UsedKnobValue:
-            assert(sApp->shmem->log_test_knobs);
+            assert(sApp->shmem->cfg.log_test_knobs);
             continue;       // not break
         }
 
@@ -1875,7 +1875,7 @@ inline int YamlLogger::print_one_thread_messages(int fd, mmap_region r, int leve
 void YamlLogger::print_result_line(int &init_skip_message_bytes)
 {
     int loglevel = this->loglevel();
-    if (loglevel == LOG_LEVEL_QUIET && file_log_fd != real_stdout_fd && sApp->shmem->verbosity < 1) {
+    if (loglevel == LOG_LEVEL_QUIET && file_log_fd != real_stdout_fd && sApp->shmem->cfg.verbosity < 1) {
         // logging_init won't have printed "- test:" to stdout, so do it now
         progress_bar_flush();
         print_tests_header(OnFirstFail);
@@ -1901,7 +1901,7 @@ void YamlLogger::print_result_line(int &init_skip_message_bytes)
                 logging_printf(loglevel, "  skip-category: %s\n",
                                char_to_skip_category(init_skip_message[0]));
                 std::string_view message(&init_skip_message[1], init_skip_message.size()-1);
-                if (loglevel <= sApp->shmem->verbosity && file_log_fd != real_stdout_fd)
+                if (loglevel <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd)
                     format_and_print_skip_reason(real_stdout_fd, message);
                 format_and_print_skip_reason(file_log_fd, message);
                 init_skip_message_bytes = init_skip_message.size() + 2;
@@ -2000,12 +2000,12 @@ void YamlLogger::print_fixed()
     if (std::isfinite(freq_avg) && freq_avg != 0.0)
         logging_printf(LOG_LEVEL_VERBOSE(1), "  avg-freq-mhz: %.1f\n", freq_avg);
 
-    if (sApp->shmem->log_test_knobs) {
+    if (sApp->shmem->cfg.log_test_knobs) {
         struct mmap_region main_mmap = maybe_mmap_log(sApp->main_thread_data());
         if (main_mmap.size) {
             int count = print_test_knobs(file_log_fd, main_mmap);
             if (count && real_stdout_fd != file_log_fd
-                    && sApp->shmem->verbosity >= UsedKnobValueLoggingLevel)
+                    && sApp->shmem->cfg.verbosity >= UsedKnobValueLoggingLevel)
                 print_test_knobs(real_stdout_fd, main_mmap);
             munmap_file(main_mmap);
         }
@@ -2017,7 +2017,7 @@ void YamlLogger::print_thread_messages()
     // print the thread messages
     auto doprint = [this](PerThreadData::Common *data, int s_tid) {
         struct mmap_region r = maybe_mmap_log(data);
-        bool want_print = data->has_failed() || sApp->shmem->verbosity >= 3;
+        bool want_print = data->has_failed() || sApp->shmem->cfg.verbosity >= 3;
         ssize_t min_size = 0;
 
         /* for main threads (negative ids) adjust the message size to account
@@ -2035,9 +2035,9 @@ void YamlLogger::print_thread_messages()
         print_thread_header(file_log_fd, s_tid, INT_MAX);
         int lowest_level = print_one_thread_messages(file_log_fd, r, INT_MAX);
 
-        if (lowest_level <= sApp->shmem->verbosity && file_log_fd != real_stdout_fd) {
-            print_thread_header(real_stdout_fd, s_tid, sApp->shmem->verbosity);
-            print_one_thread_messages(real_stdout_fd, r, sApp->shmem->verbosity);
+        if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
+            print_thread_header(real_stdout_fd, s_tid, sApp->shmem->cfg.verbosity);
+            print_one_thread_messages(real_stdout_fd, r, sApp->shmem->cfg.verbosity);
         }
 
         munmap_and_truncate_log(data, r);
@@ -2119,7 +2119,7 @@ void YamlLogger::print_tests_header(TestHeaderTime mode)
     }
 
     // if we're in quiet mode, we print the header only on first fail
-    if (mode == AtStart && sApp->shmem->verbosity == 0 && file_log_fd != real_stdout_fd)
+    if (mode == AtStart && sApp->shmem->cfg.verbosity == 0 && file_log_fd != real_stdout_fd)
         return;
 
     if (file_log_fd != real_stdout_fd)

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -140,7 +140,7 @@ framework_config.set_quoted('SANDSTONE_FALLBACK_EXEC', get_option('fallback_exec
 framework_config.set10('SANDSTONE_NO_LOGGING', get_option('logging_format') == 'no_output')
 framework_config.set(
     'SANDSTONE_DEFAULT_LOGGING',
-    'SandstoneApplication::OutputFormat::' + get_option('logging_format'),
+    'TestConfig::OutputFormat::' + get_option('logging_format'),
 )
 
 framework_config.set10(

--- a/framework/sandstone_opts.hpp
+++ b/framework/sandstone_opts.hpp
@@ -45,7 +45,9 @@ struct ProgramOptions {
     };
     const char *builtin_test_list_name = nullptr;
 
-    int parse(int argc, char** argv, SandstoneApplication* app);
+    bool test_tests = false;
+
+    int parse(int argc, char** argv, SandstoneApplicationConfig* app_cfg);
 
     // for RestrictedCommandLine put it here to enable code elimination
     void apply_restrictions() {
@@ -57,10 +59,12 @@ struct ProgramOptions {
         on_crash_arg = nullptr;
         builtin_test_list_name = "auto";
     }
+
+    TestConfig shmem_cfg;
 };
 
-inline int parse_cmdline(int argc, char** argv, SandstoneApplication* app, ProgramOptions& opts) {
-    auto ret = opts.parse(argc, argv, app);
+inline int parse_cmdline(int argc, char** argv, SandstoneApplicationConfig* app_cfg, ProgramOptions& opts) {
+    auto ret = opts.parse(argc, argv, app_cfg);
     if constexpr (SandstoneConfig::RestrictedCommandLine) {
         opts.apply_restrictions(); // enable code elimination
     }

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -469,7 +469,7 @@ static bool create_crash_pipe(int xsave_size)
         fcntl(crashpipe[CrashPipeParent], F_SETFL, ret | O_NONBLOCK);
 
     // if we're exec'ing the child, allow it to inherit the socket
-    if (sApp->current_fork_mode() == SandstoneApplication::exec_each_test)
+    if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::exec_each_test)
         fcntl(crashpipe[CrashPipeChild], F_SETFD, 0);
 
     sApp->shmem->server_debug_socket = crashpipe[CrashPipeParent];
@@ -1071,7 +1071,7 @@ void debug_init_child()
         sigaction(signum, &action, nullptr);
     }
 
-    if (sApp->current_fork_mode() == SandstoneApplication::child_exec_each_test) {
+    if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::child_exec_each_test) {
         // we're in the child side of an execve()
         xsave_size = get_xsave_size();
     }


### PR DESCRIPTION
This is a preparation step for adding unittests of `ProgramOptionsParser`.
Until now, its' `parse` member function required whole `sApp` object as one of its parameters.
Now, only the fraction touched by the parser is passed (`SandstoneApplication::Cfg`).
It'd be much easier to create such object for testing purposes. Options parsing does not
depend on any 'global' state now.