### PR TITLE
CPU-separation: introduce `special_tests` vector to store `mce_test` & others

### DIFF
--- a/framework/device/cpu/cpu_device.cpp
+++ b/framework/device/cpu/cpu_device.cpp
@@ -71,3 +71,9 @@ TestResult prepare_test_for_device(struct test *test)
     }
     return TestResult::Passed;
 }
+
+// Currently empty
+std::vector<struct test*> special_tests_for_device()
+{
+    return {};
+}

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2668,10 +2668,12 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Add mce_check as the last test to the set. It will be kept last by
+    /* Add device-specific monitoring tests to the set. They will be kept last by
      * SandstoneTestSet in case randomization is requested. */
-    if (!sApp->ignore_mce_errors)
-        test_set->add(&mce_test);
+    for (auto special_test : test_set->get_special_tests()) {
+        if (special_test != &mce_test || (special_test == &mce_test && !sApp->ignore_mce_errors))
+            test_set->add(special_test);
+    }
 
     /* Remove all the tests we were told to disable */
     if (opts.disabled_tests.size()) {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -130,6 +130,13 @@ void dump_device_info();
 }
 
 /*
+* Returns a vector with device-specific tests that should be
+* added as last tests to the test list. An example of such
+* test (device-agnostic, however) is mce_check.
+*/
+std::vector<struct test*> special_tests_for_device();
+
+/*
 * Returns formatted string, with comma separated features
 */
 std::string device_features_to_string(device_features_t f);

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -27,8 +27,9 @@ void SandstoneTestSet::load_all_tests()
         }
     }
 
-    /* add "special" mce_check as well */
-    all_tests.push_back(&mce_test);
+    /* add "special" tests */
+    special_tests = special_tests_for_device();
+    special_tests.push_back(&mce_test); // mce always added last
 }
 
 /* Looks up a name or a pattern among all "known" tests. Returns all the
@@ -55,8 +56,12 @@ std::vector<struct test *> SandstoneTestSet::lookup(const char *name)
     } else {
         for (struct test *t : all_tests) {
             if (!strcmp(t->id, name)) {
-                res.push_back(t);
-                break;
+                return {t};
+            }
+        }
+        for (struct test *t : special_tests) {
+            if (!strcmp(t->id, name)) {
+                return {t};
             }
         }
     }

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -79,9 +79,9 @@ public:
     EnabledTestList::iterator maybe_reshuffle() noexcept
     {
         if (cfg.randomize) {
-            /* Do not shuffle mce_check if present. */
+            /* Do not shuffle special tests if present. */
             auto end = test_set.end();
-            auto last = end[-1].test == &mce_test ? end - 1 : end;
+            auto last = end - special_tests.size();
             std::shuffle(test_set.begin(), last, SandstoneURBG());
         }
         return test_set.begin();
@@ -107,6 +107,11 @@ public:
 
     std::vector<struct test_cfg_info> add_builtin_test_list(const char *name, std::vector<std::string> &errors);
 
+    const TestSet& get_special_tests() const noexcept
+    {
+        return special_tests;
+    }
+
 private:
     /* Make a Uniform Random Bit Generator to use our own random as opposed to
      * standard library's. */
@@ -119,6 +124,8 @@ private:
 
     /* list of all available tests. */
     TestSet all_tests;
+    /* list of all 'special' tests. */
+    TestSet special_tests;
     /* maps group name to a vector of tests it contains. */
     std::map<std::string_view, std::vector<struct test *>> all_group_map;
 


### PR DESCRIPTION
Non-CPU builds would be able to prepend this vector with its' own device-specific tests expected to work the same way as `mce_check`. That is, placed at the end of the test lists, and not being able to be added manually (serving a purpose of a "monitor"). `mce_test` is still guaranteed to be executed as the very last one.