### PR TITLE
FW/Logging: refactor and make the log level an `enum class`

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -127,7 +127,8 @@ void KeyValuePairLogger::print_thread_messages()
             return;           /* nothing to be printed, on any level */
 
         print_thread_header(file_log_fd, i, timestamp_prefix.c_str());
-        int lowest_level = print_one_thread_messages_tdata(file_log_fd, data, r, INT_MAX);
+        LogLevelVerbosity lowest_level =
+                print_one_thread_messages_tdata(file_log_fd, data, r, LogLevelVerbosity::Max);
 
         if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
             print_thread_header(real_stdout_fd, i, test->id);
@@ -271,7 +272,7 @@ void TapFormatLogger::maybe_print_yaml_marker(int fd)
         IGNORE_RETVAL(write(fd, fail_info.c_str(), fail_info.size()));
 }
 
-void TapFormatLogger::print_thread_header(int fd, int device, int verbosity)
+void TapFormatLogger::print_thread_header(int fd, int device, LogLevelVerbosity verbosity)
 {
     maybe_print_yaml_marker(fd);
     if (device < 0) {
@@ -326,8 +327,9 @@ void TapFormatLogger::print_thread_messages()
         if (r.size == 0 && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
             return;             /* nothing to be printed, on any level */
 
-        print_thread_header(file_log_fd, i, INT_MAX);
-        int lowest_level = print_one_thread_messages_tdata(file_log_fd, data, r, INT_MAX);
+        print_thread_header(file_log_fd, i, LogLevelVerbosity::Max);
+        LogLevelVerbosity lowest_level =
+                print_one_thread_messages_tdata(file_log_fd, data, r, LogLevelVerbosity::Max);
 
         if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
             print_thread_header(real_stdout_fd, i, sApp->shmem->cfg.verbosity);
@@ -380,7 +382,7 @@ auto thread_core_spacing()
 }
 } // end unnamed namespace
 
-std::string AbstractLogger::thread_id_header_for_device(int thread, int verbosity)
+std::string AbstractLogger::thread_id_header_for_device(int thread, LogLevelVerbosity verbosity)
 {
     cpu_info_t *info = cpu_info + thread;
     std::string line;

--- a/framework/device/cpu/logging_cpu.h
+++ b/framework/device/cpu/logging_cpu.h
@@ -45,7 +45,7 @@ private:
     static const char *quality_string(const struct test *test);
     void maybe_print_yaml_marker(int fd);
     void print_thread_messages();
-    void print_thread_header(int fd, int device, int verbosity);
+    void print_thread_header(int fd, int device, LogLevelVerbosity verbosity);
     void print_child_stderr();
     std::string format_status_code();
 };

--- a/framework/device/gpu/logging_gpu.cpp
+++ b/framework/device/gpu/logging_gpu.cpp
@@ -7,7 +7,7 @@
 #include "test_data_gpu.h"
 
 #if !SANDSTONE_NO_LOGGING
-std::string AbstractLogger::thread_id_header_for_device(int cpu, int verbosity)
+std::string AbstractLogger::thread_id_header_for_device(int cpu, LogLevelVerbosity verbosity)
 {
     std::string line;
     return line;

--- a/framework/logging.h
+++ b/framework/logging.h
@@ -55,7 +55,7 @@ public:
     [[gnu::pure]] static const char *sysexit_reason(const ChildExitStatus &status);
 
     // device-specific interfaces
-    static std::string thread_id_header_for_device(int device, int verbosity);
+    static std::string thread_id_header_for_device(int device, LogLevelVerbosity verbosity);
     static void print_thread_header_for_device(int fd, PerThreadData::Test *thr);
     static void print_fixed_for_device();
 
@@ -68,12 +68,12 @@ public:
     bool skipInMainThread = false;
 
 protected:
-    int loglevel() const;
+    LogLevelVerbosity loglevel() const;
     bool should_print_fail_info() const;
 
     // shared between the TAP and key-value loggers; YAML overrides
     static void format_and_print_message(int fd, std::string_view message, bool from_thread_message);
-    int print_one_thread_messages_tdata(int fd, PerThreadData::Common *data, struct mmap_region r, int level);
+    LogLevelVerbosity print_one_thread_messages_tdata(int fd, PerThreadData::Common *data, struct mmap_region r, LogLevelVerbosity level);
 };
 
 class YamlLogger : public AbstractLogger
@@ -105,17 +105,17 @@ private:
     inline void maybe_print_messages_header(int fd);
     void print_fixed();
     void print_thread_messages();
-    void print_thread_header(int fd, int device, int verbosity);
+    void print_thread_header(int fd, int device, LogLevelVerbosity verbosity);
     inline bool want_slice_resource_usage(int slice);
     void maybe_print_slice_resource_usage(int fd, int slice);
     inline int print_test_knobs(int fd, mmap_region r);
     static void format_and_print_skip_reason(int fd, std::string_view message);
-    int print_one_thread_messages(int fd, mmap_region r, int level);
+    LogLevelVerbosity print_one_thread_messages(int fd, mmap_region r, LogLevelVerbosity level);
     void print_result_line(int &init_skip_message_bytes);
 };
 
 #if SANDSTONE_NO_LOGGING
