### PR TITLE
FW/tests: fail execution if we can't open the test list file

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -870,6 +870,14 @@ test_random() {
     selftest_pass --ignore-unknown-test --disable=$invalid_test "$@"
 }
 
+@test "--test-list-file non-existent" {
+    export LC_ALL=C.UTF-8   # We don't do setlocale(), but just in case
+    fname=/dev/this/does/not/exist.txt
+    run $SANDSTONE --test-list-file $fname
+    ((status == 64))
+    [[ "$output" = *"$fname:"*"No such file or directory" ]]
+}
+
 test_list_file_common() {
     declare -A yamldump
     local listcontents=$1

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -248,6 +248,10 @@ std::vector<struct test_cfg_info> SandstoneTestSet::add_test_list(const char *fn
     }
 
     std::ifstream list_file(fname, std::ios_base::in);
+    if (!list_file) {
+        errors.push_back(strerror(errno));
+        return {};
+    }
     std::vector<struct test_cfg_info> entries = load_test_list(list_file, this, cfg.ignore_unknown_tests, errors);
     if (!errors.empty()) return {};
     if (test_set.empty()) {


### PR DESCRIPTION
Instead of silently reading from an empty stream, with a successful load of no tests.