### PR TITLE
FW: rename `cpu_info` global array to `device_info`

### DIFF
--- a/docs/writing_tests.md
+++ b/docs/writing_tests.md
@@ -863,16 +863,16 @@ restricts the number of threads that are visible to OpenDCDiag in some way. The
 *num_cpus* function can be called in the *test_init*, *test_run* and
 *test_cleanup* functions.
 
-#### cpu_info and cpu
+#### device_info and cpu
 
 The *test_run* function's second parameter, *cpu*, has not been been discussed
 in much detail until now. This parameter is an OpenDCDiag specific identifier
 that identifies the hardware thread on which the current instance of the
 *test_run* function is executing. It will always be greater than or equal to zero
 and less than the value returned by *num_cpus*. It can be used as an index into
-a global array maintained by the framework called *cpu_info*. This is an array
-of structures, also called *cpu_info* that contain information about the
-hardware threads on which the test is being run. The *cpu_info* structure is
+a global array maintained by the framework called *device_info*. This is an array
+of structures, also called *device_info* that contain information about the
+hardware threads on which the test is being run. The *device_info* structure is
 documented in [sandstone.h](../framework/sandstone.h). It can be used for
 example to figure out which core the current thread is associated with, how much
 cache that core has, in which socket the current core is located, and what
@@ -905,7 +905,7 @@ not yet been run. The size of this set will be no greater than *max_threads*,
 although it may be smaller.
 3. It calls the init function on the main thread. The framework ensures that
 the return value of the framework's *num_cpu* function will return a value of no
-greater than *max_threads* and that the *cpu_info* structure contains the
+greater than *max_threads* and that the *device_info* structure contains the
 correct information for the current set of hardware threads.
 4. It then runs the *test_run* function on each of these threads.
 5. The *test_cleanup* function is called.

--- a/framework/device/cpu/cpu_device.cpp
+++ b/framework/device/cpu/cpu_device.cpp
@@ -44,11 +44,11 @@ void dump_device_info()
            device_features_to_string(device_features).c_str());
     printf("# CPU\tPkgID\tCoreID\tThrdID\tModId\tNUMAId\tApicId\tMicrocode\tPPIN\n");
     for (i = 0; i < num_cpus(); ++i) {
-        printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t0x%" PRIx64, cpu_info[i].cpu_number,
-               cpu_info[i].package_id, cpu_info[i].core_id, cpu_info[i].thread_id,
-               cpu_info[i].module_id, cpu_info[i].numa_id, cpu_info[i].hwid,
-               cpu_info[i].microcode);
-        const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(cpu_info[i].package_id);
+        printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t0x%" PRIx64, device_info[i].cpu_number,
+               device_info[i].package_id, device_info[i].core_id, device_info[i].thread_id,
+               device_info[i].module_id, device_info[i].numa_id, device_info[i].hwid,
+               device_info[i].microcode);
+        const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(device_info[i].package_id);
         if (pkg && pkg->ppin)
             printf("\t%016" PRIx64, pkg->ppin);
         puts("");
