### PR TITLE
FW/Logging: report virtualisation/contenerisation state in YAML logs

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -11,6 +11,8 @@
 #include "sandstone_p.h"
 #include "sandstone_iovec.h"
 #include "sandstone_utils.h"
+#include "sandstone_virt.h"
+
 #if SANDSTONE_SSL_BUILD
 #  include "sandstone_ssl.h"
 #endif
@@ -2134,6 +2136,21 @@ void YamlLogger::print()
     logging_flush();
 }
 
+void YamlLogger::maybe_print_virt_state() {
+    auto detected_vm = detect_running_vm();
+    auto detected_container = detect_running_container();
+
+    if ((!detected_vm.empty()) || (!detected_container.empty())) {
+        logging_printf(LOG_LEVEL_VERBOSE(1), "virtualization-state: { %s%s%s%s }\n",
+                detected_vm.empty() ? "" : "vm: ",
+                detected_vm.empty() ? "" : detected_vm.c_str(),
+                detected_container.empty() ? "" : detected_vm.empty()
+                    ? "container: " : ", container: ",
+                detected_container.empty() ? "" : detected_container.c_str()
+            );
+    }
+}
+
 void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, Duration test_timeout)
 {
     using ::format_duration;
@@ -2150,6 +2167,7 @@ void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, 
                    format_duration(test_timeout, FormatDurationOptions::WithoutUnit).c_str());
 
     // print the device information
+    maybe_print_virt_state();
 #if SANDSTONE_DEVICE_CPU
     logging_printf(LOG_LEVEL_VERBOSE(1), "cpu-info:\n");
 #else

--- a/framework/logging.h
+++ b/framework/logging.h
@@ -112,6 +112,8 @@ private:
     static void format_and_print_skip_reason(int fd, std::string_view message);
     int print_one_thread_messages(int fd, mmap_region r, int level);
     void print_result_line(int &init_skip_message_bytes);
+
+    static void maybe_print_virt_state();
 };
 
 #if SANDSTONE_NO_LOGGING

--- a/framework/sandstone_virt.h
+++ b/framework/sandstone_virt.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __INCLUDE_GUARD_SANDSTONE_VIRT_H_
+#define __INCLUDE_GUARD_SANDSTONE_VIRT_H_
+
+#include <string>
+
+/*
+ * If running inside of container, will return
+ * non-empty string with the container's name
+ */
+std::string detect_running_container();
+
+/*
+ * If running inside a vm, will return
+ * non-empty string with the vm's name
+ */
+std::string detect_running_vm();
+
+#endif /* __INCLUDE_GUARD_SANDSTONE_VIRT_H_ */

--- a/framework/sysdeps/unix/meson.build
+++ b/framework/sysdeps/unix/meson.build
@@ -8,6 +8,7 @@ framework_files += files(
     'splitlock_detect.c',
     'stacksize.cpp',
     'tmpfile.c',
+    'virt.cpp',
 )
 
 # same check as linux/meson.build

--- a/framework/sysdeps/unix/virt.cpp
+++ b/framework/sysdeps/unix/virt.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "sandstone_virt.h"
+#include <unistd.h>
+#include <cstring>
+
+static std::string popen_and_readline(const char* cmd) {
+    static constexpr size_t max_line_len = 256;
+
+    FILE* fp = popen(cmd, "r");
+
+    if (fp == NULL) {
+        return "";
+    }
+
+    std::string line;
+    line.resize_and_overwrite(max_line_len, [&](char* buf, size_t len) {
+        return fgets(buf, len, fp) ? strlen(buf) : 0;
+    });
+
+    pclose(fp);
+
+    if(line.back() == '\n') {
+        line.pop_back(); // remove the newline character read
+                         // from stdout of systemd-detect-virt
+    }
+
+    return line;
+}
+
+static constexpr const char* detect_virt_container_cmd =
+    "systemd-detect-virt --container";
+
+static constexpr const char* detect_virt_vm_cmd =
+    "systemd-detect-virt --vm";
+
+std::string detect_running_container() {
+    std::string detected =
+        popen_and_readline(detect_virt_container_cmd);
+
+    if (detected.compare("none") == 0) {
+        return "";
+    } else if (!detected.empty()) {
+        return detected;
+    }
+
+    /* either failed to detect or not
+     * running inside of a container */
+    return "";
+}
+
+std::string detect_running_vm() {
+    std::string detected =
+        popen_and_readline(detect_virt_vm_cmd);
+
+    if (detected.compare("none") == 0) {
+        return "";
+    } else if (!detected.empty()) {
+        return detected;
+    }
+
+#if SANDSTONE_DEVICE_CPU
+    // failed to detect the vm with systemd-detect-virt
+    // but hypervisor is present so we report it as 'unknown'?
+    if (cpu_has_feature(cpu_feature_hypervisor)) {
+        return "unknown";
+    }
+#endif
+
+    return "";
+}

--- a/framework/sysdeps/windows/meson.build
+++ b/framework/sysdeps/windows/meson.build
@@ -16,6 +16,7 @@ framework_files += \
         'splitlock_detect.c',
         'tmpfile.c',
         'unistd.c',
+        'virt.cpp',
         'win32_perror.cpp',
         '../generic/kvm.c',
         '../generic/memfpt.c',

--- a/framework/sysdeps/windows/virt.cpp
+++ b/framework/sysdeps/windows/virt.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <sandstone_virt.h>
+
+std::string detect_running_container() {
+    return "";
+}
+
+std::string detect_running_vm() {
+
+#if SANDSTONE_DEVICE_CPU
+    // failed to detect the vm with systemd-detect-virt
+    // but hypervisor is present so we report it as 'unknown'?
+    if (cpu_has_feature(cpu_feature_hypervisor)) {
+        return "unknown";
+    }
+#endif
+
+    return "";
+}


### PR DESCRIPTION
Added container detection via 'systemd-detect-virt' (SysV only), and logging of the virtualisation/contenerisation state in the YAML format.

The proposed changes address a freature request described in #784.