### PR TITLE
FW: finish fixing printing of negative runtimes

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1839,6 +1839,11 @@ static TestResult run_one_test_once(const struct test *test)
     }
 
     // print results and find out if the test failed
+    MonotonicTimePoint now = MonotonicTimePoint::clock::now();
+    for (ChildExitStatus &result : children.results) {
+        if (result.endtime == MonotonicTimePoint())
+            result.endtime = now;
+    }
     TestResult testResult = logging_print_results(children.results, test);
     switch (testResult) {
     case TestResult::Passed:


### PR DESCRIPTION
This commit finishes 606566b.

---
Now we have some duplicated code. Given that it's happening before every call to `logging_print_results()`, maybe we should think of putting it inside there.