### PR TITLE
FW: rename `test_tests_init` function

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -404,7 +404,7 @@ static bool shouldTestTheTest(const struct test *the_test)
     return true;
 }
 
-inline void test_the_test_data<true>::test_tests_init(const struct test *the_test)
+inline void test_the_test_data<true>::prepare_test_tests(const struct test *the_test)
 {
     if (!shouldTestTheTest(the_test))
         return;
@@ -1406,7 +1406,7 @@ static TestResult child_run(/*nonconst*/ struct test *test, int child_number)
         std::fill_n(test->per_thread, sApp->thread_count, test_data_per_thread{});
         init_per_thread_data();
 
-        sApp->test_tests_init(test);
+        sApp->prepare_test_tests(test);
         state = prepare_test_for_device(test);
         if (state != TestResult::Passed) {
             break;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -191,7 +191,7 @@ template <bool IsDebug> struct test_the_test_data
 {
     bool test_tests_enabled() const             { return false; }
     void enable_test_tests()                    {}
-    void test_tests_init(const struct test *)   {}
+    void prepare_test_tests(const struct test *)   {}
     void test_tests_iteration(const struct test *)  {}
     void test_tests_finish(const struct test *) {}
 };
@@ -215,7 +215,7 @@ template <> struct test_the_test_data<true>
     bool test_tests_enabled() const { return test_tests; }
     void enable_test_tests()        { test_tests = true; }
 
-    void test_tests_init(const struct test *);
+    void prepare_test_tests(const struct test *);
     void test_tests_iteration(const struct test *);
     void test_tests_finish(const struct test *);
 };


### PR DESCRIPTION
To better fit `prepare_test_for_device` being called right after it.

---
parent: #818 