### PR TITLE
CI/Bats: escape the expression for `test_yaml_expr`

### DIFF
--- a/bats/sanity-check/helpers.bash
+++ b/bats/sanity-check/helpers.bash
@@ -52,12 +52,13 @@ test_yaml_expr() {
     local value
     extract_from_yaml "$query"
     shift
-    if test "$value" "$@"; then
+    set "$value" "$@"
+    if test "$@"; then
         return 0
     fi
     printf "Expression test failed:\n"
     printf "query:      %s\n" "$query"
-    printf "expression: %s\n" "$value $*"
+    printf "expression: %s\n" "${*@Q}"
     return 1
 }
 


### PR DESCRIPTION
Before, it might print:
```
# Expression test failed:
# query:      /tests/0/threads/0/messages/2/text
# expression: E> This is an another error message = This is an another error message
```

Now, we get:
```
# Expression test failed:
# query:      /tests/0/threads/0/messages/2/text
# expression: 'E> This is an another error message' '=' 'This is an another error message'
```