@@ -59,7 +59,7 @@ TestResult prepare_test_for_device(struct test *test)
 {
     auto has_smt = []() -> bool {
         for(int idx = 0; idx < thread_count() - 1; idx++) {
-            if (cpu_info[idx].core_id == cpu_info[idx + 1].core_id)
+            if (device_info[idx].core_id == device_info[idx + 1].core_id)
                 return true;
         }
         return false;

--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -193,16 +193,18 @@ struct cpu_info_t
 // Alias for use in common framework code.
 typedef struct cpu_info_t device_info_t;
 
-/// cpu_info is an array of cpu_info_t structures.  Each element of the array
+/// device_info is an array of cpu_info_t structures.  Each element of the array
 /// contains information about a logical CPU that will be used to
 /// execute a test's test_run function.  The size of this array is
 /// equal to the value returned by num_cpus().
-extern struct cpu_info_t *cpu_info;
+extern struct cpu_info_t *device_info;
+// Interim alias for compatibility.
+extern struct cpu_info_t *cpu_info asm("device_info");
 
 #ifdef __cplusplus
 inline int cpu_info_t::cpu() const
 {
-    return this - ::cpu_info;
+    return this - ::device_info;
 }
 
 extern "C" {

--- a/framework/device/cpu/frequency_manager.hpp
+++ b/framework/device/cpu/frequency_manager.hpp
@@ -180,13 +180,13 @@ public:
         for (int cpu = 0; cpu < num_cpus(); cpu++) {
             //save scaling governor for every cpu
             std::string scaling_governor_path = BASE_CORE_FREQ_PATH;
-            scaling_governor_path += std::to_string(cpu_info[cpu].cpu_number);
+            scaling_governor_path += std::to_string(device_info[cpu].cpu_number);
             scaling_governor_path += SCALING_GOVERNOR;
             per_cpu_initial_scaling_governor.push_back(read_file(scaling_governor_path));
 
             //save frequency for every cpu
             std::string initial_scaling_setspeed_frequency_path = BASE_CORE_FREQ_PATH;
-            initial_scaling_setspeed_frequency_path += std::to_string(cpu_info[cpu].cpu_number);
+            initial_scaling_setspeed_frequency_path += std::to_string(device_info[cpu].cpu_number);
             initial_scaling_setspeed_frequency_path += SCALING_SETSPEED;
             per_cpu_initial_scaling_setspeed.push_back(read_file(initial_scaling_setspeed_frequency_path));
 
@@ -206,7 +206,7 @@ public:
             uint16_t total_sockets = 0;
 
             for (int cpu = 0; cpu < num_cpus(); cpu++) {
-                int socket_id = cpu_info[cpu].package_id;
+                int socket_id = device_info[cpu].package_id;
                 if (found_socket_ids.count(socket_id) == 0) {
                     total_sockets++;
                     found_socket_ids.insert(socket_id);
@@ -244,7 +244,7 @@ public:
 
         for (int cpu = 0; cpu < num_cpus(); cpu++) {
             std::string scaling_setspeed = BASE_CORE_FREQ_PATH;
-            scaling_setspeed += std::to_string(cpu_info[cpu].cpu_number);
+            scaling_setspeed += std::to_string(device_info[cpu].cpu_number);
             scaling_setspeed += SCALING_SETSPEED;
             write_file(scaling_setspeed, std::to_string(current_set_frequency));
         }
@@ -274,13 +274,13 @@ public:
         for (int cpu = 0; cpu < num_cpus(); cpu++) {
             //restore saved scaling governor for every cpu
             std::string scaling_governor_path = BASE_CORE_FREQ_PATH;
-            scaling_governor_path += std::to_string(cpu_info[cpu].cpu_number);
+            scaling_governor_path += std::to_string(device_info[cpu].cpu_number);
             scaling_governor_path += SCALING_GOVERNOR;
             write_file(scaling_governor_path, per_cpu_initial_scaling_governor[cpu]);
 
             //restore saved frequency for every cpu
             std::string scaling_setspeed_path = BASE_CORE_FREQ_PATH;
-            scaling_setspeed_path += std::to_string(cpu_info[cpu].cpu_number);
+            scaling_setspeed_path += std::to_string(device_info[cpu].cpu_number);
             scaling_setspeed_path += SCALING_SETSPEED;
             write_file(scaling_setspeed_path, per_cpu_initial_scaling_setspeed[cpu]);
         }

--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -92,7 +92,7 @@ void KeyValuePairLogger::print_thread_header(int fd, int device, const char *pre
         return;
     }
 
-    cpu_info_t *info = cpu_info + device;
+    cpu_info_t *info = device_info + device;
     const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(info->package_id);
     PerThreadData::Test *thr = sApp->test_thread_data(device);
     if (std::string time = format_duration(thr->fail_time); time.size()) {
@@ -284,7 +284,7 @@ void TapFormatLogger::print_thread_header(int fd, int device, LogLevelVerbosity 
         return;
     }
 
-    cpu_info_t *info = cpu_info + device;
+    cpu_info_t *info = device_info + device;
     std::string line = stdprintf("  Thread %d on CPU %d (pkg %d, core %d, thr %d", device,
             info->cpu_number, info->package_id, info->core_id, info->thread_id);
     if (const char *type = native_device_type(info))
@@ -361,10 +361,10 @@ auto thread_core_spacing()
         int max_core_id = 0;
         int max_logical_id = 0;
         for (int i = 0; i < thread_count(); ++i) {
-            if (cpu_info[i].cpu_number > max_logical_id)
-                max_logical_id = cpu_info[i].cpu_number;
-            if (cpu_info[i].core_id > max_core_id)
-                max_core_id = cpu_info[i].core_id;
+            if (device_info[i].cpu_number > max_logical_id)
+                max_logical_id = device_info[i].cpu_number;
+            if (device_info[i].core_id > max_core_id)
+                max_core_id = device_info[i].core_id;
         }
         if (max_logical_id > 9)
             ++result.logical;
@@ -384,7 +384,7 @@ auto thread_core_spacing()
 
 std::string AbstractLogger::thread_id_header_for_device(int thread, LogLevelVerbosity verbosity)
 {
-    cpu_info_t *info = cpu_info + thread;
+    cpu_info_t *info = device_info + thread;
     std::string line;
 #ifdef _WIN32
     line = stdprintf("{ logical-group: %2u, logical: %2u, ",

--- a/framework/device/cpu/sysdeps/linux/effective_cpu_freq.hpp
+++ b/framework/device/cpu/sysdeps/linux/effective_cpu_freq.hpp
@@ -22,7 +22,7 @@ public:
 
     void Snapshot(const int thread_num)
     {
-        cpu_number = cpu_info[thread_num].cpu_number;
+        cpu_number = device_info[thread_num].cpu_number;
         ns = MonotonicTimePoint::clock::now();
         tsc = __rdtscp(&tsc_aux);
 

--- a/framework/device/gpu/build_topology.cpp
+++ b/framework/device/gpu/build_topology.cpp
@@ -9,8 +9,8 @@
 Topology build_topology()
 {
     Topology topo;
-    gpu_info_t* info = cpu_info;
-    const gpu_info_t* cend = cpu_info + thread_count();
+    gpu_info_t* info = device_info;
+    const gpu_info_t* cend = device_info + thread_count();
     auto root_first = info;
     while (info != cend) {
         if (info->subdevice_index == -1) {

--- a/framework/device/gpu/gpu_device.h
+++ b/framework/device/gpu/gpu_device.h
@@ -51,12 +51,12 @@ struct gpu_info_t
 // Alias for use in common framework code
 typedef struct gpu_info_t device_info_t;
 
-extern struct gpu_info_t *cpu_info;
+extern struct gpu_info_t *device_info;
 
 #ifdef __cplusplus
 inline int gpu_info_t::gpu() const
 {
-    return this - ::cpu_info;
+    return this - ::device_info;
 }
 #endif
 

--- a/framework/device/gpu/logging_gpu.cpp
+++ b/framework/device/gpu/logging_gpu.cpp
@@ -16,11 +16,11 @@ auto calc_spacing()
     static const auto spacing = []() {
         struct { int gpu, cpu; } result {0, 0};
         auto max_gpu = std::max_element(
-            cpu_info, cpu_info + thread_count(),
+            device_info, device_info + thread_count(),
             [](const auto& g1, const auto& g2) { return g1.gpu_number < g2.gpu_number; }
         )->gpu_number;
         auto max_cpu = std::max_element(
-            cpu_info, cpu_info + thread_count(),
+            device_info, device_info + thread_count(),
             [](const auto& g1, const auto& g2) { return g1.cpu_number < g2.cpu_number; }
         )->cpu_number;
 
@@ -35,7 +35,7 @@ auto calc_spacing()
 
 std::string AbstractLogger::thread_id_header_for_device(int thread, LogLevelVerbosity verbosity)
 {
-    gpu_info_t *info = cpu_info + thread;
+    gpu_info_t *info = device_info + thread;
     std::string line;
     if (info->subdevice_index != -1) {
         line = std::format("{{ gpu_index: {}/{}, gpu_number: {:{}}, ", info->device_index, info->subdevice_index, info->gpu_number, calc_spacing().gpu);

--- a/framework/device/gpu/topology_gpu.h
+++ b/framework/device/gpu/topology_gpu.h
@@ -48,7 +48,7 @@ public:
     static const Topology &topology();
 };
 
-/// Fills the topology (devices & their subdevices) based on cpu_info.
+/// Fills the topology (devices & their subdevices) based on device_info.
 /// Supports heterogenous topology (mixed kind of devices - End and Root).
 Topology build_topology();
 

--- a/framework/device/gpu/unit-tests/topology_tests.cpp
+++ b/framework/device/gpu/unit-tests/topology_tests.cpp
@@ -54,7 +54,7 @@ TEST(Topology, HeterogenousTopology)
 
     gpu_info.emplace_back(make_gpu_info_entry(-1, 0xbadbabe)); // end
 
-    cpu_info = gpu_info.data();
+    device_info = gpu_info.data();
     Topology topo = build_topology();
 
     EXPECT_EQ(topo.devices.size(), 8);
@@ -103,7 +103,7 @@ TEST(Topology, TailingRoot)
     gpu_info.emplace_back(make_gpu_info_entry(4, 0xbadcafe));
     gpu_info.emplace_back(make_gpu_info_entry(5, 0xbadcafe));
 
-    cpu_info = gpu_info.data();
+    device_info = gpu_info.data();
     Topology topo = build_topology();
 
     EXPECT_EQ(topo.devices.size(), 2);

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -892,7 +892,7 @@ void reschedule()
 static uintptr_t thread_runner(int thread_number)
 {
     // convert from internal Sandstone numbering to the system one
-    pin_to_logical_processor(LogicalProcessor(cpu_info[thread_number].cpu_number), current_test->id);
+    pin_to_logical_processor(LogicalProcessor(device_info[thread_number].cpu_number), current_test->id);
 
     PerThreadData::Test *this_thread = sApp->test_thread_data(thread_number);
     random_init_thread(thread_number);
@@ -1448,7 +1448,7 @@ static TestResult run_one_test_inner(struct test *test, bool init_in_aux_thread 
                 // processor but its pinning doesn't affect this control thread
                 auto init_thread_runner = [](void *testptr) {
                     auto test = static_cast</*nonconst*/ struct test *>(testptr);
-                    pin_to_logical_processor(LogicalProcessor(cpu_info[0].cpu_number));
+                    pin_to_logical_processor(LogicalProcessor(device_info[0].cpu_number));
                     thread_num = -1;
                     intptr_t ret = test->test_init(test);
                     return reinterpret_cast<void *>(ret);
@@ -2224,7 +2224,7 @@ static int exec_mode_run(int argc, char **argv)
     int child_number = parse_int(argv[3]);
 
     attach_shmem(parse_int(argv[2]));
-    cpu_info = sApp->shmem->device_info;
+    device_info = sApp->shmem->device_info;
     sApp->thread_count = sApp->shmem->total_thread_count;
     sApp->user_thread_data.resize(sApp->thread_count);
 

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -549,7 +549,7 @@ uint64_t set_random_bits(unsigned num_bits_to_set, uint32_t bitwidth);
 extern device_features_t device_features;
 
 /// thread_num always contains the integer identifier for the executing
-/// thread.  It can be used to index the cpu_info array and is equivalent
+/// thread.  It can be used to index the device_info array and is equivalent
 /// to the thread parameter in the test_run function.
 #ifdef __llvm__
 extern thread_local int thread_num;

--- a/framework/sandstone_unittests_utils.cpp
+++ b/framework/sandstone_unittests_utils.cpp
@@ -8,7 +8,7 @@
 #define UNITTESTS_THREAD_COUNT 16
 
 /* Define dummy setup struct that can be used by unittests when needed */
-device_info_t *cpu_info = nullptr;
+device_info_t *device_info = nullptr;
 
 /* Define dummy number of dummy threads */
 int thread_count() { return UNITTESTS_THREAD_COUNT; }

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -378,14 +378,14 @@ static int selftest_logerror_cleanup(struct test *test)
 
 template <int PackageId> static int selftest_log_skip_socket_init(struct test *test)
 {
-    if (num_packages() == 1 && cpu_info[0].package_id == PackageId)
+    if (num_packages() == 1 && device_info[0].package_id == PackageId)
         return selftest_log_skip_init(test);
     return EXIT_SUCCESS;
 }
 
 template <int PackageId> static int selftest_log_skip_socket_run(struct test *test, int thread)
 {
-    if (num_packages() == 1 && cpu_info[0].package_id == PackageId)
+    if (num_packages() == 1 && device_info[0].package_id == PackageId)
         return selftest_skip_run(test, thread);
     return EXIT_SUCCESS;
 }
@@ -462,7 +462,7 @@ static int adjust_cpu_for_isolate_socket(int cpu)
 {
     // pretend we're running in test_schedule_isolate_socket
     for (int cpu0 = cpu - 1; cpu0 >= 0; --cpu0) {
-        if (cpu_info[cpu0].package_id == cpu_info[cpu].package_id)
+        if (device_info[cpu0].package_id == device_info[cpu].package_id)
             continue;
         return cpu - cpu0 - 1;
     }
@@ -472,14 +472,14 @@ static int adjust_cpu_for_isolate_socket(int cpu)
 
 template <auto F> static int selftest_if_socket1_initcleanup(struct test *test)
 {
-    if (cpu_info[0].package_id == 1)
+    if (device_info[0].package_id == 1)
         return F(test);
     return EXIT_SUCCESS;
 }
 
 template <auto F> static int selftest_if_socket1_run(struct test *test, int thread)
 {
-    if (cpu_info[thread].package_id == 1)
+    if (device_info[thread].package_id == 1)
         return F(test, adjust_cpu_for_isolate_socket(thread));
     return EXIT_SUCCESS;
 }

--- a/framework/sysdeps/linux/cpu_affinity.cpp
+++ b/framework/sysdeps/linux/cpu_affinity.cpp
@@ -75,7 +75,7 @@ bool pin_to_logical_processors(DeviceRange range, const char *thread_name)
     // find the maximum CPU number
     int n = 0;
     for (int device = range.starting_device; device < range.starting_device + range.device_count; ++device)
-        n = std::max(n, cpu_info[device].cpu_number);
+        n = std::max(n, device_info[device].cpu_number);
 
     using Word = LogicalProcessorSetOps::Word;
     constexpr size_t ProcessorsPerWord = LogicalProcessorSetOps::ProcessorsPerWord;
@@ -85,7 +85,7 @@ bool pin_to_logical_processors(DeviceRange range, const char *thread_name)
     memset(cpu_set, 0, sizeof(cpu_set));
 
     for (int device = range.starting_device; device < range.starting_device + range.device_count; ++device) {
-        auto lp = LogicalProcessor(cpu_info[device].cpu_number);
+        auto lp = LogicalProcessor(device_info[device].cpu_number);
         LogicalProcessorSetOps::setInArray({ cpu_set, size }, lp);
     }
 

--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -88,8 +88,8 @@ bool pin_thread_to_logical_processor(LogicalProcessor n, tid_t thread_id, const 
 bool pin_to_logical_processors(DeviceRange range, const char *thread_name)
 {
     set_thread_name(thread_name);
-    const device_info_t *first_cpu = &cpu_info[range.starting_device];
-    const device_info_t *last_cpu = &cpu_info[range.starting_device + range.device_count - 1];
+    const device_info_t *first_cpu = &device_info[range.starting_device];
+    const device_info_t *last_cpu = &device_info[range.starting_device + range.device_count - 1];
     PROCESSOR_NUMBER first = to_processor_number(LogicalProcessor(first_cpu->cpu_number));
     PROCESSOR_NUMBER last = to_processor_number(LogicalProcessor(last_cpu->cpu_number));
     if (first.Group != last.Group) {

--- a/tests/common/mce_check/mce_check.cpp
+++ b/tests/common/mce_check/mce_check.cpp
@@ -75,7 +75,7 @@ int mce_check_run(struct test *test, int thread)
     // check the CPUs we were running tests on
     for (int i = 0; i < thread_count(); ++i) {
         // translate our thread number to the OS CPU number
-        thread = cpu_info[i].cpu_number;
+        thread = device_info[i].cpu_number;
         assert(thread < int(differences.size()));
 
         if (differences[thread] != 0) {

--- a/tests/common/smi_count/smi_count.cpp
+++ b/tests/common/smi_count/smi_count.cpp
@@ -25,7 +25,7 @@ std::vector<uint64_t> smi_counts_start;
 
 int initialize_smi_counts(struct test*)
 {
-    std::optional<uint64_t> v = InterruptMonitor::count_smi_events(cpu_info[0].cpu_number);
+    std::optional<uint64_t> v = InterruptMonitor::count_smi_events(device_info[0].cpu_number);
     if (!v) {
         log_skip(RuntimeSkipCategory, "Could not read msr");
         return EXIT_SKIP;
@@ -33,7 +33,7 @@ int initialize_smi_counts(struct test*)
     smi_counts_start.resize(thread_count());
     smi_counts_start[0] = *v;
     for (int i = 1; i < thread_count(); i++) {
-        smi_counts_start[i] = InterruptMonitor::count_smi_events(cpu_info[i].cpu_number).value_or(0);
+        smi_counts_start[i] = InterruptMonitor::count_smi_events(device_info[i].cpu_number).value_or(0);
     }
     return EXIT_SUCCESS;
 }
@@ -43,7 +43,7 @@ int smi_count_run(struct test *test, int thread)
     (void) test;
 
     if (int(smi_counts_start.size()) > thread) {
-        int real_cpu_number = cpu_info[thread].cpu_number;
+        int real_cpu_number = device_info[thread].cpu_number;
         auto initial_count = smi_counts_start[thread];
         auto current_count = InterruptMonitor::count_smi_events(real_cpu_number);
         if (current_count) {

--- a/tests/cpu/ifs/ifs.c
+++ b/tests/cpu/ifs/ifs.c
@@ -206,10 +206,10 @@ static int scan_run(struct test *test, int cpu)
         char result[BUFLEN] = {}, my_cpu[BUFLEN] = {};
         unsigned long long code;
 
-        if (cpu_info[cpu].thread_id != 0)
+        if (device_info[cpu].thread_id != 0)
                 return EXIT_SKIP;
 
-        snprintf(my_cpu, sizeof(my_cpu), "%d\n", cpu_info[cpu].cpu_number);
+        snprintf(my_cpu, sizeof(my_cpu), "%d\n", device_info[cpu].cpu_number);
 
         char sys_path[PATH_MAX];
         int n = snprintf(sys_path, PATH_MAX, PATH_SYS_IFS_BASE "%s", ifs_info->sys_dir);

--- a/tests/cpu/ifs/unit/ifs_unittests.cpp
+++ b/tests/cpu/ifs/unit/ifs_unittests.cpp
@@ -272,10 +272,10 @@ TEST(IFSTrigger, AllCoresPass)
     test *test_t = (test *) test_setup(trigger_test1);
     ifs_test_t *ifs_info = (ifs_test_t *) test_t->data;
 
-    // Setup dummy cpu_info array
+    // Setup dummy device_info array
     int cpu_num = 2;
-    cpu_info = new cpu_info_t[cpu_num];
-    cpu_info[1].cpu_number = 1;
+    device_info = new cpu_info_t[cpu_num];
+    device_info[1].cpu_number = 1;
 
     // Loop over each cpu
     for (size_t i=0; i < cpu_num; i++)
@@ -289,7 +289,7 @@ TEST(IFSTrigger, AllCoresPass)
         EXPECT_STREQ(contents, expected);
     }
 
-    delete [] cpu_info;
+    delete [] device_info;
     test_cleanup(test_t, ifs_info, trigger_test1);
 }
 
@@ -302,10 +302,10 @@ TEST(IFSTrigger, AllCoresFail)
     test *test_t = (test *) test_setup(trigger_test2);
     ifs_test_t *ifs_info = (ifs_test_t *) test_t->data;
 
-    // Setup dummy cpu_info array
+    // Setup dummy device_info array
     int cpu_num = 2;
-    cpu_info = new cpu_info_t[cpu_num];
-    cpu_info[1].cpu_number = 1;
+    device_info = new cpu_info_t[cpu_num];
+    device_info[1].cpu_number = 1;
 
     // Loop over each cpu
     for (size_t i=0; i < cpu_num; i++)
@@ -319,7 +319,7 @@ TEST(IFSTrigger, AllCoresFail)
         EXPECT_STREQ(contents, expected);
     }
 
-    delete [] cpu_info;
+    delete [] device_info;
     test_cleanup(test_t, ifs_info, trigger_test2);
 }
 
@@ -332,10 +332,10 @@ TEST(IFSTrigger, SingleCoreFail)
     test *test_t = (test *) test_setup(trigger_test3);
     ifs_test_t *ifs_info = (ifs_test_t *) test_t->data;
 
-    // Setup dummy cpu_info array
+    // Setup dummy device_info array
     int cpu_num = 2;
-    cpu_info = new cpu_info_t[cpu_num];
-    cpu_info[1].cpu_number = 1;
+    device_info = new cpu_info_t[cpu_num];
+    device_info[1].cpu_number = 1;
 
     // First run is expected to pass
     EXPECT_EQ(scan_run(test_t, 0), EXIT_SUCCESS);
@@ -344,7 +344,7 @@ TEST(IFSTrigger, SingleCoreFail)
     setup_sysfs_file(ifs_info->sys_dir, "status", "fail");
     EXPECT_EQ(scan_run(test_t, 1), EXIT_FAILURE);
 
-    delete [] cpu_info;
+    delete [] device_info;
     test_cleanup(test_t, ifs_info, trigger_test3);
 }
 
@@ -357,10 +357,10 @@ TEST(IFSTrigger, AllCoresUntested)
     test *test_t = (test *) test_setup(trigger_test4);
     ifs_test_t *ifs_info = (ifs_test_t *) test_t->data;
 
-    // Setup dummy cpu_info array
+    // Setup dummy device_info array
     int cpu_num = 2;
-    cpu_info = new cpu_info_t[cpu_num];
-    cpu_info[1].cpu_number = 1;
+    device_info = new cpu_info_t[cpu_num];
+    device_info[1].cpu_number = 1;
 
     // Loop over each cpu
     for (size_t i=0; i < cpu_num; i++)
@@ -374,7 +374,7 @@ TEST(IFSTrigger, AllCoresUntested)
         EXPECT_STREQ(contents, expected);
     }
 
-    delete [] cpu_info;
+    delete [] device_info;
     test_cleanup(test_t, ifs_info, trigger_test4);
 }
 


### PR DESCRIPTION
Leave `cpu_info` alias for backward compatibility though.