### PR TITLE
Explicitly set name of the output binary when compiling gpu kernels.

### DIFF
--- a/framework/device/gpu/scripts/compile-embed-ze-kernel.py
+++ b/framework/device/gpu/scripts/compile-embed-ze-kernel.py
@@ -31,7 +31,9 @@ def compile_spirv(source_file):
 
 def compile_bin(source_file, device, language):
     # TODO what does -gen_file option actually do? What is .gen file? Could it be useful in our code?
-    ocloc_args = ['ocloc', '-file', source_file, '-device', device, '-output_no_suffix']
+    filename, _ = os.path.splitext(os.path.basename(source_file))
+    out_filename = f"{filename}.bin"
+    ocloc_args = ['ocloc', '-file', source_file, '-device', device, '-o', out_filename]
     if language == 'CMC':
         ocloc_args += ['-options', '-cmc']
     ocloc_proc = subprocess.Popen(ocloc_args, stdout=subprocess.PIPE)
@@ -39,7 +41,7 @@ def compile_bin(source_file, device, language):
     if ocloc_proc.returncode != 0:
         return ocloc_proc.returncode, stdout
 
-    binary_contents = open(os.path.splitext(os.path.basename(source_file))[0] + '.bin', mode='rb').read()
+    binary_contents = open(out_filename, mode='rb').read()
     return 0, binary_contents
 
 


### PR DESCRIPTION
Commit modifies the script used to compile and embed the Level Zero kernels into the final binary. ocloc produces files with different extensions, depending on other command line options. Specifically, when the -device option contains more than one target device, ocloc compiles all targets into a single binary file with 'ar' extension.

By explicitly stating the name of the output file, we can ensure that the file created by ocloc will not change its extension when building for multiple devices.