### PR TITLE
FW/Logging: print error messages even past the `--max-messages` limit

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -658,7 +658,8 @@ void log_message_preformatted(int thread_num, int level, std::string_view msg)
         return;
 
     std::atomic<int> &messages_logged = sApp->thread_data(thread_num)->messages_logged;
-    if (messages_logged.load(std::memory_order_relaxed) >= sApp->shmem->cfg.max_messages_per_thread)
+    if (level != LOG_LEVEL_QUIET &&
+            messages_logged.load(std::memory_order_relaxed) >= sApp->shmem->cfg.max_messages_per_thread)
         return;
 
     if (msg[msg.size() - 1] == '\n')

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -620,6 +620,20 @@ static int selftest_logerror_run(struct test *test, int thread)
     return EXIT_SUCCESS;
 }
 
+static int selftest_logerror_lots_run(struct test *test, int thread)
+{
+    // using environment because get_testspecific_knob_value_int() doesn't work
+    // in -fexec mode
+    int count = 10;
+    if (const char *env = getenv("SELFTEST_LOGERROR_LOTS_COUNT"))
+        count = strtol(env, nullptr, 0);
+    for (int i = 0; i < count; ++i) {
+        log_info("This is log info message #%d", i);
+        log_error("This is log error message #%d", i);
+    }
+    return EXIT_SUCCESS;
+}
+
 static int selftest_reportfail_run(struct test *test, int)
 {
     report_fail(test);
@@ -1931,6 +1945,14 @@ static struct test selftests_array[] = {
     .groups = DECLARE_TEST_GROUPS(&group_negative),
     .test_init = selftest_init_installcallback,
     .test_run = selftest_logerror_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_logerror_lots",
+    .description = "Fails by calling log_error() [a lot of times]",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_run = selftest_logerror_lots_run,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },


### PR DESCRIPTION
We've had a case where a test logged some maintenance messages before the error, which wasn't captured because `--max-messages=5` is the default.

[ChangeLog][Framework] Error messages will be included in the log output even if they exceed the `--max-messages` limit.