### PR TITLE
unittests: fix stack smashing by stdio's `open_memstream()`

### DIFF
--- a/framework/unit-tests/opts_parser_tests.cpp
+++ b/framework/unit-tests/opts_parser_tests.cpp
@@ -77,11 +77,9 @@ private:
 
 #ifdef _WIN32
         buflen = ftell(test_stream);
-        if (buflen < 0) {
-            buffer = new char;
-            return;
-        }
-        buffer = new char[buflen];
+        if (buflen < 0)
+            buflen = 0;
+        buffer = (char *)malloc(buflen);
         fseek(test_stream, 0, SEEK_SET);
         fread(buffer, 1, buflen, test_stream);
 #endif


### PR DESCRIPTION
We passed a stack variable as `buflen`, but `open_memstream()`'s routines remember that address and will update it as the buffer grows or shrinks. That causes stack smashing.

Also, as we always free the buffer with `free()`, so we must allocate it with `malloc()` and friends.
