### PR TITLE
CPU-separation: rename cpu->device/thread

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -380,9 +380,9 @@ auto thread_core_spacing()
 }
 } // end unnamed namespace
 
-std::string AbstractLogger::thread_id_header_for_device(int cpu, int verbosity)
+std::string AbstractLogger::thread_id_header_for_device(int thread, int verbosity)
 {
-    struct cpu_info *info = cpu_info + cpu;
+    struct cpu_info *info = cpu_info + thread;
     std::string line;
 #ifdef _WIN32
     line = stdprintf("{ logical-group: %2u, logical: %2u, ",

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -246,7 +246,7 @@ struct test;
 typedef int (*initfunc)(struct test *test);
 typedef int (*cleanupfunc)(struct test *test);
 
-typedef int (*runfunc)(struct test *test, int cpu);
+typedef int (*runfunc)(struct test *test, int thread);
 
 typedef enum test_flag {
     /// Lets the framework heuristically choose the best slicing technique for
@@ -342,7 +342,7 @@ struct test {
     /* methods */
     initfunc test_preinit;        ///! called from the parent
     initfunc test_init;           ///! called from the child's main thread (unless set otherwise with test_init_in_parent flag)
-    runfunc test_run;             ///! called from the child, per CPU
+    runfunc test_run;             ///! called from the child, per device
     cleanupfunc test_cleanup;     ///! called from the child's main thread
 
     /// kvm_config for kvm test type
@@ -351,7 +351,7 @@ struct test {
     /* generic data for test running */
     /* filled in by framework, used by framework and tests */
 
-    /// minimum CPU required to be run, skipped if too old
+    /// minimum device required to be run, skipped if too old
     device_features_t minimum_cpu; // we need to keep that name for legacy reasons, ideally should be `minimum_device_to_run`
 
     /// duration (in ms) the test wants to run for
@@ -435,7 +435,7 @@ bool test_is_retry() noexcept __attribute__((pure));
 /// outputs msg to the logs, prefixing it with the string "Platform issue:"
 /// This function is usually used to log a warning when an error is detected
 /// in a test's test_init or test_run functions that is due to a platform issue
-/// rather than a problem with the CPU.  Examples, of such errors include
+/// rather than a problem with the device.  Examples, of such errors include
 /// failures to allocate memory or create a file.
 extern void log_platform_message(const char *msg, ...) ATTRIBUTE_PRINTF(1, 2);
 extern void log_message(int thread_num, const char *msg, ...) ATTRIBUTE_PRINTF(2, 3);
@@ -541,7 +541,7 @@ extern device_features_t device_features;
 
 /// thread_num always contains the integer identifier for the executing
 /// thread.  It can be used to index the cpu_info array and is equivalent
-/// to the cpu parameter in the test_run function.
+/// to the thread parameter in the test_run function.
 #ifdef __llvm__
 extern thread_local int thread_num;
 #else

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -460,7 +460,7 @@ struct SandstoneApplication::SharedMemory
 
     // per-thread & variable length
     int main_thread_count = 0;
-    int total_cpu_count = 0;
+    int total_thread_count = 0;
     alignas(64) device_info cpu_info[];         // C99 Flexible Array Member
 
 #if 0
@@ -468,7 +468,7 @@ struct SandstoneApplication::SharedMemory
     // layout is:
     alignas(PAGE_SIZE)
     PerThreadData::Main main_thread_data[main_thread_count];
-    PerThreadData::Test per_thread[total_cpu_count];
+    PerThreadData::Test per_thread[total_thread_count];
 #endif
 };
 

--- a/framework/sandstone_thread.cpp
+++ b/framework/sandstone_thread.cpp
@@ -31,7 +31,7 @@ struct SandstoneTestThreadAttributes
     SandstoneTestThreadAttributes &operator=(const SandstoneTestThreadAttributes &) = delete;
 
     static unsigned char *allocate_stack_block();
-    void update_with_stack_for(int cpu);
+    void update_with_stack_for(int thread);
 };
 } // unnamed namespace
 
@@ -52,12 +52,12 @@ unsigned char *SandstoneTestThreadAttributes::allocate_stack_block()
     return ptr;
 }
 
-void SandstoneTestThreadAttributes::update_with_stack_for(int cpu)
+void SandstoneTestThreadAttributes::update_with_stack_for(int thread)
 {
     if (!stacks_block)
         return;
     unsigned char *stacktop = stacks_block;
-    stacktop -= (THREAD_STACK_SIZE + GuardSize) * unsigned(cpu);
+    stacktop -= (THREAD_STACK_SIZE + GuardSize) * unsigned(thread);
     pthread_attr_setstack(&thread_attr, stacktop - THREAD_STACK_SIZE, THREAD_STACK_SIZE);
 }
 #else
@@ -81,7 +81,7 @@ void SandstoneTestThreadAttributes::update_with_stack_for(int)
 #endif
 }
 
-void SandstoneTestThread::start(RunnerFunction *f, int cpu)
+void SandstoneTestThread::start(RunnerFunction *f, int t)
 {
     assert(check_run_from_correct_thread());
 
@@ -94,9 +94,9 @@ void SandstoneTestThread::start(RunnerFunction *f, int cpu)
         return reinterpret_cast<void *>(self->target(self->thread_num));
     };
 
-    thread_num = cpu;
+    thread_num = t;
     target = f;
-    thread_attributes.update_with_stack_for(cpu);
+    thread_attributes.update_with_stack_for(t);
     pthread_create(&thread, &thread_attributes.thread_attr, runner, this);
 }
 

