### PR TITLE
FW/Logging: add support for installing a callback after errors

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -897,6 +897,7 @@ static uintptr_t thread_runner(int thread_number)
             if (sApp->shmem->cfg.ud_on_failure)
                 ud2();
             logging_mark_thread_failed(thread_number);
+            logging_run_callback();
         } else if (new_state == thread_skipped) {
             logging_mark_thread_skipped(thread_number);
         }

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -333,6 +333,11 @@ struct SandstoneApplication : SandstoneApplicationConfig, public test_the_test_d
     MonotonicTimePoint current_test_starttime;
     int threshold_time_remaining = 30000;
 
+    struct {
+        void (*cb)(void *);
+        void *token;
+    } current_test_failure_callback;
+
     std::unique_ptr<RandomEngineWrapper, RandomEngineDeleter> random_engine;
 #if SANDSTONE_FREQUENCY_MANAGER
     std::unique_ptr<FrequencyManager> frequency_manager;
@@ -574,6 +579,7 @@ void logging_restricted(int level, const char *fmt, ...);
 void logging_printf(int level, const char *msg, ...) ATTRIBUTE_PRINTF(2, 3);
 void logging_mark_thread_failed(int thread_num) noexcept;
 void logging_mark_thread_skipped(int thread_num) noexcept;
+void logging_run_callback();
 void logging_report_mismatched_data(enum DataType type, const uint8_t *actual, const uint8_t *expected,
                                     size_t size, ptrdiff_t offset, const char *fmt, va_list);
 void logging_print_header(int argc, char **argv, ShortDuration test_duration, ShortDuration test_timeout);

--- a/framework/test_data.h
+++ b/framework/test_data.h
@@ -33,6 +33,19 @@ struct Common
     /* Records the number of bytes log_data'ed per thread */
     std::atomic<unsigned> data_bytes_logged;
 
+    enum class Flag {
+        CallbackCalled = 0x0001,
+    };
+    uint32_t thread_flags;
+    friend constexpr inline uint32_t operator|(Flag f1, Flag f2)
+    {
+        return unsigned(f1) | unsigned(f2);
+    }
+    friend constexpr inline uint32_t operator&(uint32_t flags, Flag f2)
+    {
+        return flags & unsigned(f2);
+    }
+
     MonotonicTimePoint fail_time;
     bool has_failed() const
     {
@@ -46,9 +59,10 @@ struct Common
     void init()
     {
         thread_state.store(thread_not_started, std::memory_order_relaxed);
-        fail_time = MonotonicTimePoint{};
         messages_logged.store(0, std::memory_order_relaxed);
         data_bytes_logged.store(0, std::memory_order_relaxed);
+        fail_time = MonotonicTimePoint{};
+        thread_flags = {};
     }
 };
 


### PR DESCRIPTION
Many tests would like to print some extra, useful information to help in debugging or identifying problems. For example, accelerator tests need to print which accelerator was being tested (at least until the framework is taught to target specific accelerators). But we don't want to print any information *unless* the test fails, to avoid cluttering logs.

This commit add supports for installing a callback, which the framework will call after the first error in any given thread. It's the responsibility of the test to retain a valid state throughout, including if the test may `return EXIT_FAILURE;`. The `log_yaml()` function (PR #869) comes in very handy for this.