### PR TITLE
FW: fix repeated --deviceset/cpuset not accumulating

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1325,7 +1325,7 @@ TopologyDetector::TopologyDetector()
 {
 }
 
-void apply_deviceset_param(char *param)
+void apply_deviceset_param(const char *param)
 {
     struct MatchCpuInfoByCpuNumber {
         int cpu_number;

--- a/framework/device/gpu/topology.cpp
+++ b/framework/device/gpu/topology.cpp
@@ -51,7 +51,7 @@ int parse_int(char* arg, const char* orig_arg) {
 /// By "present in the system" we can mean constrained set of cpus enabled by 'taskset'.
 /// TODO: should we allow to specify concrete GPUs/sockets/tiles/whatever (multi-socket GPU)?
 /// TODO: specify concrete physical card, not just the index from the drver (which may change like Gaudi's)
-void apply_deviceset_param(char *param)
+void apply_deviceset_param(const char *param)
 {
     if (SandstoneConfig::RestrictedCommandLine)
         return;

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -2619,7 +2619,9 @@ int main(int argc, char **argv)
     }
 
     if (!opts.deviceset.empty() && any_device) {
-        apply_deviceset_param(&opts.deviceset[0]);
+        for (auto& d : opts.deviceset) {
+            apply_deviceset_param(d);
+        }
     }
 
     static auto check_and_exit_for_no_device = [&]() {

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "sandstone_p.h"
+#include "topology.h"
 #include "sandstone_opts.hpp"
 
 #include <string>
@@ -457,7 +458,7 @@ struct ProgramOptionsParser {
                 break;
 
             case deviceset_option:
-                opts_map.insert_or_assign(deviceset_option, optarg);
+                add_to_map_as_vec(deviceset_option, optarg);
                 break;
 
             // boolean options
@@ -696,7 +697,12 @@ struct ProgramOptionsParser {
         }
 
         // deviceset (before dump_cpu_info)
-        opts.deviceset = string_opt_for<std::string>(deviceset_option);
+        if (opts_map.contains(deviceset_option)) {
+            opts.deviceset =
+                std::get<std::vector<const char*>>(
+                        opts_map.at(deviceset_option)
+                );
+        }
 
         // selftest (before test listing)
 #ifndef NO_SELF_TESTS

--- a/framework/sandstone_opts.hpp
+++ b/framework/sandstone_opts.hpp
@@ -26,7 +26,7 @@ struct ProgramOptions {
     bool fatal_errors = false;
     const char* on_hang_arg = nullptr;
     const char* on_crash_arg = nullptr;
-    std::string deviceset; // not sure about those strings...
+    std::vector<const char*> deviceset;
 
     std::string list_group_name; // for list_group
     bool list_tests_include_descriptions = false; // for list_tests

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -168,7 +168,7 @@ bool pin_to_logical_processor(LogicalProcessor, const char *thread_name = nullpt
 bool pin_thread_to_logical_processor(LogicalProcessor n, tid_t thread_id, const char *thread_name = nullptr);
 bool pin_to_logical_processors(DeviceRange, const char *thread_name);
 
-void apply_deviceset_param(char *param);
+void apply_deviceset_param(const char *param);
 void slice_plan_init(int max_cores_per_slice);
 
 template <typename EnabledDevices>

--- a/framework/unit-tests/opts_parser_tests.cpp
+++ b/framework/unit-tests/opts_parser_tests.cpp
@@ -876,3 +876,28 @@ TEST(ProgramOptionsParser, out_of_range_exits__max_cores_per_slice)
         sb.check_eq(EMPTY_STR); // no messages printed
     }
 }
+
+
+TEST(ProgramOptionsParser, repeated_opt_accumulates__cpuset_deviceset)
+{
+    {
+        StreamBuffer sb;
+        ProgramOptions opts;
+        SandstoneApplicationConfig cfg{};
+        char* argv[] = {
+            (char*)"foo-bar", // binary name
+            (char*)"--cpuset=1",
+            (char*)"--cpuset=2",
+            (char*)"--deviceset=3",
+        };
+
+        auto ret = opts.parse(4, argv, &cfg);
+        EXPECT_FALSE(opts.deviceset.empty());
+        EXPECT_STREQ(opts.deviceset.at(0), "1");
+        EXPECT_STREQ(opts.deviceset.at(1), "2");
+        EXPECT_STREQ(opts.deviceset.at(2), "3");
+
+        EXPECT_EQ(ret, EXIT_SUCCESS);
+        sb.check_eq(EMPTY_STR); // no messages printed
+    }
+}


### PR DESCRIPTION
With multiple --cpuset/deviceset in the cli, the last were overriding the previous ones. 
The intended behavior is for the repeated --cpuset/device to accumulate as described in #634.