### PR TITLE
FW/CPU: rename `cpu_info` to `cpu_info_t`

### DIFF
--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -122,7 +122,7 @@
 /// This macro is provided in case tests need more fine grained control.
 #define cpu_has_feature(f)      ((device_compiler_features & (f)) == (f) || (device_features & (f)) == (f))
 
-/// Describes the field @c native_core_type in @ref cpu_info
+/// Describes the field @c native_core_type in @ref cpu_info_t
 // use typed enums
 enum NativeCoreType
 #if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
@@ -152,8 +152,8 @@ struct cache_info_t
     int cache_data;
 };
 
-/// cpu_info contains information about a logical CPU
-struct cpu_info
+/// cpu_info_t contains information about a logical CPU
+struct cpu_info // TODO: ultimately rename to cpu_info_t
 {
     uint64_t microcode;     ///! Microcode version read from /sys
 
@@ -190,17 +190,19 @@ struct cpu_info
 #endif
 };
 
-// Alias for use in common framework code
+// Alias for use in common framework code.
 typedef struct cpu_info device_info_t;
+// Temporary alias until we rename this struct to cpu_info_t.
+typedef struct cpu_info cpu_info_t;
 
-/// cpu_info is an array of cpu_info structures.  Each element of the array
+/// cpu_info is an array of cpu_info_t structures.  Each element of the array
 /// contains information about a logical CPU that will be used to
 /// execute a test's test_run function.  The size of this array is
 /// equal to the value returned by num_cpus().
 extern struct cpu_info *cpu_info;
 
 #ifdef __cplusplus
-inline int cpu_info::cpu() const
+inline int cpu_info_t::cpu() const
 {
     return this - ::cpu_info;
 }

--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -9,7 +9,7 @@
 
 #include <cinttypes>
 
-static constexpr const char *native_device_type(const struct cpu_info *info)
+static constexpr const char *native_device_type(const cpu_info_t *info)
 {
     switch (info->native_core_type) {
     case core_type_efficiency:
@@ -92,7 +92,7 @@ void KeyValuePairLogger::print_thread_header(int fd, int device, const char *pre
         return;
     }
 
-    struct cpu_info *info = cpu_info + device;
+    cpu_info_t *info = cpu_info + device;
     const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(info->package_id);
     PerThreadData::Test *thr = sApp->test_thread_data(device);
     if (std::string time = format_duration(thr->fail_time); time.size()) {
@@ -283,7 +283,7 @@ void TapFormatLogger::print_thread_header(int fd, int device, int verbosity)
         return;
     }
 
-    struct cpu_info *info = cpu_info + device;
+    cpu_info_t *info = cpu_info + device;
     std::string line = stdprintf("  Thread %d on CPU %d (pkg %d, core %d, thr %d", device,
             info->cpu_number, info->package_id, info->core_id, info->thread_id);
     if (const char *type = native_device_type(info))
@@ -382,7 +382,7 @@ auto thread_core_spacing()
 
 std::string AbstractLogger::thread_id_header_for_device(int thread, int verbosity)
 {
-    struct cpu_info *info = cpu_info + thread;
+    cpu_info_t *info = cpu_info + thread;
     std::string line;
 #ifdef _WIN32
     line = stdprintf("{ logical-group: %2u, logical: %2u, ",

--- a/framework/device/cpu/topology_cpu.h
+++ b/framework/device/cpu/topology_cpu.h
@@ -22,7 +22,7 @@ using EnabledDevices = LogicalProcessorSet;
 class Topology
 {
 public:
-    using Thread = struct cpu_info;
+    using Thread = cpu_info_t;
     struct Core
     {
         std::span<const Thread> threads;

--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -81,8 +81,8 @@ bool pin_thread_to_logical_processor(LogicalProcessor n, tid_t thread_id, const 
 bool pin_to_logical_processors(DeviceRange range, const char *thread_name)
 {
     set_thread_name(thread_name);
-    const struct cpu_info *first_cpu = &cpu_info[range.starting_device];
-    const struct cpu_info *last_cpu = &cpu_info[range.starting_device + range.device_count - 1];
+    const cpu_info_t *first_cpu = &cpu_info[range.starting_device];
+    const cpu_info_t *last_cpu = &cpu_info[range.starting_device + range.device_count - 1];
     PROCESSOR_NUMBER first = to_processor_number(LogicalProcessor(first_cpu->cpu_number));
     PROCESSOR_NUMBER last = to_processor_number(LogicalProcessor(last_cpu->cpu_number));
     if (first.Group != last.Group) {

--- a/tests/cpu/ifs/unit/ifs_unittests.cpp
+++ b/tests/cpu/ifs/unit/ifs_unittests.cpp
@@ -304,7 +304,7 @@ TEST(IFSTrigger, AllCoresFail)
 
     // Setup dummy cpu_info array
     int cpu_num = 2;
-    cpu_info = new struct cpu_info[cpu_num];
+    cpu_info = new cpu_info_t[cpu_num];
     cpu_info[1].cpu_number = 1;
 
     // Loop over each cpu
@@ -334,7 +334,7 @@ TEST(IFSTrigger, SingleCoreFail)
 
     // Setup dummy cpu_info array
     int cpu_num = 2;
-    cpu_info = new struct cpu_info[cpu_num];
+    cpu_info = new cpu_info_t[cpu_num];
     cpu_info[1].cpu_number = 1;
 
     // First run is expected to pass
@@ -359,7 +359,7 @@ TEST(IFSTrigger, AllCoresUntested)
 
     // Setup dummy cpu_info array
     int cpu_num = 2;
-    cpu_info = new struct cpu_info[cpu_num];
+    cpu_info = new cpu_info_t[cpu_num];
     cpu_info[1].cpu_number = 1;
 
     // Loop over each cpu


### PR DESCRIPTION
This way we can drop the `struct` keyword when referring to this type, as it's not interferring with `cpu_info` variable anymore.