### PR TITLE
FW: add support for executing with no devices found

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1831,7 +1831,7 @@ LogicalProcessorSet detect_devices<LogicalProcessorSet>()
     if (sApp->thread_count == 0) [[unlikely]] {
         fprintf(stderr, "%s: internal error: ambient logical processor set appears to be empty!\n",
                 program_invocation_name);
-        exit(EX_OSERR);
+        return result;
     }
     sApp->user_thread_data.resize(sApp->thread_count);
 #ifdef M_ARENA_MAX

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2585,18 +2585,24 @@ int main(int argc, char **argv)
         return exec_mode_run(argc - 2, argv + 2);
     }
 
+    bool any_device = false;
     {
         auto enabled_devices = detect_devices<EnabledDevices>();
-        init_shmem();
-        setup_devices(std::move(enabled_devices));
+        if (!enabled_devices.empty()) {
+            any_device = true;
+            init_shmem();
+            setup_devices(std::move(enabled_devices));
+        }
     }
 
     ProgramOptions opts;
     if (int ret = parse_cmdline(argc, argv, sApp, opts); ret != EXIT_SUCCESS) {
         return ret;
     }
-    // copy data from cfg that needs to be in shared memory
-    sApp->shmem->cfg = std::move(opts.shmem_cfg);
+    if (any_device) {
+        // copy data from cfg that needs to be in shared memory
+        sApp->shmem->cfg = std::move(opts.shmem_cfg);
+    }
 
     if (opts.test_tests) {
         sApp->enable_test_tests();
@@ -2606,12 +2612,21 @@ int main(int argc, char **argv)
         }
     }
 
-    if (!opts.deviceset.empty()) {
+    if (!opts.deviceset.empty() && any_device) {
         apply_deviceset_param(&opts.deviceset[0]);
     }
 
+    static auto check_and_exit_for_no_device = [&]() {
+        if (!any_device) {
+            fprintf(stderr, "%s: error: no devices found\n",
+                    program_invocation_name);
+            exit(EX_OSERR);
+        }
+    };
+
     switch (opts.action) {
     case Action::dump_cpu_info:
+        check_and_exit_for_no_device();
         dump_device_info();
         return EXIT_SUCCESS;
     case Action::list_tests:
@@ -2628,6 +2643,7 @@ int main(int argc, char **argv)
     case Action::exit:
         return EXIT_SUCCESS;
     case Action::run:
+        check_and_exit_for_no_device();
         break; // continue program
     }
     if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::exec_each_test) {


### PR DESCRIPTION
As long as we do not run opendcdiag with tests or `--dump-device-info`, we should be able to proceed to the rest of actions without any devices found. This would be particularly useful to non-CPU builds, where the chance of lack of any device in the system is relatively high. We would still want to be able to run `opendcdiag --version` in that case.