--- a/framework/sandstone_thread.h
+++ b/framework/sandstone_thread.h
@@ -14,7 +14,7 @@
 struct SandstoneTestThread
 {
     using RunnerFunction = uintptr_t (int);
-    void start(RunnerFunction *, int cpu);
+    void start(RunnerFunction*, int);
     uintptr_t join();
 
     pthread_t thread;

--- a/framework/sysdeps/linux/cpu_affinity.cpp
+++ b/framework/sysdeps/linux/cpu_affinity.cpp
@@ -72,8 +72,8 @@ bool pin_to_logical_processors(DeviceRange range, const char *thread_name)
 
     // find the maximum CPU number
     int n = 0;
-    for (int cpu = range.starting_device; cpu < range.starting_device + range.device_count; ++cpu)
-        n = std::max(n, cpu_info[cpu].cpu_number);
+    for (int device = range.starting_device; device < range.starting_device + range.device_count; ++device)
+        n = std::max(n, cpu_info[device].cpu_number);
 
     using Word = LogicalProcessorSetOps::Word;
     constexpr size_t ProcessorsPerWord = LogicalProcessorSetOps::ProcessorsPerWord;
@@ -82,8 +82,8 @@ bool pin_to_logical_processors(DeviceRange range, const char *thread_name)
     Word cpu_set[size];         // -Wvla
     memset(cpu_set, 0, sizeof(cpu_set));
 
-    for (int cpu = range.starting_device; cpu < range.starting_device + range.device_count; ++cpu) {
-        auto lp = LogicalProcessor(cpu_info[cpu].cpu_number);
+    for (int device = range.starting_device; device < range.starting_device + range.device_count; ++device) {
+        auto lp = LogicalProcessor(cpu_info[device].cpu_number);
         LogicalProcessorSetOps::setInArray({ cpu_set, size }, lp);
     }
 

--- a/framework/sysdeps/windows/child_debug.cpp
+++ b/framework/sysdeps/windows/child_debug.cpp
@@ -316,9 +316,9 @@ void debug_crashed_child(std::span<const pid_t> children)
             break;
 
         auto ctx = reinterpret_cast<CrashContext *>(buf.data());
-        int cpu = ctx->header.thread_num;
-        if (cpu < -1 || cpu > sApp->thread_count)
-            cpu = ctx->header.thread_num = -1;
+        int thread = ctx->header.thread_num;
+        if (thread < -1 || thread > sApp->thread_count)
+            thread = ctx->header.thread_num = -1;
         print_exception_info(ctx);
 
         std::string log;
@@ -329,7 +329,7 @@ void debug_crashed_child(std::span<const pid_t> children)
 
         if (log.size()) {
             log.insert(0, "Registers:\n");
-            log_message_preformatted(cpu, LOG_LEVEL_VERBOSE(2), log);
+            log_message_preformatted(thread, LOG_LEVEL_VERBOSE(2), log);
         }
     }
 

--- a/tests/common/mce_check/mce_check.cpp
+++ b/tests/common/mce_check/mce_check.cpp
@@ -49,11 +49,11 @@ int mce_check_preinit(struct test *test)
     return EXIT_SUCCESS;
 }
 
-int mce_check_run(struct test *test, int cpu)
+int mce_check_run(struct test *test, int thread)
 {
     int errorcount = 0;
     (void) test;
-    if (cpu != 0)
+    if (thread != 0)
         return EXIT_SUCCESS;
 
     std::vector<uint32_t> counts = InterruptMonitor::get_mce_interrupt_counts();
@@ -75,13 +75,13 @@ int mce_check_run(struct test *test, int cpu)
     // check the CPUs we were running tests on
     for (int i = 0; i < thread_count(); ++i) {
         // translate our thread number to the OS CPU number
-        cpu = cpu_info[i].cpu_number;
-        assert(cpu < differences.size());
+        thread = cpu_info[i].cpu_number;
+        assert(thread < differences.size());
 
-        if (differences[cpu] != 0) {
+        if (differences[thread] != 0) {
             log_message(i, SANDSTONE_LOG_ERROR "MCE detected (%u interrupts since start)",
-                        differences[cpu]);
-            differences[cpu] = 0;
+                        differences[thread]);
+            differences[thread] = 0;
             ++errorcount;
         }
     }

--- a/tests/common/smi_count/smi_count.cpp
+++ b/tests/common/smi_count/smi_count.cpp
@@ -35,20 +35,20 @@ int initialize_smi_counts(struct test*)
     return EXIT_SUCCESS;
 }
 
-int smi_count_run(struct test *test, int cpu)
+int smi_count_run(struct test *test, int thread)
 {
     (void) test;
 
-    if (smi_counts_start.size() > cpu) {
-        int real_cpu_number = cpu_info[cpu].cpu_number;
-        auto initial_count = smi_counts_start[cpu];
+    if (smi_counts_start.size() > thread) {
+        int real_cpu_number = cpu_info[thread].cpu_number;
+        auto initial_count = smi_counts_start[thread];
         auto current_count = InterruptMonitor::count_smi_events(real_cpu_number);
         if (current_count) {
             uint64_t difference = *current_count - initial_count;
 
             if (difference) {
                 log_platform_message(SANDSTONE_LOG_INFO "SMI count difference detected: %" PRIu64 " new SMI detected on thread %d cpu_number %d\n",
-                                     difference, cpu, real_cpu_number);
+                                     difference, thread, real_cpu_number);
             }
         }
     }


### PR DESCRIPTION
This includes renaming some local variables, descriptions, `run` function declaration,
and `SharedMemory::total_cpu_count`.