### PR TITLE
FW: fix using correct `device_info_t` aliases

### DIFF
--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -81,8 +81,8 @@ bool pin_thread_to_logical_processor(LogicalProcessor n, tid_t thread_id, const 
 bool pin_to_logical_processors(DeviceRange range, const char *thread_name)
 {
     set_thread_name(thread_name);
-    const cpu_info_t *first_cpu = &cpu_info[range.starting_device];
-    const cpu_info_t *last_cpu = &cpu_info[range.starting_device + range.device_count - 1];
+    const device_info_t *first_cpu = &cpu_info[range.starting_device];
+    const device_info_t *last_cpu = &cpu_info[range.starting_device + range.device_count - 1];
     PROCESSOR_NUMBER first = to_processor_number(LogicalProcessor(first_cpu->cpu_number));
     PROCESSOR_NUMBER last = to_processor_number(LogicalProcessor(last_cpu->cpu_number));
     if (first.Group != last.Group) {

--- a/tests/cpu/ifs/unit/ifs_unittests.cpp
+++ b/tests/cpu/ifs/unit/ifs_unittests.cpp
@@ -274,7 +274,7 @@ TEST(IFSTrigger, AllCoresPass)
 
     // Setup dummy cpu_info array
     int cpu_num = 2;
-    cpu_info = new device_info_t[cpu_num];
+    cpu_info = new cpu_info_t[cpu_num];
     cpu_info[1].cpu_number = 1;
 
     // Loop over each cpu


### PR DESCRIPTION
As we'd agreed to use `device_info_t` in common code, and `*_info_t` in device-specific code.