### PR TITLE
CPU-separation: create interface function `print_fixed_for_device()`

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -426,4 +426,20 @@ void AbstractLogger::print_thread_header_for_device(int fd, PerThreadData::Test 
     }
 }
 
+void AbstractLogger::print_fixed_for_device()
+{
+    double freqs = 0.0;
+    int cpus_measured = 0;
+    for_each_test_thread([&](const PerThreadData::Test *data, int) {
+        if (!data->has_skipped()) {
+            freqs += data->effective_freq_mhz;
+            ++cpus_measured;
+        }
+    });
+
+    const double freq_avg = freqs / cpus_measured;
+    if (std::isfinite(freq_avg) && freq_avg != 0.0)
+        logging_printf(LOG_LEVEL_VERBOSE(1), "  avg-freq-mhz: %.1f\n", freq_avg);
+}
+
 #endif // !SANDSTONE_NO_LOGGING

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1990,18 +1990,7 @@ void YamlLogger::print_fixed()
     logging_printf(LOG_LEVEL_VERBOSE(1), "  test-runtime: %s\n",
                    format_duration(test_duration, FormatDurationOptions::WithoutUnit).c_str());
 
-    double freqs = 0.0;
-    int cpus_measured = 0;
-    for_each_test_thread([&](const PerThreadData::Test *data, int) {
-        if (!data->has_skipped()) {
-            freqs += data->effective_freq_mhz;
-            ++cpus_measured;
-        }
-    });
-
-    const double freq_avg = freqs / cpus_measured;
-    if (std::isfinite(freq_avg) && freq_avg != 0.0)
-        logging_printf(LOG_LEVEL_VERBOSE(1), "  avg-freq-mhz: %.1f\n", freq_avg);
+    print_fixed_for_device();
 
     if (sApp->shmem->cfg.log_test_knobs) {
         struct mmap_region main_mmap = maybe_mmap_log(sApp->main_thread_data());

--- a/framework/logging.h
+++ b/framework/logging.h
@@ -62,6 +62,7 @@ public:
     // device-specific interfaces
     static std::string thread_id_header_for_device(int device, int verbosity);
     static void print_thread_header_for_device(int fd, PerThreadData::Test *thr);
+    static void print_fixed_for_device();
 
     const struct test *test;
     MonotonicTimePoint earliest_fail = MonotonicTimePoint::max();
@@ -122,6 +123,8 @@ private:
 inline std::string AbstractLogger::thread_id_header_for_device(int device, int verbosity)
 { __builtin_unreachable(); return {}; }
 inline void AbstractLogger::print_thread_header_for_device(int fd, PerThreadData::Test *thr)
+{ __builtin_unreachable(); }
+inline void AbstractLogger::print_fixed_for_device()
 { __builtin_unreachable(); }
 #endif
 

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -892,8 +892,10 @@ static uintptr_t thread_runner(int thread_number)
     // indicate to SIGQUIT handler that we're running
     this_thread->thread_state.store(thread_running, std::memory_order_relaxed);
 
+#if SANDSTONE_DEVICE_CPU
     CPUTimeFreqStamp before;
     before.Snapshot(thread_number);
+#endif
     test_start();
 
     try {
@@ -905,9 +907,11 @@ static uintptr_t thread_runner(int thread_number)
 
     cleanup.run_now();
 
+#if SANDSTONE_DEVICE_CPU
     CPUTimeFreqStamp after;
     after.Snapshot(thread_number);
     this_thread->effective_freq_mhz = CPUTimeFreqStamp::EffectiveFrequencyMHz(before, after);
+#endif
 
     if (sApp->shmem->cfg.verbosity >= 3)
         log_message(thread_number, SANDSTONE_LOG_INFO "inner loop count for thread %d = %" PRIu64 "\n",


### PR DESCRIPTION
This commit adds also ifdef around `CPUTimeFreqStamp`. Ultimately, we can implement a set of device-specific "monitors" catching a snapshot before/after each test, and updating appropriate stuff in thread data.