### PR TITLE
CI/Bats: use GNU awk instead of any other awk

### DIFF
--- a/bats/sanity-check/helpers.bash
+++ b/bats/sanity-check/helpers.bash
@@ -36,7 +36,7 @@ test_yaml_numeric() {
     extract_from_yaml "$query"
     shift
     if [[ -n "$value" ]]; then
-        if awk -v value="$value" "BEGIN{exit(!($*))}" /dev/null; then
+        if gawk -v value="$value" "BEGIN{exit(!($*))}" /dev/null; then
             return 0
         fi
     fi


### PR DESCRIPTION
Debian defaults to mawk instead of gawk, which has slightly different behaviour that some of our tests have been noted to depend on (such as '1 == 0x1' - q.v. #839).