### PR TITLE
FW/Linux: widen the "wchan" field of ps in case of freeze/timeout

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -1146,7 +1146,7 @@ void debug_hung_child(pid_t child, std::span<const pid_t> children)
 
     if (on_hang_action == print_ps_on_hang) {
         const char *ps_args[] =
-            { "ps", "Hww", "-opid,tid,psr,vsz,rss,wchan,%cpu,stat,time,comm,args", buf, nullptr };
+            { "ps", "Hww", "-opid,tid,psr,vsz,rss,wchan:20,%cpu,stat,time,comm,args", buf, nullptr };
         std::string msg = run_process(ps_args);
         if (msg.size())
             log_message_preformatted(-slice - 1, LOG_LEVEL_VERBOSE(2), msg);


### PR DESCRIPTION
The current output contains only 6 characters, which causes a lot of ambiguity with common prefixes that could in turn mean a lot of different things: "migrat" could be "migrate_pages" (a memory problem) or "migration_to_node" (NUMA?). 20 characters isn't enough to disambiguate all symbols, but hopefully the problem area should be clear by then.