-inline std::string AbstractLogger::thread_id_header_for_device(int device, int verbosity)
+inline std::string AbstractLogger::thread_id_header_for_device(int device, LogLevelVerbosity verbosity)
 { __builtin_unreachable(); return {}; }
 inline void AbstractLogger::print_thread_header_for_device(int fd, PerThreadData::Test *thr)
 { __builtin_unreachable(); }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2729,8 +2729,11 @@ int main(int argc, char **argv)
         }
     }
 
-    if (sApp->shmem->cfg.verbosity == -1)
-        sApp->shmem->cfg.verbosity = (sApp->requested_quality < SandstoneApplication::DefaultQualityLevel) ? 1 : 0;
+    if (sApp->shmem->cfg.verbosity < LOG_LEVEL_QUIET) {
+        sApp->shmem->cfg.verbosity = LOG_LEVEL_QUIET;
+        if (sApp->requested_quality < SandstoneApplication::DefaultQualityLevel)
+            sApp->shmem->cfg.verbosity = LOG_LEVEL_VERBOSE(1);
+    }
 
     if (InterruptMonitor::InterruptMonitorWorks && test_set->contains(&mce_test)) {
         if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::exec_each_test) {

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -670,7 +670,7 @@ struct ProgramOptionsParser {
         if (opts_map.contains('q')) {
             verbosity = 0;
         }
-        opts.shmem_cfg.verbosity = verbosity;
+        opts.shmem_cfg.verbosity = LOG_LEVEL_VERBOSE(verbosity);
 
         // quality (before tests listing)
         if (auto it = opts_map.find(quality_option); it != opts_map.end()) {
@@ -923,7 +923,7 @@ struct ProgramOptionsParser {
                 } else if (SandstoneConfig::Debug && fmt == "none") {
                     // for testing only
                     opts.shmem_cfg.output_format = SandstoneApplication::OutputFormat::no_output;
-                    opts.shmem_cfg.verbosity = -1;
+                    opts.shmem_cfg.verbosity = LOG_LEVEL_ERROR;
                 } else {
                     fprintf(ERR_STREAM, "%s: unknown output format: %s\n", argv[0], value);
                     return EX_USAGE;
@@ -1121,7 +1121,7 @@ struct ProgramOptionsParser {
         if (SandstoneConfig::NoLogging) {
             opts.shmem_cfg.output_format = SandstoneApplication::OutputFormat::no_output;
         } else  {
-            opts.shmem_cfg.verbosity = 1;
+            opts.shmem_cfg.verbosity = LOG_LEVEL_VERBOSE(1);
         }
 
         app_cfg->delay_between_tests = 50ms;


### PR DESCRIPTION
Using macros stems from the oldest versions of the tool when this was still written in C.