### PR TITLE
FW/CPU-Topology: set defaults to mocked module_id and numa_id

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -446,8 +446,8 @@ bool TopologyDetector::create_mock_topology(const char *topo)
         struct cpu_info *info = &cpu_info[cpu_count];
         ++cpu_count;
 
-        info->package_id = info->numa_id = info->tile_id =
-                info->module_id = info->core_id = info->thread_id = 0;
+        info->package_id = info->core_id = info->thread_id = 0;
+        info->numa_id = info->module_id = info->tile_id = -1;
         info->native_core_type = core_type_unknown;
 
         // mock cache too (8 kB L1, 32 kB L2, 256 kB L3)
@@ -494,6 +494,11 @@ bool TopologyDetector::create_mock_topology(const char *topo)
 
             c = topo ? topo[0] | 0x20 : '\0';
         }
+
+        if (info->module_id < 0)
+            info->module_id = info->core_id;
+        if (info->numa_id < 0)
+            info->numa_id = info->package_id;
 
         while (topo && (*topo == ' ' || *topo == ','))
             ++topo;


### PR DESCRIPTION
This defaults `module_id` to the `core_id` if not provided, which matches the way modules are usually detected when not provided. Likewise, we are defaulting 1:1 packages (sockets) and NUMA domains.

Noticed that the CI was producing:
```
ok 116 slicing cores # skip Test only works with Debug builds (to mock the topology) or at least 2 different modules
```