### PR TITLE
FW/GPU: add helper functions for enumerating L0 resources

### DIFF
--- a/framework/device/gpu/meson.build
+++ b/framework/device/gpu/meson.build
@@ -8,6 +8,8 @@ framework_files += files(
     'gpu_device.cpp',
     'topology.cpp',
     'logging_gpu.cpp',
+    'ze_enumeration.cpp',
+    'ze_utils.cpp',
 )
 
 unittests_sources += files(

--- a/framework/device/gpu/ze_check.h
+++ b/framework/device/gpu/ze_check.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INC_ZE_CHECK_H
+#define INC_ZE_CHECK_H
+
+#include "sandstone_p.h"
+#include "ze_utils.h"
+
+#include "level_zero/ze_api.h"
+
+/// Check return value of an L0 API call. Log the return status and return EXIT_FAILURE if check against "success" status fails.
+#define ZE_CHECK(...) \
+    do { \
+        auto result = (__VA_ARGS__); \
+        if (result != ZE_RESULT_SUCCESS) { \
+            if (thread_num >= 0) { \
+                log_debug("L0 API call failed with status %s", to_string(result)); \
+            } else { \
+                logging_printf(LOG_LEVEL_VERBOSE(1), "L0 API call failed with status %s\n", to_string(result)); \
+            } \
+            return EXIT_FAILURE; \
+        } \
+    } while (0)
+
+#endif // INC_ZE_CHECK_H

--- a/framework/device/gpu/ze_enumeration.cpp
+++ b/framework/device/gpu/ze_enumeration.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ze_enumeration.h"
+
+#include "device/gpu/multi_slice_gpu.h"
+
+#include "level_zero/ze_api.h"
+#include "level_zero/zes_api.h"
+
+/// ZE API allows for nested enumeration of devices and their subdevices,
+/// depending on the ZE_FLAT_DEVICE_HIERARCHY env var value.
+int for_each_ze_device(std::function<int(ze_device_handle_t, ze_driver_handle_t, const MultiSliceGpu&)> func)
+{
+    uint32_t n_drivers = 0;
+    ze_init_driver_type_desc_t init_desc = { .stype = ZE_STRUCTURE_TYPE_DRIVER_PROPERTIES, .flags = ZE_INIT_DRIVER_TYPE_FLAG_GPU };
+    ZE_CHECK(zeInitDrivers(&n_drivers, nullptr, &init_desc));
+    std::vector<ze_driver_handle_t> drivers(n_drivers);
+    ZE_CHECK(zeInitDrivers(&n_drivers, drivers.data(), &init_desc));
+
+    int gpu_number = 0;
+    for (auto ze_driver: drivers) {
+        uint32_t n_devices = 0;
+        ZE_CHECK(zeDeviceGet(ze_driver, &n_devices, nullptr));
+        std::vector<ze_device_handle_t> devices(n_devices);
+        ZE_CHECK(zeDeviceGet(ze_driver, &n_devices, devices.data()));
+
+        for (int i = 0; i < (int)devices.size(); i++) {
+            ze_device_properties_t device_properties = { .stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES };
+            ZE_CHECK(zeDeviceGetProperties(devices[i], &device_properties));
+            if (device_properties.type == ZE_DEVICE_TYPE_GPU) {
+                uint32_t n_subdevices = 0;
+                ZE_CHECK(zeDeviceGetSubDevices(devices[i], &n_subdevices, nullptr));
+                if (n_subdevices == 0) {
+                    CHECK_SANDSTONE(func(devices[i], ze_driver, MultiSliceGpu{gpu_number++, i, -1})); // subdevice_index is -1 (undefined)
+                } else {
+                    std::vector<ze_device_handle_t> subdevices(n_subdevices);
+                    ZE_CHECK(zeDeviceGetSubDevices(devices[i], &n_subdevices, subdevices.data()));
+                    for (int sub_i = 0; sub_i < (int)subdevices.size(); sub_i++) {
+                        CHECK_SANDSTONE(func(subdevices[sub_i], ze_driver, MultiSliceGpu{gpu_number++, i, sub_i}));
+                    }
+                }
+            }
+        }
+    }
+    return EXIT_SUCCESS;
+}
+
+/// ZES API ignores ZE_FLAT_DEVICE_HIERARCHY and will always enumerate, for example, 6 root devices, instead of 12.
+/// Properties queried with this API will always contain data for all subdevices. For distinction there is subdeviceId
+/// field in ZES properties structs. func should accomodate for that.
+int for_each_zes_device(std::function<int(zes_device_handle_t, ze_driver_handle_t, const MultiSliceGpu&)> func)
+{
+    ZE_CHECK(zesInit(zes_init_flags_t{}));
+    uint32_t n_zes_drivers = 0;
+    ZE_CHECK(zesDriverGet(&n_zes_drivers, nullptr));
+    std::vector<zes_driver_handle_t> zes_drivers(n_zes_drivers);
+    ZE_CHECK(zesDriverGet(&n_zes_drivers, zes_drivers.data()));
+
+    int gpu_number = 0;
+    for (auto zes_driver: zes_drivers) {
+        uint32_t n_zes_devices = 0;
+        ZE_CHECK(zesDeviceGet(zes_driver, &n_zes_devices, nullptr));
+        std::vector<zes_device_handle_t> zes_devices(n_zes_devices);
+        ZE_CHECK(zesDeviceGet(zes_driver, &n_zes_devices, zes_devices.data()));
+
+        for (int i = 0; i < (int)zes_devices.size(); i++) {
+            zes_device_properties_t device_prop = { .stype = ZES_STRUCTURE_TYPE_DEVICE_PROPERTIES };
+            ZE_CHECK(zesDeviceGetProperties(zes_devices[i], &device_prop));
+            if (device_prop.core.type == ZE_DEVICE_TYPE_GPU) {
+                if (device_prop.numSubdevices == 0) {
+                    CHECK_SANDSTONE(func(zes_devices[i], zes_driver, MultiSliceGpu{ gpu_number++, i, -1 }));
+                } else {
+                    for (int sub_i = 0; sub_i < (int)device_prop.numSubdevices; sub_i++) {
+                        // Note the common zes_handle for all subdevices!
+                        CHECK_SANDSTONE(func(zes_devices[i], zes_driver, MultiSliceGpu{ gpu_number++, i, sub_i } ));
+                    }
+                }
+            }
+        }
+    }
+    return EXIT_SUCCESS;
+}

--- a/framework/device/gpu/ze_enumeration.h
+++ b/framework/device/gpu/ze_enumeration.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INC_ZE_ENUMERATION_H
+#define INC_ZE_ENUMERATION_H
+
+#include "sandstone_p.h"
+#include "multi_slice_gpu.h"
+#include "ze_check.h"
+
+#include "level_zero/ze_api.h"
+#include "level_zero/zes_api.h"
+
+#include <concepts>
+#include <functional>
+#include <type_traits>
+
+#define CHECK_SANDSTONE(...) \
+    if ((__VA_ARGS__) != EXIT_SUCCESS) \
+        return EXIT_FAILURE;
+
+/// Functions containing boilerplate code for drivers, devices and subdevices enumeration. Contains level-zero drivers
+/// initialization, so can be called as a standalone function anytime. Calls passed function for each found Intel device.
+/// In case where a device has its subdevices, passed function is called for each such subdevice.
+int for_each_ze_device(std::function<int(ze_device_handle_t, ze_driver_handle_t, const MultiSliceGpu&)> func);
+int for_each_zes_device(std::function<int(zes_device_handle_t, ze_driver_handle_t, const MultiSliceGpu&)> func);
+
+/// Functions for enumerating given resource type. Called inside for_each_* functions.
+inline ze_result_t get_ze_handles(zes_device_handle_t device_handle, uint32_t& count, zes_mem_handle_t* vec)
+{
+    return zesDeviceEnumMemoryModules(device_handle, &count, vec);
+}
+inline ze_result_t get_ze_handles(zes_device_handle_t device_handle, uint32_t& count, zes_engine_handle_t* vec)
+{
+    return zesDeviceEnumEngineGroups(device_handle, &count, vec);
+}
+inline ze_result_t get_ze_handles(zes_device_handle_t device_handle, uint32_t& count, zes_ras_handle_t* vec)
+{
+    return zesDeviceEnumRasErrorSets(device_handle, &count, vec);
+}
+inline ze_result_t get_ze_handles(zes_device_handle_t device_handle, uint32_t& count, zes_fabric_port_handle_t* vec)
+{
+    return zesDeviceEnumFabricPorts(device_handle, &count, vec);
+}
+inline ze_result_t get_ze_handles(zes_device_handle_t device_handle, uint32_t& count, zes_freq_handle_t* vec)
+{
+    return zesDeviceEnumFrequencyDomains(device_handle, &count, vec);
+}
+inline ze_result_t get_ze_handles(zes_device_handle_t device_handle, uint32_t& count, zes_temp_handle_t* vec)
+{
+    return zesDeviceEnumTemperatureSensors(device_handle, &count, vec);
+}
+
+/// Helper struct matching resource type to it's property type and property descriptor.
+template <typename ResourceType>
+struct ZesTypes;
+template <> struct ZesTypes<zes_mem_handle_t>
+{
+    using PropertyType = zes_mem_properties_t;
+    static constexpr _zes_structure_type_t PropertySType = ZES_STRUCTURE_TYPE_MEM_PROPERTIES;
+};
+template <> struct ZesTypes<zes_engine_handle_t>
+{
+    using PropertyType = zes_engine_properties_t;
+    static constexpr _zes_structure_type_t PropertySType = ZES_STRUCTURE_TYPE_ENGINE_PROPERTIES;
+};
+template <> struct ZesTypes<zes_ras_handle_t>
+{
+    using PropertyType = zes_ras_properties_t;
+    static constexpr _zes_structure_type_t PropertySType = ZES_STRUCTURE_TYPE_RAS_PROPERTIES;
+};
+template <> struct ZesTypes<zes_fabric_port_handle_t>
+{
+    using PropertyType = zes_fabric_port_properties_t;
+    static constexpr _zes_structure_type_t PropertySType = ZES_STRUCTURE_TYPE_FABRIC_PORT_PROPERTIES;
+};
+template <> struct ZesTypes<zes_freq_handle_t>
+{
+    using PropertyType = zes_freq_properties_t;
+    static constexpr _zes_structure_type_t PropertySType = ZES_STRUCTURE_TYPE_FREQ_PROPERTIES;
+};
+template <> struct ZesTypes<zes_temp_handle_t>
+{
+    using PropertyType = zes_temp_properties_t;
+    static constexpr _zes_structure_type_t PropertySType = ZES_STRUCTURE_TYPE_TEMP_PROPERTIES;
+};
+
+/// Functions to query for a property of a concrete resource type.
+inline ze_result_t get_ze_properties(zes_mem_handle_t handle, zes_mem_properties_t* props)
+{
+    return zesMemoryGetProperties(handle, props);
+}
+inline ze_result_t get_ze_properties(zes_engine_handle_t handle, zes_engine_properties_t* props)
+{
+    return zesEngineGetProperties(handle, props);
+}
+inline ze_result_t get_ze_properties(zes_ras_handle_t handle, zes_ras_properties_t* props)
+{
+    return zesRasGetProperties(handle, props);
+}
+inline ze_result_t get_ze_properties(zes_fabric_port_handle_t handle, zes_fabric_port_properties_t* props)
+{
+    return zesFabricPortGetProperties(handle, props);
+}
+inline ze_result_t get_ze_properties(zes_freq_handle_t handle, zes_freq_properties_t* props)
+{
+    return zesFrequencyGetProperties(handle, props);
+}
+inline ze_result_t get_ze_properties(zes_temp_handle_t handle, zes_temp_properties_t* props)
+{
+    return zesTemperatureGetProperties(handle, props);
+}
+
+template<typename Callable>
+using return_type_of_t =
+    typename decltype(std::function{std::declval<Callable>()})::result_type;
+
+/// Function containing boilerplate code for enumerating resources. It is a common pattern of level-zero API
+/// to first get number of resources, and then enumerate them, using the same enumerating function for both tasks.
+/// Calls func for each found resource handle.
+template <typename DeviceType, typename ResourceType, typename LambdaType> requires
+    std::is_same_v<return_type_of_t<LambdaType>, int> &&
+    std::is_invocable_v<LambdaType, ResourceType>
+inline int for_each_handle(DeviceType device_handle, LambdaType func)
+{
+    uint32_t count{};
+    ZE_CHECK(get_ze_handles(device_handle, count, nullptr));
+    std::vector<ResourceType> res_handles(count);
+    ZE_CHECK(get_ze_handles(device_handle, count, res_handles.data()));
+    for (auto& res_handle : res_handles) {
+        CHECK_SANDSTONE(func(res_handle));
+    }
+    return EXIT_SUCCESS;
+}
+
+#endif // INC_ZE_ENUMERATION_H

--- a/framework/device/gpu/ze_utils.cpp
+++ b/framework/device/gpu/ze_utils.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ze_utils.h"
+
+#include "level_zero/ze_api.h"
+#include "level_zero/zes_api.h"
+
+const char* to_string(ze_result_t value)
+{
+    switch (value) {
+#define CASE(X) case ZE_RESULT_ ## X: return #X
+    CASE(SUCCESS);
+    CASE(NOT_READY);
+    CASE(ERROR_DEVICE_LOST);
+    CASE(ERROR_OUT_OF_HOST_MEMORY);
+    CASE(ERROR_OUT_OF_DEVICE_MEMORY);
+    CASE(ERROR_MODULE_BUILD_FAILURE);
+    CASE(ERROR_MODULE_LINK_FAILURE);
+    CASE(ERROR_DEVICE_REQUIRES_RESET);
+    CASE(ERROR_DEVICE_IN_LOW_POWER_STATE);
+    CASE(EXP_ERROR_DEVICE_IS_NOT_VERTEX);
+    CASE(EXP_ERROR_VERTEX_IS_NOT_DEVICE);
+    CASE(EXP_ERROR_REMOTE_DEVICE);
+    CASE(EXP_ERROR_OPERANDS_INCOMPATIBLE);
+    CASE(EXP_RTAS_BUILD_RETRY);
+    CASE(EXP_RTAS_BUILD_DEFERRED);
+    CASE(ERROR_INSUFFICIENT_PERMISSIONS);
+    CASE(ERROR_NOT_AVAILABLE);
+    CASE(ERROR_DEPENDENCY_UNAVAILABLE);
+    CASE(WARNING_DROPPED_DATA);
+    CASE(ERROR_UNINITIALIZED);
+    CASE(ERROR_UNSUPPORTED_VERSION);
+    CASE(ERROR_UNSUPPORTED_FEATURE);
+    CASE(ERROR_INVALID_ARGUMENT);
+    CASE(ERROR_INVALID_NULL_HANDLE);
+    CASE(ERROR_HANDLE_OBJECT_IN_USE);
+    CASE(ERROR_INVALID_NULL_POINTER);
+    CASE(ERROR_INVALID_SIZE);
+    CASE(ERROR_UNSUPPORTED_SIZE);
+    CASE(ERROR_UNSUPPORTED_ALIGNMENT);
+    CASE(ERROR_INVALID_SYNCHRONIZATION_OBJECT);
+    CASE(ERROR_INVALID_ENUMERATION);
+    CASE(ERROR_UNSUPPORTED_ENUMERATION);
+    CASE(ERROR_UNSUPPORTED_IMAGE_FORMAT);
+    CASE(ERROR_INVALID_NATIVE_BINARY);
+    CASE(ERROR_INVALID_GLOBAL_NAME);
+    CASE(ERROR_INVALID_KERNEL_NAME);
+    CASE(ERROR_INVALID_FUNCTION_NAME);
+    CASE(ERROR_INVALID_GROUP_SIZE_DIMENSION);
+    CASE(ERROR_INVALID_GLOBAL_WIDTH_DIMENSION);
+    CASE(ERROR_INVALID_KERNEL_ARGUMENT_INDEX);
+    CASE(ERROR_INVALID_KERNEL_ARGUMENT_SIZE);
+    CASE(ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE);
+    CASE(ERROR_INVALID_MODULE_UNLINKED);
+    CASE(ERROR_INVALID_COMMAND_LIST_TYPE);
+    CASE(ERROR_OVERLAPPING_REGIONS);
+    CASE(WARNING_ACTION_REQUIRED);
+    CASE(ERROR_INVALID_KERNEL_HANDLE);
+    CASE(EXT_RTAS_BUILD_RETRY);
+    CASE(EXT_RTAS_BUILD_DEFERRED);
+    CASE(EXT_ERROR_OPERANDS_INCOMPATIBLE);
+    CASE(ERROR_SURVIVABILITY_MODE_DETECTED);
+#undef CASE
+    case ZE_RESULT_ERROR_UNKNOWN:
+    case ZE_RESULT_FORCE_UINT32:
+        break;
+    }
+    return "ERROR_UNKNOWN";
+}
+
+const char* to_string(zes_mem_type_t value)
+{
+    switch (value) {
+    case ZES_MEM_TYPE_HBM: return "HBM";
+    case ZES_MEM_TYPE_DDR: return "DDR";
+    case ZES_MEM_TYPE_DDR3: return "DDR3";
+    case ZES_MEM_TYPE_DDR4: return "DDR4";
+    case ZES_MEM_TYPE_DDR5: return "DDR5";
+    case ZES_MEM_TYPE_LPDDR: return "LPDDR";
+    case ZES_MEM_TYPE_LPDDR3: return "LPDDR3";
+    case ZES_MEM_TYPE_LPDDR4: return "LPDDR4";
+    case ZES_MEM_TYPE_LPDDR5: return "LPDDR5";
+    case ZES_MEM_TYPE_SRAM: return "SRAM";
+    case ZES_MEM_TYPE_L1: return "L1";
+    case ZES_MEM_TYPE_L3: return "L3";
+    case ZES_MEM_TYPE_GRF: return "GRF";
+    case ZES_MEM_TYPE_SLM: return "SLM";
+    case ZES_MEM_TYPE_GDDR4: return "GDDR4";
+    case ZES_MEM_TYPE_GDDR5: return "GDDR5";
+    case ZES_MEM_TYPE_GDDR5X: return "GDDR5X";
+    case ZES_MEM_TYPE_GDDR6: return "GDDR6";
+    case ZES_MEM_TYPE_GDDR6X: return "GDDR6X";
+    case ZES_MEM_TYPE_GDDR7: return "GDDR7";
+    case ZES_MEM_TYPE_FORCE_UINT32:
+        break;
+    }
+    return "MEM_TYPE_UNKNOWN";
+}
+
+const char* to_string(zes_mem_loc_t value)
+{
+    switch (value) {
+    case ZES_MEM_LOC_SYSTEM: return "system";
+    case ZES_MEM_LOC_DEVICE: return "device";
+    case ZES_MEM_LOC_FORCE_UINT32:
+        break;
+    }
+    return "MEM_LOC_UNKNOWN";
+}
+
+const char* to_string(zes_ras_error_type_t value)
+{
+    switch (value) {
+    case ZES_RAS_ERROR_TYPE_CORRECTABLE: return "correctable";
+    case ZES_RAS_ERROR_TYPE_UNCORRECTABLE: return "uncorrectable";
+    case ZES_RAS_ERROR_TYPE_FORCE_UINT32:
+        break;
+    }
+    return "ERROR_TYPE_UNKNOWN";
+}
+
+const char* to_string(zes_engine_group_t value)
+{
+    switch (value) {
+    case ZES_ENGINE_GROUP_ALL: return "all";
+    case ZES_ENGINE_GROUP_COMPUTE_ALL: return "compute_all";
+    case ZES_ENGINE_GROUP_MEDIA_ALL: return "media_all";
+    case ZES_ENGINE_GROUP_COPY_ALL: return "copy_all";
+    case ZES_ENGINE_GROUP_COMPUTE_SINGLE: return "compute_single";
+    case ZES_ENGINE_GROUP_RENDER_SINGLE: return "render_single";
+    case ZES_ENGINE_GROUP_MEDIA_DECODE_SINGLE: return "media_decode_single";
+    case ZES_ENGINE_GROUP_MEDIA_ENCODE_SINGLE: return "media_encode_single";
+    case ZES_ENGINE_GROUP_COPY_SINGLE: return "copy_single";
+    case ZES_ENGINE_GROUP_MEDIA_ENHANCEMENT_SINGLE: return "media_enhancement_single";
+    case ZES_ENGINE_GROUP_3D_SINGLE: return "3d_single";
+    case ZES_ENGINE_GROUP_3D_RENDER_COMPUTE_ALL: return "3d_render_compute_all";
+    case ZES_ENGINE_GROUP_RENDER_ALL: return "render_all";
+    case ZES_ENGINE_GROUP_3D_ALL: return "3d_all";
+    case ZES_ENGINE_GROUP_MEDIA_CODEC_SINGLE: return "media_codec_single";
+    case ZES_ENGINE_GROUP_FORCE_UINT32:
+        break;
+    }
+    return "ENGINE_GROUP_UNKNOWN";
+}
+
+const char* to_string(zes_device_ecc_state_t value)
+{
+    switch (value) {
+    case ZES_DEVICE_ECC_STATE_UNAVAILABLE: return "unavailable";
+    case ZES_DEVICE_ECC_STATE_ENABLED: return "enabled";
+    case ZES_DEVICE_ECC_STATE_DISABLED: return "disabled";
+    case ZES_DEVICE_ECC_STATE_FORCE_UINT32:
+        break;
+    }
+    return "ECC_STATE_UNKNOWN";
+}
+
+const char* to_string(zes_device_action_t value)
+{
+    switch (value) {
+    case ZES_DEVICE_ACTION_NONE: return "none";
+    case ZES_DEVICE_ACTION_WARM_CARD_RESET: return "warm_card_reset";
+    case ZES_DEVICE_ACTION_COLD_CARD_RESET: return "cold_card_reset";
+    case ZES_DEVICE_ACTION_COLD_SYSTEM_REBOOT: return "cold_system_reboot";
+    case ZES_DEVICE_ACTION_FORCE_UINT32:
+        break;
+    }
+    return "ACTION_UNKNOWN";
+}

--- a/framework/device/gpu/ze_utils.h
+++ b/framework/device/gpu/ze_utils.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INC_ZE_UTILS_H
+#define INC_ZE_UTILS_H
+
+#include "level_zero/ze_api.h"
+#include "level_zero/zes_api.h"
+
+/// Functions converting resource type to a human readable string.
+const char* to_string(ze_result_t value);
+const char* to_string(zes_mem_type_t value);
+const char* to_string(zes_mem_loc_t value);
+const char* to_string(zes_ras_error_type_t value);
+const char* to_string(zes_engine_group_t value);
+const char* to_string(zes_device_ecc_state_t value);
+const char* to_string(zes_device_action_t value);
+
+#endif // INC_ZE_UTILS_H


### PR DESCRIPTION
L0 API is C-based, which introduces a lot of boilerplate code. Helper functions grouped in `ze_enumeration.*` allow to enumerate drivers, devices, and commonly used properties. File `ze_utils.*` provides conversion functions, converting codes into strings. `ze_check.h` provides a macro for calling L0 functions.