### PR TITLE
FW: do not include sandstone.h in topology.h

### DIFF
--- a/framework/sysdeps/linux/cpu_affinity.cpp
+++ b/framework/sysdeps/linux/cpu_affinity.cpp
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <sandstone.h>
 #include <topology.h>
 
 #include <sched.h>
 #include <stdio.h>
 #include <sysexits.h>
+#include <string.h>
 
 #ifdef __linux__
 #include <sys/prctl.h>

--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <sandstone.h>
 #include <topology.h>
 
 #include <limits>

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -6,8 +6,6 @@
 #ifndef INC_TOPOLOGY_H
 #define INC_TOPOLOGY_H
 
-#include <sandstone.h>
-
 #include <memory>
 #include <span>
 #include <string>


### PR DESCRIPTION
It's not used there.