### PR TITLE
FW/Logging: add a mode to log raw YAML, not in a string

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -621,6 +621,21 @@ function selftest_log_skip_init_common() {
     check_test 1
 }
 
+@test "selftest_log_raw_yaml" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_log_raw_yaml
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/result" pass
+    for ((i = 0; i < MAX_PROC; ++i)); do
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/level" info
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/text" 'Some details from the test'
+        test_yaml_numeric "/tests/0/threads/$i/messages/0/details/cpu" "value == $i"
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/details/random" '.*'
+        test_yaml_regexp "/tests/0/threads/$i/messages/0/details/text" 'foo bar'
+    done
+}
+
 @test "selftest_logdata" {
     declare -A yamldump
     sandstone_selftest -e selftest_logdata
@@ -953,6 +968,7 @@ test_list_randomize() {
         selftest_logs
         selftest_logdata
         selftest_log_platform
+        selftest_log_raw_yaml
         selftest_logs_options
         selftest_skip
     )

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -438,6 +438,9 @@ extern void log_message_skip(int thread_num, SkipCategory c, const char *msg, ..
 /// The message parameter provides a description of the data which
 /// precedes it in the log file.  The data is output in hexadecimal.
 extern void log_data(const char *message, const void *data, size_t size);
+/// Logs pre-formatted YAML to the logs.
+extern void log_yaml(char levelchar, const char *yaml);
+#define log_yaml(level, yaml)       log_yaml(level[0], yaml)
 
 /// retrieves the physical address of a given pointer.  Currently
 /// this function is only supported on Linux and requires root
@@ -631,6 +634,7 @@ memcmp_or_fail(const T *actual, const T *expected, size_t count)
 #  undef log_error
 #  undef log_warning
 #  undef log_info
+#  undef log_yaml
 #  undef report_fail
 #  undef report_fail_msg
 
@@ -638,6 +642,7 @@ memcmp_or_fail(const T *actual, const T *expected, size_t count)
 #  define log_error(...)                    log_message(thread_num, SANDSTONE_LOG_ERROR "")
 #  define log_warning(...)                  (void)0
 #  define log_info(...)                     (void)0
+#  define log_yaml(level, yaml)             log_yaml(level[0], NULL)
 #  define report_fail(test)                 _report_fail(test, NULL, 0)
 #  define report_fail_msg(...)              _report_fail_msg(NULL, 0, NULL)
 

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -182,6 +182,17 @@ static int selftest_log_platform_init(struct test *test)
     return EXIT_SUCCESS;
 }
 
+static int selftest_lograwyaml_run(struct test *test, int cpu)
+{
+    log_yaml(SANDSTONE_LOG_INFO,
+             stdprintf("Some details from the test\n"
+                       "cpu: %d\n"
+                       "random: 0h%016llx\n"
+                       "text: foo bar\n\n",
+                       cpu, (unsigned long long)random64()).c_str());
+    return EXIT_SUCCESS;
+}
+
 static int selftest_logs_options_init(struct test *test)
 {
     const char *strvalue = get_testspecific_knob_value_string(test, "StringValue", "DefaultValue");
@@ -1258,6 +1269,14 @@ static struct test selftests_array[] = {
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_init = selftest_log_platform_init,
     .test_run = selftest_pass_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_log_raw_yaml",
+    .description = "Logs YAML content",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_run = selftest_lograwyaml_run,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },


### PR DESCRIPTION
It is the responsibility of the test author to ensure that the output is valid YAML.