### PR TITLE
FW: reduce the loop counters to 32-bit

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -97,10 +97,10 @@ void KeyValuePairLogger::print_thread_header(int fd, int device, const char *pre
     PerThreadData::Test *thr = sApp->test_thread_data(device);
     if (std::string time = format_duration(thr->fail_time); time.size()) {
         dprintf(fd, "%s_thread_%d_fail_time = %s\n", prefix, device, time.c_str());
-        dprintf(fd, "%s_thread_%d_loop_count = %" PRIu64 "\n", prefix, device,
+        dprintf(fd, "%s_thread_%d_loop_count = %u\n", prefix, device,
                 thr->inner_loop_count_at_fail);
     } else {
-        dprintf(fd, "%s_thread_%d_loop_count = %" PRIu64 "\n", prefix, device,
+        dprintf(fd, "%s_thread_%d_loop_count = %u\n", prefix, device,
                 thr->inner_loop_count);
     }
     dprintf(fd, "%s_messages_thread_%d_cpu = %d\n", prefix, device, info->cpu_number);

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -949,7 +949,7 @@ static uintptr_t thread_runner(int thread_number)
 #endif
 
     if (sApp->shmem->cfg.verbosity >= 3)
-        log_message(thread_number, SANDSTONE_LOG_INFO "inner loop count for thread %d = %" PRIu64 "\n",
+        log_message(thread_number, SANDSTONE_LOG_INFO "inner loop count for thread %d = %u\n",
                     thread_number, this_thread->inner_loop_count);
 
 

--- a/framework/test_data.h
+++ b/framework/test_data.h
@@ -74,8 +74,8 @@ struct alignas(64) Main : Common
 struct alignas(64) TestCommon : Common
 {
     /* Number of iterations of the inner loop (aka #times test_time_condition called) */
-    uint64_t inner_loop_count;
-    uint64_t inner_loop_count_at_fail;
+    uint32_t inner_loop_count;
+    uint32_t inner_loop_count_at_fail;
 
     /* Thread ID */
     std::atomic<tid_t> tid;


### PR DESCRIPTION
We can never loop more than 2^31 times anyway, because of this check in `max_loop_count_exceeded()`:
```c++
    // unsigned comparisons so sApp->current_max_loop_count == -1 causes an always false
    if (unsigned(data->inner_loop_count) >= unsigned(sApp->shmem->current_max_loop_count))
        return true;
```

In any case, if the test is calling `test_{time,loop}_condition()` more than 2^32 times, it's doing something wrong. Our test design target is that a single test loop is between 1 to 100 ms, which would allow a test to run for 49.7 days before overflowing.