### PR TITLE
FW/CPU-slicing: lower the minimum number of cores per socket to 4

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1670,7 +1670,7 @@ void slice_plan_init(int max_cores_per_slice)
 
     // The heuristic is enabled by max_cores_per_slice == 0 and a valid
     // topology:
-    // - if the CPU Set has less than or equal to MinimumCpusPerSocket (8)
+    // - if the CPU Set has less than MinimumCpusPerSocket (4)
     //   logical processors per socket (on average), we ignore the topology and
     //   will instead run in slices of up to DefaultMaxCoresPerSlice (32)
     //   logical processors.
@@ -1702,7 +1702,7 @@ void slice_plan_init(int max_cores_per_slice)
             // apply defaults
             int average_cpus_per_socket = max_cpu / topology.packages.size();
             max_cores_per_slice = DefaultMaxCoresPerSlice;
-            if (average_cpus_per_socket <= MinimumCpusPerSocket)
+            if (average_cpus_per_socket < MinimumCpusPerSocket)
                 break;
         }
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -328,7 +328,7 @@ struct SandstoneApplication : SandstoneApplicationConfig, public test_the_test_d
     using OutputFormat = TestConfig::OutputFormat;
 
     struct SlicePlans {
-        static constexpr int MinimumCpusPerSocket = 8;
+        static constexpr int MinimumCpusPerSocket = 4;
         static constexpr int DefaultMaxCoresPerSlice = 32;
         enum Type : int8_t {
             FullSystem = -1,


### PR DESCRIPTION
The limit was designed to detect broken topologies, such a report of 16 sockets of 1 core. "Less than 4" shoud still catch them.

But it won't catch a simple hybrid system with 1 Intel P-core and 1 Intel E-core module (4 cores). For those, we'll still enable slicing and split P from E cores.

[ChangeLog][Framework] Changed the slicing feature so that Intel hybrid systems always split the execution of P- and E-cores. This had been the intention, but failed to account configurations with very low core counts.