### PR TITLE
FW/CPU-Topology: fix two CPUID topology spec violations

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1098,7 +1098,7 @@ bool TopologyDetector::setup_cpuid_detection()
     // extract the domain levels
     while (b) {
         Domain domain = Domain((c >> 8) & 0xff);
-        a &= 0xf;
+        a &= 0x1f;
         switch (domain) {
         case Domain::Invalid:
             __builtin_unreachable();

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1169,7 +1169,7 @@ bool TopologyDetector::detect_topology_via_cpuid(Topology::Thread *info)
         // and is what Linux implements (how Windows determines how to return
         // RelationProcessorModule is a guess). Intel docs say "the nearest
         // power-of-2 not smaller than".
-        int l2_sharing_width = 31 - std::countl_zero(max_cpus_sharing_l2);
+        int l2_sharing_width = std::bit_width(max_cpus_sharing_l2 - 1);
         info->module_id = extract(l2_sharing_width, width(Package));
     } else {
         // if neither CPUID nor cache provide module information, we assume module == core


### PR DESCRIPTION
This fixes two spec compliance issues in `TopologyDetector`'s CPUID-based topology detection (leaves `0Bh`/`1Fh`):

 - **Shift-width mask:** Intel SDM specifies EAX[4:0] (5 bits) for the topology shift width. The mask was `0xf` (4 bits), truncating values > 15. Fixed to `0x1f`.

 - **L2-sharing width formula:** When inferring module boundaries from L2 cache sharing counts, the code used `31 - countl_zero(N)` = `floor(log2(N))`, but the
spec requires `ceil(log2(N))` for non-power-of-2 counts. Fixed to `bit_width(N - 1)`.
