### PR TITLE
CI: force always installing a compiler

### DIFF
--- a/.github/actions/build-cpu/action.yaml
+++ b/.github/actions/build-cpu/action.yaml
@@ -37,7 +37,7 @@ runs:
         DEBIAN_FRONTEND=noninteractive apt-get -y install \
             bats \
             ca-certificates \
-            ${CC} \
+            ${CC-g++} \
             elfutils \
             file \
             gawk \

--- a/.github/actions/build-gpu/action.yaml
+++ b/.github/actions/build-gpu/action.yaml
@@ -32,7 +32,7 @@ runs:
         DEBIAN_FRONTEND=noninteractive apt-get -y install \
             bats \
             ca-certificates \
-            ${CC} \
+            ${CC-g++} \
             elfutils \
             file \
             gawk \


### PR DESCRIPTION
Instead of depending on the indirect dependencies of whatever else we install.