### PR TITLE
FW/GPU: add script for compiling OpenCL kernels

### DIFF
--- a/framework/device/gpu/scripts/compile-embed-ze-kernel.py
+++ b/framework/device/gpu/scripts/compile-embed-ze-kernel.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+# Copyright 2026 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import tempfile
+import subprocess
+import sys
+import os
+
+# ocloc's -cpp_file option would emit the array for us, but only for the .bin file.
+# We would still have to do it manually for spirv. For this reason I prefer to create
+# both arrays by hand and at least maintain format coherency <ChangeMyMind>
+def compile_spirv(source_file):
+    with tempfile.NamedTemporaryFile(suffix='.bc') as fp:
+        compile_args = ['clang++', '-c', '-target', 'spir64', '-O0', '-emit-llvm', '-o', fp.name, source_file]
+        compile_proc = subprocess.Popen(compile_args, stdout=subprocess.PIPE)
+        stdout = compile_proc.communicate()[0]
+        if compile_proc.returncode != 0:
+            return compile_proc.returncode, stdout
+
+        spirv_args = ['llvm-spirv', fp.name]
+        spirv_proc = subprocess.Popen(spirv_args, stdout=subprocess.PIPE)
+        stdout = spirv_proc.communicate()[0]
+        if spirv_proc.returncode != 0:
+            return spirv_proc.returncode, stdout
+
+        binary_contents = open(fp.name[:-3] + '.spv', mode='rb').read()
+        return 0, binary_contents
+
+
+def compile_bin(source_file, device):
+    # TODO what does -gen_file option actually do? What is .gen file? Could it be useful in our code?
+    ocloc_args = ['ocloc', '-file', source_file, '-device', device, '-output_no_suffix']
+    ocloc_proc = subprocess.Popen(ocloc_args, stdout=subprocess.PIPE)
+    stdout = ocloc_proc.communicate()[0]
+    if ocloc_proc.returncode != 0:
+        return ocloc_proc.returncode, stdout
+
+    binary_contents = open(os.path.splitext(os.path.basename(source_file))[0] + '.bin', mode='rb').read()
+    return 0, binary_contents
+
+
+def embed(array_name, compilation_output):
+    print('// DO NOT EDIT, AUTO-GENERATED\n')
+    print('#include <cstdint>\n')
+    print(f'namespace {array_name} {{')
+    print(f'static constexpr uint8_t kernel_source[] = {{\n', end='    ')
+
+    bytes_output = list(compilation_output)
+    for b in bytes_output[:-1]:
+        print(f'{hex(b)}', end=', ')
+    print(f'{hex(bytes_output[-1])}')
+
+    print('};')
+    print('static constexpr auto kernel_size = std::size(kernel_source);')
+    print('}\n')
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(
+        description='Compile OpenCL kernel and translate to a C byte array')
+    p.add_argument('array_name', help='Name of the C byte array')
+    p.add_argument('source', help='Path to OpenCL source file')
+    p.add_argument('device', help='Device type (bmg/spirv/...)')
+
+    args = p.parse_args()
+
+    if (args.device == "spirv"):
+        ret, out = compile_spirv(args.source)
+    else:
+        ret, out = compile_bin(args.source, args.device)
+
+    if (ret == 0):
+        embed(args.array_name, out)
+    else:
+        sys.exit(out.decode())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -35,3 +35,5 @@ option('coverage', type : 'boolean', value : false,
     description : 'Enable code coverage (default false)')
 option('device_type', type: 'combo', choices : ['cpu', 'gpu'], value: 'cpu',
     description : 'Device type for the build (default cpu).')
+option('target_device', type : 'string', value: 'bmg',
+    description : 'Type of the device to be used for the build. Run `ocloc compile --help` for a full list of available device types. Defaults to "bmg". For SPIR-V intermediate format use "spirv".')

--- a/tests/gpu/meson.build
+++ b/tests/gpu/meson.build
@@ -6,6 +6,22 @@ setmod = import('sourceset')
 tests_config = configuration_data()
 tests_set_base = setmod.source_set()
 
+target_device = get_option('target_device')
+
+level_zero_kernels_generator_script = find_program(
+    'compile-embed-ze-kernel.py',
+    dirs : [ meson.project_source_root() / 'framework' / 'device' / 'gpu' / 'scripts', ],
+)
+
+level_zero_kernels_generator = generator(
+    level_zero_kernels_generator_script,
+    arguments : [
+        '@BASENAME@', '@INPUT@', target_device
+    ],
+    capture : true,
+    output : '@BASENAME@_source.h',
+)
+
 tests_common_c_args = [
     debug_c_flags,
     default_c_warn,
@@ -23,17 +39,26 @@ tests_common_incdirs = [
 ]
 
 # fill with tests
-# tests_set_base.add(
-#     files(
-#
-#     )
-# )
+tests_set_base.add(
+    files(
+
+    )
+)
+
+# fill with OpenCL kernels if used by tests
+level_zero_kernel_sources = files(
+
+)
 
 tests_config_base = tests_set_base.apply(tests_config)
+# level_zero_kernels_headers = level_zero_kernels_generator.process(level_zero_kernel_sources)
 
 tests_base_a = static_library(
     'tests_base',
-    sources : tests_config_base.sources(),
+    sources : [
+        tests_config_base.sources(),
+        # level_zero_kernels_headers,
+    ],
     build_by_default: false,
     include_directories : [
         tests_common_incdirs,


### PR DESCRIPTION
Tests would use OpenCL kernels which require a separate compilation process. A new build option `target_device` allows for choosing between SPIRV and native format. SPIRV is planned to be debug, rather than production format. Default is set to native "bmg" for now. Compiled sources are included in a generated header file as a byte array. This way kernel sources are embedded into the binary. This is the only way, since L0 API requires raw source bytes to load a kernel.