### PR TITLE
FW: use const ref when iterating over enabled/disabled tests

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1026,7 +1026,7 @@ int main(int argc, char **argv)
 
     /* Add all the tests we were told to enable. */
     if (opts.enabled_tests.size()) {
-        for (auto name : opts.enabled_tests) {
+        for (const auto& name : opts.enabled_tests) {
             auto tis = test_set->add(name.c_str());
             if (!tis.size() && !opts.test_set_config.ignore_unknown_tests) {
                 fprintf(stderr, "%s: Cannot find matching tests for '%s'\n", program_invocation_name, name.c_str());
@@ -1067,7 +1067,7 @@ int main(int argc, char **argv)
 
     /* Remove all the tests we were told to disable */
     if (opts.disabled_tests.size()) {
-        for (auto name : opts.disabled_tests) {
+        for (const auto& name : opts.disabled_tests) {
             test_set->remove(name.c_str());
         }
     }


### PR DESCRIPTION
Must've been a leftover from when those vector contained `const char*`, not `std::string`. Avoid unnecessary copying.