### PR TITLE
Change reschedule() to an in-line API

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -131,10 +131,13 @@ int num_packages()
 std::unique_ptr<DeviceScheduler> make_rescheduler(RescheduleMode mode)
 {
     if (mode == RescheduleMode::barrier) {
+        reschedule_enabled = true;
         return std::make_unique<BarrierDeviceScheduler>();
     } else if (mode == RescheduleMode::queue) {
+        reschedule_enabled = true;
         return std::make_unique<QueueDeviceScheduler>();
     } else if (mode == RescheduleMode::random) {
+        reschedule_enabled = true;
         return std::make_unique<RandomDeviceScheduler>();
     }
     return nullptr;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -892,10 +892,10 @@ void test_loop_end() noexcept
     assembly_marker<TestLoop, End>(sApp->test_thread_data(thread_num)->inner_loop_count);
 }
 
-void reschedule()
+bool reschedule_enabled = false;
+void reschedule_internal()
 {
-    if (sApp->device_scheduler)
-        sApp->device_scheduler->reschedule_to_next_device();
+    sApp->device_scheduler->reschedule_to_next_device();
 }
 
 #ifndef _WIN32
@@ -2682,6 +2682,7 @@ int main(int argc, char **argv)
             return EX_USAGE;
         }
         if (sApp->device_scheduler) {
+            reschedule_enabled = false;
             sApp->device_scheduler = nullptr;
             logging_printf(LOG_LEVEL_VERBOSE(1), "# WARNING: --reschedule is not supported in this configuration\n");
         }

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -487,7 +487,13 @@ static inline bool write_msr(int cpu, uint32_t msr, uint64_t value)
 #endif
 
 /// Interface for C-based tests
-void reschedule();
+extern bool reschedule_enabled;
+void reschedule_internal(void);
+static inline void reschedule(void)
+{
+    if (reschedule_enabled)
+        reschedule_internal();
+}
 
 /// Calls aligned_alloc but first checks to see whether size is a multiple
 /// of alignment.  If it is not, the requested size of the allocation is increased


### PR DESCRIPTION
This commit changes reschedule() to an inline function that checks reschedule is enabled before calling reschedule_internal(), minimizing performance overhead when not enabled.