### PR TITLE
FW: implement rescheduling for `-fexec` mode

### DIFF
--- a/bats/sanity-check/25-cpu-topology.bats
+++ b/bats/sanity-check/25-cpu-topology.bats
@@ -599,10 +599,6 @@ function selftest_cpuset_accumulate() {
         skip "Not supported"
     fi
 
-    if $is_windows; then
-       skip "Reschedule isn't supported "
-    fi
-
     run $SANDSTONE --selftests -e selftest_logs_reschedule --reschedule=queue
     [[ $status == 64 ]] && false
 

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -128,16 +128,17 @@ int num_packages()
     return Topology::topology().packages.size();
 }
 
-DeviceScheduler *make_rescheduler(RescheduleMode mode)
+void make_rescheduler(RescheduleMode mode)
 {
+    if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::exec_each_test)
+        return; // we'll be called again in the child
     if (mode == RescheduleMode::barrier) {
-        return new BarrierDeviceScheduler();
+        device_scheduler = new BarrierDeviceScheduler();
     } else if (mode == RescheduleMode::queue || mode == RescheduleMode::unset) {
-        return new QueueDeviceScheduler();
+        device_scheduler = new QueueDeviceScheduler();
     } else if (mode == RescheduleMode::random) {
-        return new RandomDeviceScheduler();
+        device_scheduler = new RandomDeviceScheduler();
     }
-    return nullptr;
 }
 
 namespace {

--- a/framework/device/gpu/topology.cpp
+++ b/framework/device/gpu/topology.cpp
@@ -25,9 +25,8 @@ int num_packages()
     return 1;
 }
 
-DeviceScheduler *make_rescheduler(RescheduleMode mode)
+void make_rescheduler(RescheduleMode)
 {
-    return nullptr;
 }
 
 namespace {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -558,6 +558,7 @@ static int exec_mode_run(int argc, char **argv)
 
     logging_init_global_child();
     random_init_global(argv[1]);
+    make_rescheduler(sApp->shmem->cfg.reschedule_mode);
 
     return test_result_to_exit_code(child_run(tests_to_run.at(0), child_number));
 }
@@ -996,20 +997,13 @@ int main(int argc, char **argv)
         logging_printf(LOG_LEVEL_QUIET, "# WARNING: --reschedule is only useful with at least 2 cores, ignoring\n");
         sApp->shmem->cfg.reschedule_mode = RescheduleMode::none;
     }
-    device_scheduler = make_rescheduler(sApp->shmem->cfg.reschedule_mode);
+    make_rescheduler(sApp->shmem->cfg.reschedule_mode);
 
     if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::exec_each_test) {
         if (sApp->shmem->cfg.log_test_knobs) {
             fprintf(stderr, "%s: error: --test-option is not supported in this configuration\n",
                     program_invocation_name);
             return EX_USAGE;
-        }
-        if (device_scheduler) {
-            delete device_scheduler;
-            device_scheduler = nullptr;
-#ifndef _WIN32
-            logging_printf(LOG_LEVEL_VERBOSE(1), "# WARNING: --reschedule is not supported in this configuration\n");
-#endif
         }
     }
 

--- a/framework/sysdeps/freebsd/cpu_affinity.cpp
+++ b/framework/sysdeps/freebsd/cpu_affinity.cpp
@@ -6,9 +6,9 @@
 #include <pthread.h>
 #include <pthread_np.h>
 
-static void set_thread_name(const char *thread_name)
+static void set_thread_name(tid_t tid, const char *thread_name)
 {
-    if (thread_name)
+    if (tid == 0 && thread_name)
         pthread_set_name_np(pthread_self(), thread_name);
 }
 

--- a/framework/sysdeps/linux/cpu_affinity.cpp
+++ b/framework/sysdeps/linux/cpu_affinity.cpp
@@ -14,9 +14,9 @@
 #ifdef __linux__
 #include <sys/prctl.h>
 
-static void set_thread_name(const char *thread_name)
+static void set_thread_name(tid_t tid, const char *thread_name)
 {
-    if (thread_name)
+    if (tid == 0 && thread_name)
         prctl(PR_SET_NAME, thread_name);
 }
 #endif
@@ -49,7 +49,7 @@ bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
 
 bool pin_thread_to_logical_processor(LogicalProcessor n, tid_t thread_id, const char *thread_name)
 {
-    set_thread_name(thread_name);
+    set_thread_name(thread_id, thread_name);
     if (n == LogicalProcessor(-1))
         return true;            // don't change affinity
 
@@ -70,7 +70,7 @@ bool pin_thread_to_logical_processor(LogicalProcessor n, tid_t thread_id, const 
 
 bool pin_to_logical_processors(DeviceRange range, const char *thread_name)
 {
-    set_thread_name(thread_name);
+    set_thread_name(0, thread_name);
 
     // find the maximum CPU number
     int n = 0;

--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -80,6 +80,9 @@ bool pin_to_logical_processor(LogicalProcessor n, const char *thread_name)
 
 bool pin_thread_to_logical_processor(LogicalProcessor n, tid_t thread_id, const char *thread_name)
 {
+    if (thread_id == 0)
+        return pin_to_logical_processor(n, thread_name);
+
     HANDLE hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, thread_id);
     bool ret = pin_handle_to_logical_processor(n, hThread, thread_name);
     CloseHandle(hThread);

--- a/framework/sysdeps/windows/cpu_affinity.cpp
+++ b/framework/sysdeps/windows/cpu_affinity.cpp
@@ -48,14 +48,15 @@ static constexpr PROCESSOR_NUMBER to_processor_number(LogicalProcessor lp)
     return n;
 }
 
-static void set_thread_name(const char *thread_name)
+static void set_thread_name(HANDLE hThread, const char *thread_name)
 {
+    (void) hThread;
     (void) thread_name;
 }
 
 bool pin_handle_to_logical_processor(LogicalProcessor n, HANDLE hThread, const char *thread_name)
 {
-    set_thread_name(thread_name);
+    set_thread_name(hThread, thread_name);
     if (n == LogicalProcessor(-1))
         return true;            // don't change affinity
 
@@ -87,7 +88,7 @@ bool pin_thread_to_logical_processor(LogicalProcessor n, tid_t thread_id, const 
 
 bool pin_to_logical_processors(DeviceRange range, const char *thread_name)
 {
-    set_thread_name(thread_name);
+    set_thread_name(GetCurrentThread(), thread_name);
     const device_info_t *first_cpu = &device_info[range.starting_device];
     const device_info_t *last_cpu = &device_info[range.starting_device + range.device_count - 1];
     PROCESSOR_NUMBER first = to_processor_number(LogicalProcessor(first_cpu->cpu_number));

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -33,7 +33,7 @@ struct DeviceScheduler
     virtual void finish_reschedule() = 0;
 };
 
-DeviceScheduler *make_rescheduler(RescheduleMode mode);
+void make_rescheduler(RescheduleMode mode);
 
 using PerThreadFailures = std::vector<__uint128_t>;
 


### PR DESCRIPTION
Which includes Windows. It's easier to just implement it than to deal with it sometimes being unavailable.

This reverts fc661358e7d4f7b154c2cbfbf9cfa3d9f9e0c710 (PR #1042).

This PR includes a bugfix for calling `pin_thread_to_logical_processor()` on Windows, revealed by this change. Two of the three calls sites to cpu/topology.cpp's `pin_to_next_cpu()` use `thread_id = 0` indicating the current thread. That caused `OpenThread()` to fail with `GetLastError() = ERROR_INVALID_PARAMETER`.