### PR TITLE
CI/bats: Fix always-skipping thread queue reschedule

### DIFF
--- a/bats/sanity-check/25-cpu-topology.bats
+++ b/bats/sanity-check/25-cpu-topology.bats
@@ -542,7 +542,13 @@ selftest_cpuset_negated() {
 # Confirm we are rescheduling properly
 @test "thread queue reschedule" {
     PLATFORM=$(uname -m)
-    [[ "${PLATFORM}" != "x86_64" || ${is_windows} ]] && skip "Not supported"
+    if [[ "${PLATFORM}" != "x86_64" ]]; then
+        skip "Not supported"
+    fi
+
+    if $is_windows; then
+       skip "Reschedule isn't supported "
+    fi
 
     run $SANDSTONE --selftests -e selftest_logs_reschedule --reschedule=queue
     [[ $status == 64 ]] && false


### PR DESCRIPTION
Test was always skipped because of a malformed conditional statement in the check section.