### PR TITLE
FW: add flag `test_in_parent` to execute whole test in parent

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -303,6 +303,10 @@ typedef enum test_flag {
     /// the state. Do not cause a "memory" effect between tests, and do not use
     /// the random generator.
     test_init_in_parent             = 0x10000,
+
+    /// Indicates that test will be run entirely in parent, regardless of mode selected
+    /// from the command line.
+    test_in_parent                  = 0x20000,
 } test_flags;
 
 struct test_data_per_thread


### PR DESCRIPTION
This allows tests to be run in parent regardless of the command line mode selected. It's a preparation step for device-specific special tests that may want to spawn a 'monitoring' thread in their preinit (to listen for driver events, for example) and join it in cleanup (test added at the end of the test list).