### PR TITLE
FW/Opts: reset `optind`; do not use `optind` name in `simple_getopt`

### DIFF
--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -417,6 +417,7 @@ struct ProgramOptionsParser {
     {
         int opt;
         int coptind = -1;
+        optind = 1; // reset before starting scanning
 
         while ((opt = simple_getopt(argc, argv, long_options, &coptind)) != -1) {
             switch (opt) {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -168,7 +168,7 @@ struct test_group
    initfunc (*group_init)() noexcept;       // returns a replacement init function (or not)
 };
 
-inline int simple_getopt(int argc, char **argv, struct option *options, int *optind = nullptr)
+inline int simple_getopt(int argc, char **argv, struct option *options, int *coptind = nullptr)
 {
     // cache the result
     static std::string cached_short_opts = [=]() {
@@ -184,7 +184,7 @@ inline int simple_getopt(int argc, char **argv, struct option *options, int *opt
         }
         return result;
     }();
-    return getopt_long(argc, argv, cached_short_opts.c_str(), options, optind);
+    return getopt_long(argc, argv, cached_short_opts.c_str(), options, coptind);
 }
 
 template <bool IsDebug> struct test_the_test_data


### PR DESCRIPTION
By setting `optind` to 1, we enable calling `parse_cmdline` more than once in a single program (useful in unittests).
Since it's an extern variable, let's not use this exact name anywhere in the code.