### PR TITLE
FW/GPU: implement `dump_device_info`

### DIFF
--- a/framework/device/gpu/gpu_device.cpp
+++ b/framework/device/gpu/gpu_device.cpp
@@ -5,8 +5,10 @@
 
 #include <sandstone_p.h>
 #include "gpu_device.h"
+#include "topology_gpu.h"
 
 #include <string>
+#include <print>
 
 bool logging_in_test = false;
 
@@ -16,9 +18,36 @@ std::string device_features_to_string(device_features_t f)
     return result;
 }
 
+namespace {
+void dump_single_gpu(gpu_info_t* info)
+{
+    std::print("{}\t", info->gpu_number);
+    if (info->subdevice_index != -1) {
+        std::print("{}/{}\t", info->device_index, info->subdevice_index);
+    } else {
+        std::print("{}\t", info->gpu_number);
+    }
+
+    std::print("{:04x}:{:02x}:{:02x}.{:01x}\t",
+        info->bdf.domain, info->bdf.bus, info->bdf.device, info->bdf.function
+    );
+    const auto& uuid = info->device_properties.uuid.id;
+    std::print(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}\t",
+        uuid[15], uuid[14], uuid[13], uuid[12], uuid[11], uuid[10], uuid[9], uuid[8],
+        uuid[7],  uuid[6],  uuid[5],  uuid[4],  uuid[3],  uuid[2],  uuid[1], uuid[0]
+    );
+    std::print("{}\n", info->device_properties.name);
+}
+}
+
 void dump_device_info()
 {
-
+    printf("#GPU\t#Topo\tPCI-addr\tUUID\t\t\t\t\tModel\n");
+    for_each_topo_device([&](gpu_info_t& info) {
+        dump_single_gpu(&info);
+        return EXIT_SUCCESS;
+    });
 }
 
 TestResult prepare_test_for_device(struct test *test)


### PR DESCRIPTION
Example output:
```
$ ./opendcdiag --dump-device-info
#GPU    #Topo   PCI-addr        UUID                                    Model
0       0       0000:19:00.0    00000000-0000-0019-0000-0000e20b8086    Intel(R) Arc(TM) B580 Graphics
```
