### PR TITLE
FW/GPU: handle empty `shmem` in `ZE_CHECK`

### DIFF
--- a/framework/device/gpu/ze_check.h
+++ b/framework/device/gpu/ze_check.h
@@ -16,7 +16,9 @@
     do { \
         auto result = (__VA_ARGS__); \
         if (result != ZE_RESULT_SUCCESS) { \
-            if (thread_num >= 0) { \
+            if (!sApp->shmem) { \
+                fprintf(stderr, "L0 API call failed with status %s\n", to_string(result)); \
+            } else if (thread_num >= 0) { \
                 log_debug("L0 API call failed with status %s", to_string(result)); \
             } else { \
                 logging_printf(LOG_LEVEL_VERBOSE(1), "L0 API call failed with status %s\n", to_string(result)); \


### PR DESCRIPTION
We need additional case when it's too early to call `logging_printf`.