### PR TITLE
TESTS: eigen_svd*: disable deprecation warnings.

### DIFF
--- a/tests/cpu/eigen_svd/sandstone_eigen_common.h
+++ b/tests/cpu/eigen_svd/sandstone_eigen_common.h
@@ -9,6 +9,11 @@
 #ifndef SANDSTONE_EIGEN_COMMON_H
 #define SANDSTONE_EIGEN_COMMON_H
 
+/* Disable deprecation warnings in case the library used is >= 3.5.x. Once
+ * majority of the distros move to 3.5 or higher,
+ * https://github.com/opendcdiag/opendcdiag/pull/941 should be adopted. */
+#define EIGEN_NO_DEPRECATED_WARNING
+
 #include <sandstone.h>
 
 #include <boost/type_traits/is_complex.hpp>


### PR DESCRIPTION
In case version 3.5.x is used to build the sources, it'll warn of BDCSVD constructor deprecation. This disables the warnings while the world transitions. #941 properly fixes it.

Example of a warning with Eigen 3.5.x:
```
tests/cpu/eigen_svd/sandstone_eigen_common.h:29:13: warning: 'Eigen::BDCSVD<MatrixType, Options>::BDCSVD(const Eigen::MatrixBase<OtherDerived>&, unsigned int) [with Derived = Eigen::Matrix<std::complex<double>, -1, -1>; MatrixType_ = Eigen::Matrix<std::complex<double>, -1, -1>; int Options_ = 0]' is deprecated: Options should be specified using the class template parameter. [-Wdeprecated-declarations]
   29 |         SVD fullSvd(orig_matrix, Eigen::ComputeFullU | Eigen::ComputeFullV);
      |             ^~~~~~~
In file included from /usr/local/include/eigen3/Eigen/SVD:40,
                 from /usr/local/include/eigen3/Eigen/Geometry:13,
                 from /usr/local/include/eigen3/Eigen/Eigenvalues:17,
                 from ../opendcdiag/tests/cpu/eigen_svd/sandstone_eigen_common.h:15:
/usr/local/include/eigen3/Eigen/src/SVD/BDCSVD.h:188:3: note: declared here
  188 |   BDCSVD(const MatrixBase<Derived>& matrix, unsigned int computationOptions) : m_algoswap(16), m_numIters(0) {
      |   ^~~~~~
```