### PR TITLE
FW/Meson: move the common tests from tests_base.a to framework.a

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -277,6 +277,7 @@ framework_a = static_library(
     'framework',
     framework_files,
     generated_files,
+    tests_set_common,
     build_by_default: false,
     include_directories: [
         framework_incdir,

--- a/meson.build
+++ b/meson.build
@@ -285,6 +285,7 @@ unittests_deps += [
     pthread_dep,
 ]
 
+subdir('tests/common')
 subdir('framework')
 subdir('tests')
 

--- a/tests/cpu/meson.build
+++ b/tests/cpu/meson.build
@@ -40,10 +40,6 @@ if target_machine.system() == 'windows' and get_option('buildtype') == 'debug'
 endif
 
 tests_set_base.add(
-    tests_set_common,
-)
-
-tests_set_base.add(
     files(
         'ifs/sandstone_ifs.c',
         'ifs/ifs.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,4 @@
 # Copyright 2025 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-subdir('common')
 subdir(device_type)


### PR DESCRIPTION
The files aren't moved, but they are logically part of the framework. That is especially true for the `mce_test`, because the framework directly refers to it:

```
ld: opendcdiag/framework/libframework.a.p/sandstone.cpp.o: in function `main':
../opendcdiag/framework/sandstone.cpp:2716:(.text.startup+0xf98): undefined reference to `mce_test'
```