### PR TITLE
FW/Logging: delay destroying the callback until threads have finished

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1556,6 +1556,11 @@ function selftest_logerror_common() {
             Float16)            type=_Float16;;
             long_double)        type=_Float64x;;
         esac
+        local description="data of type '$type'"
+        case "$type" in
+            uint8_t)            description='';;
+        esac
+
         sandstone_selftest -vvv -e $test
         set -e
         fail_common
@@ -1570,6 +1575,7 @@ function selftest_logerror_common() {
             test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/mask" '0x[0-9a-f]+'
             test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/actual data" '[0-9a-f ]+'
             test_yaml_regexp "/tests/0/threads/$i/messages/0/data-miscompare/expected data" '[0-9a-f ]+'
+            test_yaml_expr "/tests/0/threads/$i/messages/0/data-miscompare/description" = "$description"
         done
     done
 }

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1545,7 +1545,7 @@ function selftest_logerror_common() {
 @test "selftest_datacompare" {  # also "_with_cb" version
     declare -A yamldump
     local dataregexp='0x[0-9a-f]+( \(([-0-9]+|[-+0-9a-fpx.]+)\))?'
-    for test in `$SANDSTONE --selftests --list-tests | sed -n '/^selftest_datacomparefail/s/\r$//p'`; do
+    for test in `$SANDSTONE --selftests --list-tests | sed -n '/^selftest_datacomparefail_/s/\r$//p'`; do
         type=${test#selftest_datacomparefail_}
         case "$type" in
             Float16)            type=_Float16;;

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1547,6 +1547,7 @@ function selftest_logerror_common() {
     local dataregexp='0x[0-9a-f]+( \(([-0-9]+|[-+0-9a-fpx.]+)\))?'
     for test in `$SANDSTONE --selftests --list-tests | sed -n '/^selftest_datacomparefail_/s/\r$//p'`; do
         type=${test#selftest_datacomparefail_}
+        type=${type%_with_cb}   # if any
         case "$type" in
             Float16)            type=_Float16;;
             long_double)        type=_Float64x;;

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1545,7 +1545,11 @@ function selftest_logerror_common() {
 @test "selftest_datacompare" {  # also "_with_cb" version
     declare -A yamldump
     local dataregexp='0x[0-9a-f]+( \(([-0-9]+|[-+0-9a-fpx.]+)\))?'
-    for test in `$SANDSTONE --selftests --list-tests | sed -n '/^selftest_datacomparefail_/s/\r$//p'`; do
+    local testlist=($($SANDSTONE --selftests --list-tests | sed -n '/^selftest_datacomparefail_/{s/\r$//;p;}'))
+    ((${#testlist[@]} > 0))      # ensure we've found at least one
+    for test in ${testlist[@]}; do
+        printf '# %s\n' "$test" >&3     # print as progress report
+
         type=${test#selftest_datacomparefail_}
         type=${type%_with_cb}   # if any
         case "$type" in

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -640,8 +640,8 @@ void logging_run_callback()
 
     // make sure so we don't recurse in case the callback calls log_error()
     thr->thread_flags |= uint32_t(PerThreadData::Common::Flag::CallbackCalled);
-    if (!SandstoneConfig::NoLogging && sApp->current_test_failure_callback.cb)
-        sApp->current_test_failure_callback.cb(sApp->current_test_failure_callback.token);
+    if (!SandstoneConfig::NoLogging && sApp->current_test_failure_callback.call)
+        sApp->current_test_failure_callback.call(sApp->current_test_failure_callback.token);
 }
 
 static void log_message_preformatted(int thread_num, std::string_view msg)
@@ -949,7 +949,6 @@ void logging_flush(void)
 
 void logging_init(const struct test *test)
 {
-    sApp->current_test_failure_callback = {};
     if (sApp->shmem->cfg.verbosity <= 0)
         progress_bar_update();
 
@@ -1052,12 +1051,22 @@ void log_message(int thread_num, const char *fmt, ...)
 }
 
 #if SANDSTONE_NO_LOGGING == 0
-void install_failure_callback(void (*cb)(void *), void *token)
+void install_failure_callback(void (*cb)(void *), void *token, void (*cleanup)(void *))
 {
     assert(thread_num < 0 && "callbacks can only be installed from the main thread");
     sApp->current_test_failure_callback.token = token;
-    sApp->current_test_failure_callback.cb = cb;
+    sApp->current_test_failure_callback.call = cb;
+    sApp->current_test_failure_callback.cleanup = cleanup;
 }
+
+void logging_cleanup_failure_callback() noexcept
+{
+    if (sApp->current_test_failure_callback.cleanup)
+        sApp->current_test_failure_callback.cleanup(sApp->current_test_failure_callback.token);
+    sApp->current_test_failure_callback = {};
+}
+#else
+void logging_cleanup_failure_callback() noexcept {}
 #endif
 
 /// Escapes \c{message} suitable for a single-quote YAML line and returns it.

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -405,8 +405,9 @@ extern void _memcmp_fail_report(const void *actual, const void *expected, size_t
 /// the test's run function). The callback is called at most once per thread.
 ///
 /// This function must be called from the main thread (usually, from the test's
-/// init function).
-extern void install_failure_callback(void (*cb)(void *), void *token);
+/// init function). The @p cleanup callback, if not a null pointer, will be
+/// called from the main thread between after the test's cleanup function.
+extern void install_failure_callback(void (*cb)(void *), void *token, void (*cleanup)(void *));
 
 /// can be called from a test's test_run function to fail the test.
 /// This macro will kill the calling thread and cause the test to
@@ -601,13 +602,16 @@ template <typename Callback> void install_failure_callback(Callback cb)
 {
     using Stateless = void (*)();
     if constexpr (std::is_constructible_v<Stateless, Callback>) {
-        install_failure_callback(reinterpret_cast<void (*)(void *)>(+cb), nullptr);
+        install_failure_callback(reinterpret_cast<void (*)(void *)>(+cb), nullptr, nullptr);
     } else {
+        auto call_cb = [](void *token) {
+            (*static_cast<Callback *>(token))();
+        };
+        auto cleanup_cb = [](void *token) {
+            delete static_cast<Callback *>(token);
+        };
         auto copy = new Callback(std::forward<Callback>(cb));
-        install_failure_callback([](void *token) {
-            std::unique_ptr<Callback> self(static_cast<Callback *>(token));
-            (*self)();
-        }, copy);
+        install_failure_callback(call_cb, copy, cleanup_cb);
     }
 }
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -358,9 +358,10 @@ struct SandstoneApplication : SandstoneApplicationConfig, public test_the_test_d
     int threshold_time_remaining = 30000;
 
     struct {
-        void (*cb)(void *);
+        void (*call)(void *);
+        void (*cleanup)(void *);
         void *token;
-    } current_test_failure_callback;
+    } current_test_failure_callback = {};
 
     std::unique_ptr<RandomEngineWrapper, RandomEngineDeleter> random_engine;
 #if SANDSTONE_FREQUENCY_MANAGER
@@ -624,6 +625,7 @@ void logging_restricted(LogLevelVerbosity level, const char *fmt, ...);
 void logging_printf(LogLevelVerbosity level, const char *msg, ...) ATTRIBUTE_PRINTF(2, 3);
 void logging_mark_thread_failed(int thread_num) noexcept;
 void logging_mark_thread_skipped(int thread_num) noexcept;
+void logging_cleanup_failure_callback() noexcept;
 void logging_run_callback();
 void logging_report_mismatched_data(enum DataType type, const uint8_t *actual, const uint8_t *expected,
                                     size_t size, ptrdiff_t offset, const char *fmt, va_list);

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1149,6 +1149,7 @@ static TestResult run_one_test_inner(struct test *test, bool init_in_aux_thread 
         sApp->test_tests_finish(test);
     } while (false);
 
+    logging_cleanup_failure_callback();
     return state;
 }
 

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -1785,7 +1785,7 @@ static struct test selftests_array[] = {
     .quality_level = TEST_QUALITY_PROD,
 },
 {
-    .id = "selftest_datacomparefail_int_50pct",
+    .id = "selftest_datacomparefailrare_int_50pct",
     .description = "Fakes a memcmp_or_fail that finds a difference that isn't there, 50% of the time",
     .groups = DECLARE_TEST_GROUPS(&group_random),
             .test_run = selftest_datacomparefailrare_run<std::ratio<1, 2>>,
@@ -1793,7 +1793,7 @@ static struct test selftests_array[] = {
     .quality_level = TEST_QUALITY_PROD,
 },
 {
-    .id = "selftest_datacomparefail_int_rare",
+    .id = "selftest_datacomparefailrare_int_rare",
     .description = "Fakes a memcmp_or_fail that finds a difference that isn't there, less than 0.1% of the time",
     .groups = DECLARE_TEST_GROUPS(&group_random),
             .test_run = selftest_datacomparefailrare_run<std::ratio<1, 1024>>,
@@ -1801,7 +1801,7 @@ static struct test selftests_array[] = {
     .quality_level = TEST_QUALITY_PROD,
 },
 {
-    .id = "selftest_datacomparefail_double_50pct",
+    .id = "selftest_datacomparefailrare_double_50pct",
     .description = "Fakes a memcmp_or_fail that finds a difference that isn't there, 50% of the time",
     .groups = DECLARE_TEST_GROUPS(&group_random),
             .test_run = selftest_datacomparefailrare_run<std::ratio<1, 2>, double>,
@@ -1809,7 +1809,7 @@ static struct test selftests_array[] = {
     .quality_level = TEST_QUALITY_PROD,
 },
 {
-    .id = "selftest_datacomparefail_double_rare",
+    .id = "selftest_datacomparefailrare_double_rare",
     .description = "Fakes a memcmp_or_fail that finds a difference that isn't there, less than 0.1% of the time",
     .groups = DECLARE_TEST_GROUPS(&group_random),
             .test_run = selftest_datacomparefailrare_run<std::ratio<1, 1024>, double>,

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -702,6 +702,12 @@ template <typename T> static int selftest_datacomparefail_run(struct test *, int
     int diff = (thread & (Count - 1));
     values[diff] = make_datacompare_value<T>();
 
+    if constexpr (std::is_same_v<T, uint8_t>)
+        memcmp_or_fail(values, values + 1, Count);
+    memcmp_or_fail(values, values + 1, Count, "data of type '%s'",
+                   SandstoneDataDetails::TypeToDataType<T>::name());
+
+    // won't be reached, but verify that it compiles
     memcmp_or_fail(values, values + 1, Count);
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Otherwise, if more than one thread fails, the second or later threads would dereference a dangling pointer. This wasn't caught by the unit-testing because it only applies to stateful callbacks, which we only tested in the `selftest_datacompare` test... 

which was broken and not running anything: the sed expression `s/\r$//p` prints the matched line *only if* there
was a substitution made. Since our Unix builds don't print using CRLF and the MSYS execution automatically converts from CRLF, this ended up matching nothing, and thus executing nothing. This PR fixes that by splitting into separate substitute and print commands. Additionally, print the list of tests that were matched, and ensure we did catch at least one.

Turning that on revealed a few other minor things that needed fixing.
