### PR TITLE
TESTS: eigen_svd*: specify options in the template.

### DIFF
--- a/tests/cpu/eigen_svd/sandstone_eigen_common.h
+++ b/tests/cpu/eigen_svd/sandstone_eigen_common.h
@@ -26,7 +26,7 @@ template <typename SVD, int Dim> struct EigenSVDTest
 
     [[gnu::noinline]] static void calculate_once(const Mat &orig_matrix, Mat &u, Mat &v)
     {
-        SVD fullSvd(orig_matrix, Eigen::ComputeFullU | Eigen::ComputeFullV);
+        SVD fullSvd(orig_matrix);
         u = fullSvd.matrixU();
         v = fullSvd.matrixV();
     }

--- a/tests/cpu/eigen_svd/svd_cdouble.cpp
+++ b/tests/cpu/eigen_svd/svd_cdouble.cpp
@@ -30,8 +30,7 @@
 
 using namespace Eigen;
 
-typedef Matrix < std::complex <double >, Dynamic, Dynamic > Mat;
-typedef Eigen::BDCSVD < Mat > SVD;
+using SVD = BDCSVD<Matrix<std::complex <double>, Dynamic, Dynamic>, ComputeFullU | ComputeFullV>;
 
 #define M_DIM 300               // weird dim on purpose
 

--- a/tests/cpu/eigen_svd/svd_cdouble_noavx512.cpp
+++ b/tests/cpu/eigen_svd/svd_cdouble_noavx512.cpp
@@ -30,8 +30,7 @@
 
 using namespace Eigen;
 
-typedef Matrix < std::complex <double >, Dynamic, Dynamic > Mat;
-typedef Eigen::BDCSVD < Mat > SVD;
+using SVD = BDCSVD<Matrix<std::complex <double>, Dynamic, Dynamic>, ComputeFullU | ComputeFullV>;
 
 #define M_DIM 300               // weird dim on purpose
 

--- a/tests/cpu/eigen_svd/svd_double.cpp
+++ b/tests/cpu/eigen_svd/svd_double.cpp
@@ -30,8 +30,7 @@
 
 using namespace Eigen;
 
-typedef Matrix < double, Dynamic, Dynamic > Mat;
-typedef Eigen::BDCSVD < Mat > SVD;
+using SVD = BDCSVD<Matrix<double, Dynamic, Dynamic>, ComputeFullU | ComputeFullV>;
 
 #define M_DIM 256
 

--- a/tests/cpu/eigen_svd/svd_fvectors.cpp
+++ b/tests/cpu/eigen_svd/svd_fvectors.cpp
@@ -33,8 +33,9 @@
 #include "fp_vectors/static_vectors.h"
 
 using namespace Eigen;
-typedef Matrix < float, Dynamic, Dynamic > Mat;
-typedef Eigen::BDCSVD < Mat > SVD;
+
+using Mat = Matrix<float, Dynamic, Dynamic>;
+using SVD = BDCSVD<Mat, ComputeFullU | ComputeFullV>;
 
 #define M_DIM 512
 


### PR DESCRIPTION
The previous way of specifying the options in the constructor has been deprecated and results in compile-time warnings, for example:
```
tests/cpu/eigen_svd/sandstone_eigen_common.h:29:13: warning: 'Eigen::BDCSVD<MatrixType, Options>::BDCSVD(const Eigen::MatrixBase<OtherDerived>&, unsigned int) [with Derived = Eigen::Matrix<std::complex<double>, -1, -1>; MatrixType_ = Eigen::Matrix<std::complex<double>, -1, -1>; int Options_ = 0]' is deprecated: Options should be specified using the class template parameter. [-Wdeprecated-declarations]
   29 |         SVD fullSvd(orig_matrix, Eigen::ComputeFullU | Eigen::ComputeFullV);
      |             ^~~~~~~
In file included from /usr/local/include/eigen3/Eigen/SVD:40,
                 from /usr/local/include/eigen3/Eigen/Geometry:13,
                 from /usr/local/include/eigen3/Eigen/Eigenvalues:17,
                 from ../opendcdiag/tests/cpu/eigen_svd/sandstone_eigen_common.h:15:
/usr/local/include/eigen3/Eigen/src/SVD/BDCSVD.h:188:3: note: declared here
  188 |   BDCSVD(const MatrixBase<Derived>& matrix, unsigned int computationOptions) : m_algoswap(16), m_numIters(0) {
      |   ^~~~~~
```