### PR TITLE
FW: add postcleanup function

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -327,14 +327,6 @@ selftest_pass() {
     test_yaml_regexp "/tests/0/test" selftest_preinit
 }
 
-@test "selftest_postcleanup" {
-    declare -A yamldump
-    sandstone_selftest -e selftest_postcleanup
-    [[ "$status" -eq 0 ]]
-    test_yaml_regexp "/exit" pass
-    test_yaml_regexp "/tests/0/test" selftest_postcleanup
-}
-
 @test "selftest_cxxthrowcatch" {
     # Note: we want to test with the crash handler enabled (--on-crash)
     declare -A yamldump

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -773,8 +773,11 @@ static void postcleanup_tests()
     for (test_cfg_info &cfg : *test_set) {
         struct test *test = cfg.test;
         if (test->test_postcleanup) {
-            // At this point it's too late to decide whether test passed or not.
-            [[maybe_unused]] auto ret = test->test_postcleanup(test);
+            auto ret = test->test_postcleanup(test);
+
+            assert(ret == EXIT_SUCCESS && "Internal error: test_postcleanup must return EXIT_SUCCESS");
+            PerThreadData::Main *main = sApp->main_thread_data();
+            assert(!main->has_skipped() && !main->has_failed() && "Internal error: test_postcleanup must not cause test skip or fail");
         }
     }
 }

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -350,12 +350,6 @@ static int selftest_skip_cleanup(struct test *test)
     return EXIT_SKIP;
 }
 
-static int selftest_skip_postcleanup(struct test *test)
-{
-    // We cannot call log_info, as all test's messages have already been logged.
-    return EXIT_SKIP;
-}
-
 static int selftest_log_skip_preinit(struct test *test)
 {
     check_is_main_process();
@@ -1280,15 +1274,6 @@ static struct test selftests_array[] = {
     .test_init = selftest_preinit_init,
     .test_run = selftest_pass_run,
     .desired_duration = INT_MAX,        // we change to -1 in the preinit
-    .quality_level = TEST_QUALITY_PROD,
-},
-{
-    .id = "selftest_postcleanup",
-    .description = "Skip from postcleanup function is ignored",
-    .groups = DECLARE_TEST_GROUPS(&group_positive),
-    .test_run = selftest_pass_run,
-    .test_postcleanup = selftest_skip_postcleanup,
-    .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },
 {


### PR DESCRIPTION
The idea is that resources created during preinit might require to be freed once, at the end of application. This commit introduces a function symmetric to `test_preinit`, where such 'global' cleanup can be done.

---
TODO: postcleanup shouldn't call log_info, as all test's data have already been flushed. In case we'd like to print something, however, one idea would be to enable printing raw yaml without the use of loggers. This way we could construct a custom test summary maintaining the yaml format coherency. If we'd like it, this should be implemented in separate PR.
```
...
- test: mce_check
  details: { quality: production, description: "Machine Check Exceptions/Events count" }
  state: { seed: 'LCG:213241594', iteration: 0, retry: false }
  time-at-start: { elapsed:   1156.990, now: !!timestamp '2025-11-26T10:24:14Z' }
  result: pass
  time-at-end:   { elapsed:   1159.990, now: !!timestamp '2025-11-26T10:24:14Z' }
  test-runtime: 1.276
  threads:
  - thread: 0
    id: { logical: 0, package: 0, numa_node: 0, module: 0, core: 0, thread: 0, family: 6, model: 0x55, stepping: 4, microcode: 0x2007006, ppin: null }
    loop-count: 0
    messages:
    - { level: info, text: 'I> inner loop count for thread 0 = 0' }
# Loop iteration 1 finished, average time 1169.46 ms, total 1169.46 ms
- test: some-test-with-postcleanup
  cleanup-summary: { "Events detected during application run: foo bar ..." }
exit: pass
mcisowska@X299-6:~/opendcdiag$ 
```
An example of such test would be a "monitor" test, spawning a monitoring thread in preinint, joining it in postcleanup, and printing a summary.