### PR TITLE
FW: rename struct `device_info` to `device_info_t` for better clarity

### DIFF
--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -191,7 +191,7 @@ struct cpu_info
 };
 
 // Alias for use in common framework code
-typedef struct cpu_info device_info;
+typedef struct cpu_info device_info_t;
 
 /// cpu_info is an array of cpu_info structures.  Each element of the array
 /// contains information about a logical CPU that will be used to

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1504,7 +1504,7 @@ void TopologyDetector::detect(const LogicalProcessorSet &enabled_cpus)
 {
     assert(sApp->thread_count);
     assert(sApp->thread_count == enabled_cpus.count());
-    cpu_info = sApp->shmem->cpu_info;
+    cpu_info = sApp->shmem->device_info;
 
     // detect this CPU's family - it's impossible for them to be different
     detect_family_via_cpuid();
@@ -1849,7 +1849,7 @@ void setup_devices<LogicalProcessorSet>(const LogicalProcessorSet &enabled_devic
 void restrict_topology(DeviceRange range)
 {
     assert(range.starting_device + range.device_count <= sApp->thread_count);
-    auto old_cpu_info = std::exchange(cpu_info, sApp->shmem->cpu_info + range.starting_device);
+    auto old_cpu_info = std::exchange(cpu_info, sApp->shmem->device_info + range.starting_device);
     int old_thread_count = std::exchange(sApp->thread_count, range.device_count);
 
     Topology &topo = cached_topology();

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2205,7 +2205,7 @@ static int exec_mode_run(int argc, char **argv)
     int child_number = parse_int(argv[3]);
 
     attach_shmem(parse_int(argv[2]));
-    cpu_info = sApp->shmem->cpu_info;
+    cpu_info = sApp->shmem->device_info;
     sApp->thread_count = sApp->shmem->total_thread_count;
     sApp->user_thread_data.resize(sApp->thread_count);
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -414,7 +414,7 @@ struct SandstoneApplication::SharedMemory
     // per-thread & variable length
     int main_thread_count = 0;
     int total_thread_count = 0;
-    alignas(64) device_info cpu_info[];         // C99 Flexible Array Member
+    alignas(64) device_info_t device_info[];         // C99 Flexible Array Member
 
 #if 0
     // in/out per-thread data allocated dynamically;

--- a/framework/sandstone_unittests_utils.cpp
+++ b/framework/sandstone_unittests_utils.cpp
@@ -8,7 +8,7 @@
 #define UNITTESTS_NUM_CPUS 16
 
 /* Define dummy setup struct that can be used by unittests when needed */
-device_info *cpu_info = nullptr;
+device_info_t *cpu_info = nullptr;
 
 /* Define dummy number of dummy cpus */
 int num_cpus() { return UNITTESTS_NUM_CPUS; }

--- a/tests/cpu/ifs/unit/ifs_unittests.cpp
+++ b/tests/cpu/ifs/unit/ifs_unittests.cpp
@@ -274,7 +274,7 @@ TEST(IFSTrigger, AllCoresPass)
 
     // Setup dummy cpu_info array
     int cpu_num = 2;
-    cpu_info = new device_info[cpu_num];
+    cpu_info = new device_info_t[cpu_num];
     cpu_info[1].cpu_number = 1;
 
     // Loop over each cpu


### PR DESCRIPTION
This way we can use `device_info` variable name in `SharedMemory`, as it's not interferring with type alias.