### PR TITLE
FW/simd.conf: remove amx-transpose

### DIFF
--- a/framework/device/cpu/simd.conf
+++ b/framework/device/cpu/simd.conf
@@ -119,7 +119,6 @@ apx-f			Leaf07_01EDX	    21		# Advanced Performance Extensions
 #amx-complex		Leaf1E_01EDX	    2	amx-tile	# (repeated) AMX Tile multiplication for complex matrices
 #amx-fp16		Leaf1E_01EAX	    3	amx-tile	# (repeated) AMX Tile multiplication in FP16
 amx-fp8			Leaf1E_01EAX	    4	amx-tile	# AMX Tile multiplication in FP8
-amx-transpose		Leaf1E_01EAX	    5	amx-tile	# AMX Tile transpositions
 amx-tf32		Leaf1E_01EAX	    6	amx-tile	# AMX Tile multiplications in TF32 (FP19)
 #amx-avx512		Leaf1E_01EAX	    7	amx-tile,avx10_2	# AMX instructions moving rows into AVX512 registers
 amx-movrs		Leaf1E_01EAX	    8	amx-tile	# AMX loads with Read-Shared hint
@@ -210,7 +209,7 @@ arch=ICX	SNC	pconfig
 arch=SPR	GLC	pconfig,amx-tile,amx-bf16,amx-int8	# enqcmd
 arch=EMR	RPC	pconfig,amx-tile,amx-bf16,amx-int8	# enqcmd
 arch=GNR	RWC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16	# amx-complex
-arch=DMR	PNC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16,amx-fp8,amx-transpose,amx-tf32,amx-avx512,amx-movrs		# amx-complex
+arch=DMR	PNC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16,amx-fp8,amx-tf32,amx-avx512,amx-movrs		# amx-complex
 arch=SRF	CMT	cmpccxadd,avxifma,avxneconvert,avxvnniint8	# enqcmd
 arch=GRR	SRF	raoint
 arch=CWF	DKT	user_msr


### PR DESCRIPTION
Edition 059 of the Instruction Set Extensions manual[1] removed it.

[1] https://software.intel.com/content/www/us/en/develop/download/intel-architecture-instruction-set-extensions-programming-reference.html