### PR TITLE
smi_count: set quality based on `InterruptMonitorWorks`; call `log_skip` when skipping

### DIFF
--- a/tests/common/smi_count/smi_count.cpp
+++ b/tests/common/smi_count/smi_count.cpp
@@ -27,6 +27,7 @@ int initialize_smi_counts(struct test*)
 {
     std::optional<uint64_t> v = InterruptMonitor::count_smi_events(cpu_info[0].cpu_number);
     if (!v) {
+        log_skip(RuntimeSkipCategory, "Could not read msr");
         return EXIT_SKIP;
     }
     smi_counts_start.resize(thread_count());


### PR DESCRIPTION
Quality is set to PROD when `InterruptMonitor::InterruptMonitorWorks`, otherwise to SKIP,
so that we do not have to handle this case in preinit.

It was printing generic skip reason from preinit replacement function.
Before:
```
  skip-reason: 'Skip replacement from preinit'
```
After:
```
  skip-reason: 'Could not read msr'
```