### PR TITLE
FW/GPU: introduce topology enumeration functions

### DIFF
--- a/framework/device/gpu/topology_gpu.h
+++ b/framework/device/gpu/topology_gpu.h
@@ -13,6 +13,7 @@
 #include "level_zero/ze_api.h"
 #include "level_zero/zes_api.h"
 
+#include <functional>
 #include <map>
 #include <variant>
 #include <span>
@@ -44,12 +45,15 @@ public:
 
     std::vector<std::variant<RootDevice, EndDevice>> devices;
 
-    // static const Topology &topology();
+    static const Topology &topology();
 };
 
 /// Fills the topology (devices & their subdevices) based on cpu_info.
 /// Supports heterogenous topology (mixed kind of devices - End and Root).
 Topology build_topology();
+
+/// Calls passed function for each 'end' device within topology.
+int for_each_topo_device(std::function<int(gpu_info_t&)> func);
 
 /// Struct should contain common info for all detected GPUs, such as brand, etc.
 struct HardwareInfo

--- a/framework/device/gpu/ze_enumeration.h
+++ b/framework/device/gpu/ze_enumeration.h
@@ -27,6 +27,11 @@
 int for_each_ze_device(std::function<int(ze_device_handle_t, ze_driver_handle_t, const MultiSliceGpu&)> func);
 int for_each_zes_device(std::function<int(zes_device_handle_t, ze_driver_handle_t, const MultiSliceGpu&)> func);
 
+/// Same as above, but with additional topology lookup step. Calls passed function for each found Intel device being
+/// part of the current Topology.
+int for_each_ze_device_within_topo(std::function<int(ze_device_handle_t, ze_driver_handle_t, const MultiSliceGpu&)> func);
+int for_each_zes_device_within_topo(std::function<int(zes_device_handle_t, ze_driver_handle_t, const MultiSliceGpu&)> func);
+
 /// Functions for enumerating given resource type. Called inside for_each_* functions.
 inline ze_result_t get_ze_handles(zes_device_handle_t device_handle, uint32_t& count, zes_mem_handle_t* vec)
 {


### PR DESCRIPTION
This commit adds a new function `for_each_topo_device`. For some use cases, however, we cannot just iterate over topology, as it does not contain L0 driver&device handles (they would not survive forking).
For that reason, `for_each_ze(s)_device_within_topo` functions are also introduced. Apart from seeking through all available L0 devices, they also perform additional lookup step, so that we operate only on devices within current topology.
