### PR TITLE
FW: add `test_schedule_isolate_numa_domain`

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2089,10 +2089,13 @@ void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, 
         return result;
     };
     const std::vector<DeviceRange> &fullsocket = sApp->slice_plans.plans[SandstoneApplication::SlicePlans::IsolateSockets];
+    const std::vector<DeviceRange> &isolatenuma = sApp->slice_plans.plans[SandstoneApplication::SlicePlans::IsolateNuma];
     const std::vector<DeviceRange> &heuristic = sApp->slice_plans.plans[SandstoneApplication::SlicePlans::Heuristic];
     logging_printf(LOG_LEVEL_VERBOSE(1), "test-plans:\n");
     logging_printf(LOG_LEVEL_VERBOSE(1), "  fullsocket: [ %s ]\n",
                    make_plan_string(fullsocket).c_str());
+    logging_printf(LOG_LEVEL_VERBOSE(1), "  isolate_numa: [ %s ]\n",
+                   make_plan_string(isolatenuma).c_str());
     logging_printf(LOG_LEVEL_VERBOSE(1), "  heuristic: [ %s ]\n",
                    make_plan_string(heuristic).c_str());
 #endif

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1681,6 +1681,9 @@ static int slices_for_test(const struct test *test)
         case test_schedule_isolate_socket:
             return SandstoneApplication::SlicePlans::IsolateSockets;
 
+        case test_schedule_isolate_numa_domain:
+            return SandstoneApplication::SlicePlans::IsolateNuma;
+
         case test_schedule_default:
             break;
         }

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -265,6 +265,12 @@ typedef enum test_flag {
     /// system, with all cores.
     test_schedule_isolate_socket    = 3,
 
+    /// Asks the framework to run one child process per NUMA domain in each
+    /// socket in the system, with all cores. Note: on hybrid systems with
+    /// different core types, each core type is considered a different "NUMA"
+    /// domain.
+    test_schedule_isolate_numa_domain = 4,
+
     test_schedule_mask              = 0x0f,
 
     /// Tells the --test-tests mode to ignore memory consumption for this test

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -370,10 +370,11 @@ struct SandstoneApplication : SandstoneApplicationConfig, public test_the_test_d
         enum Type : int8_t {
             FullSystem = -1,
             IsolateSockets,
+            IsolateNuma,
             Heuristic,
         };
         using Slices = std::vector<DeviceRange>;
-        std::array<Slices, 2> plans;
+        std::array<Slices, 3> plans;
     };
 
     struct SharedMemory;


### PR DESCRIPTION
This flag allows tests to specify that they want to run in all cores/modules of a given NUMA domain. This should map 1:1 to the tiles in a high-core-count CPU, though I don't have access to one to show it does.

For example, on an 120-core Granite Rapids, which has 3 NUMA domains of 40 cores each:
```yaml
test-plans:
  fullsocket: [ { starting_cpu: 0, count: 240 } ]
  isolate_numa: [ { starting_cpu: 0, count: 80 }, { starting_cpu: 80, count: 80 }, { starting_cpu: 160, count: 80 } ]
  heuristic: [ { starting_cpu: 0, count: 40 }, { starting_cpu: 40, count: 40 }, { starting_cpu: 80, count: 40 }, { starting_cpu: 120, count: 40 }, { starting_cpu: 160, count: 40 }, { starting_cpu: 200, count: 40 } ]
```

As a side-effect of the way I implemented the core-type separation in PR#853, each core type is considered a separate "NUMA" domain, so on my Alder Lake workstation I get:
```yaml
test-plans:
  fullsocket: [ { starting_cpu: 0, count: 20 } ]
  isolate_numa: [ { starting_cpu: 0, count: 16 }, { starting_cpu: 16, count: 4 } ]
  heuristic: [ { starting_cpu: 0, count: 16 }, { starting_cpu: 16, count: 4 } ]
```

