### PR TITLE
BUILD: use common tests as a static_library.

### DIFF
--- a/framework/meson.build
+++ b/framework/meson.build
@@ -277,7 +277,6 @@ framework_a = static_library(
     'framework',
     framework_files,
     generated_files,
-    tests_set_common,
     build_by_default: false,
     include_directories: [
         framework_incdir,

--- a/meson.build
+++ b/meson.build
@@ -285,7 +285,6 @@ unittests_deps += [
     pthread_dep,
 ]
 
-subdir('tests/common')
 subdir('framework')
 subdir('tests')
 

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -13,3 +13,20 @@ if target_machine.system() == 'linux' and host_machine.cpu_family() == 'x86_64'
         'smi_count/smi_count.cpp',
     )
 endif
+
+tests_common_a = static_library(
+    'tests_common',
+    sources: tests_set_common,
+    build_by_default: true,
+    include_directories: [
+        framework_incdir,
+    ],
+    c_args: [
+        default_c_flags,
+    ],
+    cpp_args: [
+        default_cpp_flags,
+    ],
+)
+
+sandstone_tests += [ tests_common_a ]

--- a/tests/gpu/meson.build
+++ b/tests/gpu/meson.build
@@ -22,10 +22,6 @@ tests_common_incdirs = [
     framework_incdir,
 ]
 
-tests_set_base.add(
-    tests_set_common,
-)
-
 # fill with tests
 # tests_set_base.add(
 #     files(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,5 @@
 # Copyright 2025 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
+subdir('common')
 subdir(device_type)


### PR DESCRIPTION
This is a better way to share the tests between various device types. Organize them as a static library instead of introducing dependencies on sources (which #913 tried to do, but in a way incompatible with device/gpu).