### PR TITLE
build: pass missing selftests parameter from matrix

### DIFF
--- a/.github/actions/build-cpu/action.yaml
+++ b/.github/actions/build-cpu/action.yaml
@@ -17,6 +17,10 @@ inputs:
     description: Unittests
     type: string
     required: true
+  selftests:
+    description: Selftests
+    type: string
+    required: true
 
 # https://github.com/orgs/community/discussions/18597
 # defaults:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -54,6 +54,7 @@ jobs:
             env: ${{ matrix.env }}
             meson_args: ${{ matrix.meson_args }}
             unittests: ${{ matrix.unittests }}
+            selftests: ${{ matrix.selftests }}
 
   build-cpu-win:
     name: Build binary for CPU (Windows)


### PR DESCRIPTION
The CPU build for Linux has conditional execution of selftests based on matrix's `selftests` value. It was not passed to the action file at all.