### PR TITLE
FW/Opts: treat non-arguments as test names

### DIFF
--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -645,6 +645,20 @@ struct ProgramOptionsParser {
                 return EX_USAGE;
             }
         }
+
+        // attempt to treat positional arguments as test names
+        if (optind < argc) {
+            bool should_parse_positional_args = strcmp(argv[optind - 1], "--") == 0;
+            for (auto i = optind; i < argc; i++) {
+                if (should_parse_positional_args) {
+                    add_to_map_as_vec('e', argv[i]);
+                } else {
+                    fprintf(ERR_STREAM, "%s: option '%s' is ignored - positional arguments should be put after --\n",
+                        program_invocation_name, argv[i]);
+                }
+            }
+        }
+
         return EXIT_SUCCESS;
     }
 


### PR DESCRIPTION
So far they were always ignored which was confusing. Now they are attempted to be added to the enabled tests list, but only when they come after `--`. Otherwise a warning is emitted.
```
$ build/opendcdiag -e zlib -- zlib2
build/opendcdiag: Cannot find matching tests for 'zlib2'
$ build/opendcdiag -e zlib zlib2
build/opendcdiag: option 'zlib2' is ignored - positional arguments should be put after --
command-line: 'opendcdiag -e zlib zlib2'
version: opendcdiag-5ebccb2ff82b
exit: pass
```