### PR TITLE
FW/Win32: don't make function calls for `GetCurrentThread()`

### DIFF
--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -10,6 +10,10 @@
 
 #include <windows.h>
 
+#ifndef GetCurrentThread
+#  define GetCurrentThread()    HANDLE(-2)
+#endif
+
 static constexpr unsigned MaxLogicalProcessorsPerGroup =
         std::numeric_limits<KAFFINITY>::digits;
 


### PR DESCRIPTION
Its value is always -2. The API docs[1] say "the return value is a pseudo handle for the current thread".

[1] https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentthread