### PR TITLE
FW/Unix: fix detection and reporting of virtualisation/container state

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -223,6 +223,13 @@ tap_negative_check() {
     test_yaml_numeric "/timing/duration" 'value == 1234'
     test_yaml_numeric "/timing/timeout" 'value == 12345'
 
+    if vm=`cat /sys/hypervisor/type 2>/dev/null`; then
+        test_yaml_expr "/virtualization-state/vm" = "$vm"
+    fi
+    if container=`cat /run/host/container-manager 2>/dev/null`; then
+        test_yaml_expr "/virtualization-state/container" = "$container"
+    fi
+
     if [[ "$SANDSTONE_DEVICE_TYPE" = "CPU" ]]; then
         # just verify these exist
         local machine=`uname -m`


### PR DESCRIPTION
First, the code failed to compile on an older GCC 11 we still have to support, because `resize_and_overwrite()` isn't available there. Second, it crashed if `systemd-detect-virt` wasn't present, resulting in an empty output.

But more importantly, we don't need `systemd-detect-virt` at all. Thanks to @fenrus75 for the hint of which files to open (on Linux) to get the information we needed anyway.

Fixes #969.