### PR TITLE
FW: Remove TEST_QUALITY_OPTIONAL support

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -283,7 +283,6 @@ selftest_pass() {
     selftest_pass -e 'selftest_pass*'
     [[ ${yamldump[/tests]} != *selftest_pass_low_quality* ]]
     [[ ${yamldump[/tests]} != *selftest_pass_beta* ]]
-    [[ ${yamldump[/tests]} != *selftest_pass_optional* ]]
 }
 
 @test "selftest_pass_beta" {
@@ -299,17 +298,6 @@ selftest_pass() {
     test_yaml_regexp "/tests/0/skip-reason" '.*BETA quality.*'
 }
 
-@test "selftest_pass_optional" {
-    # This should RUN selftest_pass_optional
-    declare -A yamldump
-    sandstone_selftest -e selftest_pass_optional -e selftest_pass
-    [[ "$status" -eq 0 ]]
-    test_yaml_regexp "/exit" pass
-    test_yaml_regexp "/tests/0/test" selftest_pass_optional
-    test_yaml_regexp "/tests/0/details/quality" production
-    test_yaml_regexp "/tests/0/result" pass
-}
-
 @test "selftest_pass_low_quality" {
     # This should NOT run selftest_pass_low_quality
     declare -A yamldump
@@ -318,7 +306,7 @@ selftest_pass() {
 }
 
 @test "selftest_pass group" {
-    # This should run both selftest_pass and selftest_pass_optional,
+    # This should run selftest_pass,
     # skip selftest_pass_beta and not mention selftest_pass_low_quality
     declare -A yamldump
     sandstone_selftest -e '@selftest_passes'
@@ -326,10 +314,8 @@ selftest_pass() {
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/test" selftest_pass
     test_yaml_regexp "/tests/0/result" pass
-    test_yaml_regexp "/tests/1/test" selftest_pass_optional
-    test_yaml_regexp "/tests/1/result" pass
-    test_yaml_regexp "/tests/2/test" selftest_pass_beta
-    test_yaml_regexp "/tests/2/result" skip
+    test_yaml_regexp "/tests/1/test" selftest_pass_beta
+    test_yaml_regexp "/tests/1/result" skip
 }
 
 @test "selftest_preinit" {
@@ -908,10 +894,6 @@ test_list_file() {
     test_list_file selftest_pass selftest_logs selftest_pass
 }
 
-@test "--test-list-file with optional test" {
-    test_list_file selftest_pass selftest_pass_optional
-}
-
 @test "--test-list-file with duration" {
     test_list_file selftest_pass:default selftest_timedpass:250 selftest_timedpass:10 \
         '' 'selftest_timedpass: 10' '' "$(printf "selftest_timedpass:\t10")"
@@ -1009,8 +991,8 @@ test_list_randomize() {
 test_list_file_ignores_beta() {
     declare -A yamldump
     local -a list=(selftest_pass selftest_pass_low_quality
-                   selftest_pass_beta selftest_pass_optional
-                   selftest_skip selftest_pass selftest_logs)
+                   selftest_pass_beta selftest_skip
+                   selftest_pass selftest_logs)
     local -a not_to_run=(selftest_pass_low_quality selftest_pass_beta)
 
     local testlistfile=`mktempfile list.XXXXXX`

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -105,8 +105,6 @@ typedef enum TestQuality {
     TEST_QUALITY_SKIP               = -1,
     /// test is a beta test (default) and should be run only if --beta is used
     TEST_QUALITY_BETA               = 0,
-    /// test is a production-quality test but should not be run by default
-    TEST_QUALITY_OPTIONAL           = 1,
     /// test is a production test and should be run by default
     TEST_QUALITY_PROD               = 2,
 } test_quality;

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -665,7 +665,6 @@ struct ProgramOptionsParser {
         }
         if (auto it = opts_map.find(include_optional_option); it != opts_map.end()) {
             /* do not override lower quality levels if they were requested */
-            app->requested_quality = std::min<int>(app->requested_quality, TEST_QUALITY_OPTIONAL);
             app->include_optional = true;
         }
 

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -1176,14 +1176,6 @@ static struct test selftests_array[] = {
     .quality_level = TEST_QUALITY_PROD,
 },
 {
-    .id = "selftest_pass_optional",
-    .description = "Just pass",
-    .groups = DECLARE_TEST_GROUPS(&group_positive, &group_selftest_passes),
-    .test_run = selftest_pass_run,
-    .desired_duration = -1,
-    .quality_level = TEST_QUALITY_OPTIONAL,
-},
-{
     .id = "selftest_pass_beta",
     .description = "Just pass",
     .groups = DECLARE_TEST_GROUPS(&group_positive, &group_selftest_passes),


### PR DESCRIPTION
`TEST_QUALITY_OPTIONAL` is deprecated and is replaced by `test_is_optional`. Removing complete support for it.

Commit that adds `test_is_optional` feature:

fd36f3615134787b104d976033631b27b1db3d99 (FW: Add test_is_optional flag to tests)

`TEST_QUALITY_OPTIONAL` has been replaced by `test_is_optional` in the internal repository.