### PR TITLE
FW/Logging: mark `logging_mark_thread_{failed,skipped}()` noexcept

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -606,7 +606,7 @@ static std::string create_filtered_message_string(const char *fmt, va_list va)
 }
 
 // function must be async-signal-safe
-void logging_mark_thread_failed(int thread_num)
+void logging_mark_thread_failed(int thread_num) noexcept
 {
     PerThreadData::Common *thr = sApp->thread_data(thread_num);
     if (thr->has_failed())
@@ -622,7 +622,7 @@ void logging_mark_thread_failed(int thread_num)
     }
 }
 
-void logging_mark_thread_skipped(int thread_num)
+void logging_mark_thread_skipped(int thread_num) noexcept
 {
     PerThreadData::Common *thr = sApp->thread_data(thread_num);
     if (thr->has_failed())

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -634,8 +634,8 @@ int logging_close_global(int exitcode);
 void logging_print_log_file_name();
 void logging_restricted(int level, const char *fmt, ...);
 void logging_printf(int level, const char *msg, ...) ATTRIBUTE_PRINTF(2, 3);
-void logging_mark_thread_failed(int thread_num);
-void logging_mark_thread_skipped(int thread_num);
+void logging_mark_thread_failed(int thread_num) noexcept;
+void logging_mark_thread_skipped(int thread_num) noexcept;
 void logging_report_mismatched_data(enum DataType type, const uint8_t *actual, const uint8_t *expected,
                                     size_t size, ptrdiff_t offset, const char *fmt, va_list);
 void logging_print_header(int argc, char **argv, ShortDuration test_duration, ShortDuration test_timeout);


### PR DESCRIPTION
The `logging_mark_thread_failed()` function is called from the Unix child_debug signal handler, so it already has a comment indicating it must be async-signal-safe. In theory, async-signal-safe functions *can* throw and even unwind to a catch point outside the handler, but we're not using that.

So help codegen by with the marker.