### PR TITLE
FW/Logging: use TLVs for the logging content

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -121,9 +121,9 @@ void KeyValuePairLogger::print_thread_header(int fd, int device, const char *pre
 void KeyValuePairLogger::print_thread_messages()
 {
     auto doprint = [this](PerThreadData::Common *data, int i) {
-        struct mmap_region r = maybe_mmap_log(data);
+        LogMessagesFile r = maybe_mmap_log(data);
 
-        if (r.size == 0 && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
+        if (r.empty() && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
             return;           /* nothing to be printed, on any level */
 
         print_thread_header(file_log_fd, i, timestamp_prefix.c_str());
@@ -322,9 +322,9 @@ void TapFormatLogger::print_thread_header(int fd, int device, LogLevelVerbosity 
 void TapFormatLogger::print_thread_messages()
 {
     auto doprint = [this](PerThreadData::Common *data, int i) {
-        struct mmap_region r = maybe_mmap_log(data);
+        LogMessagesFile r = maybe_mmap_log(data);
 
-        if (r.size == 0 && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
+        if (r.empty() && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
             return;             /* nothing to be printed, on any level */
 
         print_thread_header(file_log_fd, i, LogLevelVerbosity::Max);

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -83,6 +83,9 @@ RtlGetVersion(
 #  include <gnu/libc-version.h>
 #endif
 
+using LogMessage = AbstractLogger::LogMessage;              // for convenience
+using LogMessagesFile = AbstractLogger::LogMessagesFile;    // for convenience
+
 static constexpr const char *levels[] = { "error", "warning", "info", "debug" };
 
 static int tty = -1;
@@ -126,24 +129,6 @@ static const char *strnchr(const char *buffer, char c, size_t len)
     // we do NOT handle an embedded NUL, but the code in this file doesn't do
     // that (crossing fingers, promise)
     return static_cast<const char *>(memchr(buffer, c, len));
-}
-
-static uint8_t message_code(LogTypes logType, LogLevelVerbosity level)
-{
-    assert((int)logType < 0xf);
-    unsigned code = ((unsigned)logType + 1) << 4;
-    code |= (unsigned(level) & 0xf);
-    return (uint8_t)code;
-}
-
-static LogTypes log_type_from_code(uint8_t code)
-{
-    return (LogTypes)((code >> 4) - 1);
-}
-
-static auto level_from_code(uint8_t code)
-{
-    return LogLevelVerbosity(code & 0xf);
 }
 
 static Iso8601Format operator|(Iso8601Format f1, Iso8601Format f2)
@@ -321,10 +306,18 @@ template <typename... Args> static ssize_t
 log_message_for_thread(PerThreadData::Common *thread, LogTypes logType,
                        LogLevelVerbosity level, Args &&... args)
 {
-    int fd = thread->log_fd;
-    uint8_t code = message_code(logType, level);
+    iovec vec[1 + sizeof...(args)] = { {}, IoVecMaker{}(args)... };
+    size_t size_bytes = 0;
+    for (const iovec &v : vec)
+        size_bytes += v.iov_len;
+
+    LogMessage msg = { .msglen = uint32_t(size_bytes), .type = logType, .verbosity = level, };
+    assert(msg.msglen == size_bytes && "too many bytes logged in a single message!");
     thread->messages_logged.fetch_add(1, std::memory_order_relaxed);
-    return writevec(fd, code, std::forward<Args>(args)..., '\0');
+
+    vec[0].iov_base = &msg;
+    vec[0].iov_len = sizeof(msg);
+    return writev(thread->log_fd, vec, std::size(vec));
 }
 
 int logging_stdout_fd(void)
@@ -347,18 +340,18 @@ static inline void truncate_log(int fd)
     IGNORE_RETVAL(ftruncate(fd, 0));
 }
 
-mmap_region AbstractLogger::maybe_mmap_log(const PerThreadData::Common *data)
+AbstractLogger::LogMessagesFile AbstractLogger::maybe_mmap_log(const PerThreadData::Common *data)
 {
     if (data->messages_logged.load(std::memory_order_relaxed) == 0)
         return {};
-    return mmap_file(data->log_fd);
+    return LogMessagesFile(data->log_fd);
 }
 
-void AbstractLogger::munmap_and_truncate_log(PerThreadData::Common *data, mmap_region r)
+void AbstractLogger::munmap_and_truncate_log(PerThreadData::Common *data, LogMessagesFile &r)
 {
-    if (r.size == 0)
+    if (r.empty())
         return;
-    munmap_file(r);
+    r.unmap();
     truncate_log(data->log_fd);
     data->messages_logged.store(0, std::memory_order_relaxed);
 }
@@ -1403,19 +1396,13 @@ static void print_content_single_line(int fd, std::string_view before,
 std::string AbstractLogger::get_skip_message(int thread_num)
 {
     std::string skip_message;
-    struct mmap_region r = mmap_file(sApp->thread_data(thread_num)->log_fd);
-    auto ptr = static_cast<const char *>(r.base);
-    const char *end = ptr + r.size;
-    const char *delim;
-
-    for ( ; ptr < end && (delim = strnchr(ptr, '\0', end - ptr)) != nullptr; ptr = delim + 1) {
-        uint8_t code = (uint8_t)*ptr++;
-        if (log_type_from_code(code) == LogTypes::SkipMessages) {
-            skip_message.assign(ptr, delim);
+    LogMessagesFile msgs(sApp->thread_data(thread_num)->log_fd);
+    for (const LogMessage &msg : msgs) {
+        if (msg.type == LogTypes::SkipMessages) {
+            skip_message.assign(msg);
             break;
         }
     }
-    munmap_file(r);
     return skip_message;
 }
 
@@ -1505,22 +1492,16 @@ void AbstractLogger::format_and_print_message(int fd, std::string_view message, 
 /// (this function is shared between the TAP and key-value pair loggers)
 LogLevelVerbosity
 AbstractLogger::print_one_thread_messages_tdata(int fd, PerThreadData::Common *data,
-                                                struct mmap_region r, LogLevelVerbosity level)
+                                                const LogMessagesFile &msgs, LogLevelVerbosity level)
 {
     LogLevelVerbosity lowest_level = LogLevelVerbosity::Max;
-    auto ptr = static_cast<const char *>(r.base);
-    const char *end = ptr + r.size;
-    const char *delim;
-
-    for ( ; ptr < end && (delim = strnchr(ptr, '\0', end - ptr)) != nullptr; ptr = delim + 1) {
-        uint8_t code = (uint8_t)*ptr++;
-        LogLevelVerbosity message_level = level_from_code(code);
-
+    for (const LogMessage &msg : msgs) {
+        LogLevelVerbosity message_level = msg.verbosity;
         if (message_level > level)
             continue;
 
-        std::string_view message(ptr, delim - ptr);
-        switch (log_type_from_code(code)) {
+        std::string_view message = msg;
+        switch (msg.type) {
         case LogTypes::UserMessages:
             format_and_print_message(fd, message, true);
             break;
@@ -1530,7 +1511,7 @@ AbstractLogger::print_one_thread_messages_tdata(int fd, PerThreadData::Common *d
             break;
 
         case LogTypes::Preformatted:
-            IGNORE_RETVAL(write(fd, ptr, delim - ptr));
+            IGNORE_RETVAL(writevec(fd, message));
             break;
 
         case LogTypes::SkipMessages:
@@ -1853,27 +1834,18 @@ void YamlLogger::maybe_print_slice_resource_usage(int fd, int slice)
             );
 }
 
-int YamlLogger::print_test_knobs(int fd, mmap_region r)
+int YamlLogger::print_test_knobs(int fd, const LogMessagesFile &msgs)
 {
     std::unordered_set<std::string_view> seen_keys;
     int print_count = 0;
-    auto ptr = static_cast<const char *>(r.base);
-    const char *end = ptr + r.size;
-    const char *delim;
-
-    for ( ; ptr < end; ptr = delim + 1) {
-        delim = static_cast<const char *>(memchr(ptr, '\0', end - ptr));
-        if (!delim)
-            break;          // shouldn't happen...
-
-        uint8_t code = uint8_t(*ptr++);
-        if (log_type_from_code(code) != LogTypes::UsedKnobValue)
+    for (const LogMessage &msg : msgs) {
+        if (msg.type != LogTypes::UsedKnobValue)
             continue;
 
         if (print_count++ == 0)
             writeln(fd, indent_spaces(), "  test-options:");
 
-        std::string_view message(ptr, delim - ptr);
+        std::string_view message = msg;
         size_t colon = message.find(':');
         assert(colon != std::string_view::npos);
 
@@ -1916,29 +1888,20 @@ void YamlLogger::format_and_print_skip_reason(int fd, std::string_view message)
     }
 }
 
-inline LogLevelVerbosity YamlLogger::print_one_thread_messages(int fd, mmap_region r, LogLevelVerbosity level)
+inline LogLevelVerbosity
+YamlLogger::print_one_thread_messages(int fd, const LogMessagesFile &msgs, LogLevelVerbosity level)
 {
     LogLevelVerbosity lowest_level = LogLevelVerbosity::Max;
-    auto ptr = static_cast<const char *>(r.base);
-    const char *end = ptr + r.size;
-    const char *delim;
-
-    for ( ; ptr < end; ptr = delim + 1) {
-        delim = static_cast<const char *>(memchr(ptr, '\0', end - ptr));
-        if (!delim)
-            break;          // shouldn't happen...
-
-        uint8_t code = uint8_t(*ptr++);
-        LogLevelVerbosity message_level = level_from_code(code);
-
+    for (const LogMessage &msg : msgs) {
+        LogLevelVerbosity message_level = msg.verbosity;
         if (message_level > level)
             continue;
 
-        std::string_view message(ptr, delim - ptr);
+        std::string_view message = msg;
         if (message.empty())
             continue;       // shouldn't happen...
 
-        switch (log_type_from_code(code)) {
+        switch (msg.type) {
         case LogTypes::UserMessages:
             assert(size_t(message_level) < std::size(levels));
             format_and_print_message(fd, levels[size_t(message_level)], message);
@@ -2090,13 +2053,12 @@ void YamlLogger::print_fixed()
     print_fixed_for_device();
 
     if (sApp->shmem->cfg.log_test_knobs) {
-        struct mmap_region main_mmap = maybe_mmap_log(sApp->main_thread_data());
-        if (main_mmap.size) {
+        LogMessagesFile main_mmap = maybe_mmap_log(sApp->main_thread_data());
+        if (!main_mmap.empty()) {
             int count = print_test_knobs(file_log_fd, main_mmap);
             if (count && real_stdout_fd != file_log_fd
                     && sApp->shmem->cfg.verbosity >= UsedKnobValueLoggingLevel)
                 print_test_knobs(real_stdout_fd, main_mmap);
-            munmap_file(main_mmap);
         }
     }
 }
@@ -2105,7 +2067,7 @@ void YamlLogger::print_thread_messages()
 {
     // print the thread messages
     auto doprint = [this](PerThreadData::Common *data, int s_tid) {
-        struct mmap_region r = maybe_mmap_log(data);
+        LogMessagesFile r = maybe_mmap_log(data);
         bool want_print = data->has_failed() || sApp->shmem->cfg.verbosity >= 3;
         ssize_t min_size = 0;
 
@@ -2116,7 +2078,7 @@ void YamlLogger::print_thread_messages()
             min_size = init_skip_message_bytes;
             want_print = want_slice_resource_usage(~s_tid);
         }
-        if (r.size <= min_size && !want_print) {
+        if (r.size_bytes() <= min_size && !want_print) {
             munmap_and_truncate_log(data, r);
             return;             /* nothing to be printed, on any level */
         }

--- a/framework/logging.h
+++ b/framework/logging.h
@@ -31,6 +31,56 @@ class AbstractLogger
 public:
     enum class LogTypes : uint8_t;
 
+    struct [[gnu::packed]] LogMessage {
+        uint32_t msglen;
+        LogTypes type;
+        LogLevelVerbosity verbosity;
+        char payload[];         // C99 Flexible Array Member
+
+        operator std::string_view() const noexcept
+        { return { payload, msglen }; }
+        operator std::span<const uint8_t>() const noexcept
+        { return { reinterpret_cast<const uint8_t *>(payload), msglen }; }
+    };
+
+    class LogMessagesFile {
+        mmap_region r;
+    public:
+        struct const_iterator {
+            const LogMessage *ptr;
+
+            // just enough iterator API to work for us
+            using value_type = LogMessage;
+            using iterator_category = std::forward_iterator_tag;
+
+            friend auto operator<=>(const_iterator, const_iterator) = default;
+            const LogMessage &operator*() const { return *ptr; }
+            const LogMessage *operator->() const { return ptr; }
+            const_iterator operator++(int) noexcept
+            { return { reinterpret_cast<const LogMessage *>(ptr->payload + ptr->msglen) }; }
+            const_iterator &operator++() noexcept
+            { return *this = (*this)++; }
+        };
+
+        LogMessagesFile() noexcept : r{} {}
+        explicit LogMessagesFile(mmap_region r) noexcept : r(r) {}
+        LogMessagesFile(int fd) : LogMessagesFile(mmap_file(fd)) {}
+        LogMessagesFile(const LogMessagesFile &) = delete;
+        LogMessagesFile(LogMessagesFile &&other) : r(std::exchange(other.r, {})) {}
+        ~LogMessagesFile() { unmap(); }
+        LogMessagesFile &operator=(const LogMessagesFile &) = delete;
+        LogMessagesFile &operator=(LogMessagesFile &&) = delete;
+
+        bool empty() const { return r.size == 0; }
+        const_iterator begin() const
+        { return { static_cast<const LogMessage *>(r.base) }; }
+        const_iterator end() const
+        { return { reinterpret_cast<const LogMessage *>(static_cast<const char *>(r.base) + r.size) }; }
+
+        size_t size_bytes() const { return r.size; }
+        void unmap() { if (r.size) munmap_file(r); r = {}; }
+    };
+
     AbstractLogger(const struct test *test, std::span<const ChildExitStatus> state);
 
     static constexpr char program_version[] = SANDSTONE_EXECUTABLE_NAME "-" GIT_ID;
@@ -41,8 +91,8 @@ public:
     static std::string log_timestamp();
     static std::string get_skip_message(int thread_num);
     static const char *char_to_skip_category(int val);
-    static mmap_region maybe_mmap_log(const PerThreadData::Common *data);
-    static void munmap_and_truncate_log(PerThreadData::Common *data, mmap_region r);
+    static LogMessagesFile maybe_mmap_log(const PerThreadData::Common *data);
+    static void munmap_and_truncate_log(PerThreadData::Common *data, LogMessagesFile &r);
     static void print_child_stderr_common(std::function<void(int)> header);
     static std::string_view indent_spaces();
 
@@ -75,7 +125,8 @@ protected:
 
     // shared between the TAP and key-value loggers; YAML overrides
     static void format_and_print_message(int fd, std::string_view message, bool from_thread_message);
-    LogLevelVerbosity print_one_thread_messages_tdata(int fd, PerThreadData::Common *data, struct mmap_region r, LogLevelVerbosity level);
+    LogLevelVerbosity print_one_thread_messages_tdata(int fd, PerThreadData::Common *data,
+                                                      const LogMessagesFile &msgs, LogLevelVerbosity level);
 };
 
 class YamlLogger : public AbstractLogger
@@ -110,9 +161,9 @@ private:
     void print_thread_header(int fd, int device, LogLevelVerbosity verbosity);
     inline bool want_slice_resource_usage(int slice);
     void maybe_print_slice_resource_usage(int fd, int slice);
-    inline int print_test_knobs(int fd, mmap_region r);
+    inline int print_test_knobs(int fd, const LogMessagesFile &msgs);
     static void format_and_print_skip_reason(int fd, std::string_view message);
-    LogLevelVerbosity print_one_thread_messages(int fd, mmap_region r, LogLevelVerbosity level);
+    LogLevelVerbosity print_one_thread_messages(int fd, const LogMessagesFile &msgs, LogLevelVerbosity level);
     void print_result_line(int &init_skip_message_bytes);
 };
 

--- a/framework/sandstone_iovec.h
+++ b/framework/sandstone_iovec.h
@@ -13,40 +13,43 @@
 #include <unistd.h>
 
 namespace {
+struct IoVecMaker
+{
+    struct iovec operator()(struct iovec vec)
+    {
+        return vec;
+    }
+
+    struct iovec operator()(const void *ptr, size_t size)
+    {
+        return { .iov_base = const_cast<void *>(ptr), .iov_len = size };
+    }
+
+    struct iovec operator()(std::string_view str)
+    {
+        return operator()(str.data(), str.size());
+    }
+
+    struct iovec operator()(const char *str)
+    {
+        return operator()(str, strlen(str));
+    }
+
+    struct iovec operator()(const char &c)
+    {
+        return operator()(&c, 1);
+    }
+
+    struct iovec operator()(const uint8_t &b)
+    {
+        return operator()(&b, 1);
+    }
+};
+
 template <typename... Args>
 inline ssize_t writevec(int fd, const Args &... args)
 {
-    struct IoVecMaker {
-        struct iovec operator()(struct iovec vec)
-        {
-            return vec;
-        }
-
-        struct iovec operator()(const void *ptr, size_t size)
-        {
-            return { .iov_base = const_cast<void *>(ptr), .iov_len = size };
-        }
-
-        struct iovec operator()(std::string_view str)
-        {
-            return operator()(str.data(), str.size());
-        }
-
-        struct iovec operator()(const char *str)
-        {
-            return operator()(str, strlen(str));
-        }
-
-        struct iovec operator()(const char &c)
-        {
-            return operator()(&c, 1);
-        }
-
-        struct iovec operator()(const uint8_t &b)
-        {
-            return operator()(&b, 1);
-        }
-    } maker;
+    IoVecMaker maker;
 
     iovec vec[] = { maker(args)... };
     return writev(fd, vec, std::size(vec));


### PR DESCRIPTION
Type-Length-Value (or length-type-payload, for us) are superior in that they don't depend on a sentinel value, which we've used \0 for. We don't need to memchr() to find the bound of the payload, if we have the length.

This does increase the overhead from 1 to 6 bytes, but it also increases the number of possible log types from 16 to 256.