### PR TITLE
CI: install GNU awk, jq, and yq in the Debian container images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,9 @@ jobs:
             ${CC} \
             elfutils \
             file \
+            gawk \
             git \
+            jq \
             libboost-dev \
             libeigen3-dev \
             libgtest-dev \
@@ -45,6 +47,7 @@ jobs:
             meson \
             ninja-build \
             python3-yaml \
+            yq \
             zlib1g-dev 
     - uses: actions/checkout@v4
     - name: meson setup


### PR DESCRIPTION
gawk because Debian defaults to mawk, a POSIX-compatible awk that doesn't understand that `1 == 0x1`.

yq so our selftests can process/select the output.