### PR TITLE
FW/CPU: remove the XSAVE "CetState" entry

### DIFF
--- a/framework/device/cpu/simd.conf
+++ b/framework/device/cpu/simd.conf
@@ -156,7 +156,6 @@ xsave=ApxState		0x80000			apx-f	# APX Extended GPRs
 xsave=AvxState		SseState|Ymm_Hi128	avx,avx512f
 xsave=MPXState		Bndregs|Bndcsr		mpx
 xsave=Avx512State	AvxState|OpMask|Zmm_Hi256|Hi16_Zmm	avx512f
-xsave=CetState		CetUState|CetSState	shstk
 xsave=AmxState		Xtilecfg|Xtiledata	amx-tile
 
 # Processor/arch listing below this line


### PR DESCRIPTION
This is a supervisor-mode state, not saved in the XSAVE area. Therefore, the bits for them in XCR0 are always disabled. We should not disable the feature because of that.

In fact, using `cpu_feature_shstk` is probably the wrong way to detect the feature's presence. Since that requires operating system support, one probably needs to query the OS instead. On Linux, that's using arch_prctl(2) with the `ARCH_SHSTK_*` constants.

Fixes bug introduced by commit 2f9653845f837aa5940e24e4c151def225e79f46, which said:
> FW/CPU: enable checking of XSAVE states
>...
> In addition to APX-F, this also enables checking of the CET state.

```
$ cpuid -1l0xd -s1
CPU:
      XSAVEOPT instruction                    = true
      XSAVEC instruction                      = true
      XGETBV instruction                      = true
      XSAVES/XRSTORS instructions             = true
      XFD: extended feature disable supported = false
      SAVE area size in bytes                 = 0x000009b0 (2480)
      IA32_XSS valid bit field mask           = 0x0000000000003900
         PT state                             = true
         PASID state                          = false
         CET_U user state                     = true
         CET_S supervisor state               = true
         HDC state                            = true
         UINTR state                          = false
         LBR state                            = false
         HWP state                            = false
$ cpuid -1l0xd -s12
CPU:
   CET_S supervisor features (0xd/0xc):
      CET_S supervisor save state byte size    = 0x00000018 (24)
      CET_S supervisor save state byte offset  = 0x00000000 (0)
      supported in IA32_XSS or XCR0            = IA32_XSS (supervisor state)
      64-byte alignment in compacted XSAVE     = false
      XFD faulting supported                   = false
$ cpuid -1l0xd -s11
CPU:
   CET_U user features (0xd/0xb):
      CET_U user save state byte size          = 0x00000010 (16)
      CET_U user save state byte offset        = 0x00000000 (0)
      supported in IA32_XSS or XCR0            = IA32_XSS (supervisor state)
      64-byte alignment in compacted XSAVE     = false
      XFD faulting supported                   = false
```