### PR TITLE
FW: do not call `restrict_topology()` inside `commit_shmem()`

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1036,8 +1036,8 @@ static void commit_shmem()
         sApp->shmemfd = -1;
     }
 
-    // sApp->shmem has probably moved
-    restrict_topology({ 0, thread_count() });
+    // sApp->shmem has probably moved, update ptr
+    cpu_info = sApp->shmem->cpu_info;
 }
 
 static void attach_shmem(int fd)


### PR DESCRIPTION
All we need from this call is the update of `cpu_info` ptr, as `sApp->shmem` may have moved. A side effect of this is that `build_topology()` is always called, because `sApp->shmem` changed, even though device range has not changed and no update to the topology is required. The way it's been implemented was enforcing other implementations of `restrict_topology()` to know that they must provide update of the pointer inside of it as well. Since this step is completely device-agnostic, let's just call it directly at the end of `commit_shmem()`.