### PR TITLE
FW: add API to format simple `std::map`-based contents to YAML

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -651,9 +651,9 @@ function selftest_log_skip_init_common() {
     check_test 1
 }
 
-@test "selftest_log_raw_yaml" {
+function selftest_log_yaml_common() {
     declare -A yamldump
-    sandstone_selftest -e selftest_log_raw_yaml
+    sandstone_selftest -e $1
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/result" pass
@@ -664,6 +664,13 @@ function selftest_log_skip_init_common() {
         test_yaml_regexp "/tests/0/threads/$i/messages/0/details/random" '.*'
         test_yaml_regexp "/tests/0/threads/$i/messages/0/details/text" 'foo bar'
     done
+}
+
+@test "selftest_log_raw_yaml" {
+    selftest_log_yaml_common selftest_log_raw_yaml
+}
+@test "selftest_log_formatted_yaml" {
+    selftest_log_yaml_common selftest_log_formatted_yaml
 }
 
 @test "selftest_logdata" {

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -88,6 +88,7 @@ RtlGetVersion(
 
 using LogMessage = AbstractLogger::LogMessage;              // for convenience
 using LogMessagesFile = AbstractLogger::LogMessagesFile;    // for convenience
+using YamlFormatter::escape_for_single_line;                // for convenience
 
 static constexpr const char *levels[] = { "error", "warning", "info", "debug" };
 
@@ -1068,39 +1069,6 @@ void logging_cleanup_failure_callback() noexcept
 #else
 void logging_cleanup_failure_callback() noexcept {}
 #endif
-
-/// Escapes \c{message} suitable for a single-quote YAML line and returns it.
-/// The \c{storage} parameter is used in case we need to do escaping.
-/// (This could've been a std::variant<std::string, std::string_view>)
-static std::string_view escape_for_single_line(std::string_view message, std::string &storage)
-{
-    const char quote = '\'';
-    size_t pos = message.find(quote);
-    if (pos == std::string_view::npos)
-        return message;
-
-    // Message contains apostrophes, so we need to double the single
-    // quotes. Do that by looping over the string copying it in chunks
-    // delimited by apostrophes, with the apostrophes being copied twice
-    // (that means we're inefficient for back-to-back apostrophes, but
-    // that's not common English text)
-    storage.resize(0);          // just in case
-    storage.reserve(message.size() + message.size() / 16);  // 1/16th is guesstimate
-
-    while (pos != std::string_view::npos) {
-        storage += message.substr(0, pos + 1);
-        message.remove_prefix(pos);
-        pos = message.find(quote, 1);
-    }
-
-    storage += message;     // copy the last chunk (if any)
-    return storage;
-}
-
-static std::string_view escape_for_single_line(std::string_view msg, std::string &&storage = {})
-{
-    return escape_for_single_line(msg, storage);
-}
 
 static void log_data_common(const char *message, const uint8_t *ptr, size_t size, bool from_memcmp)
 {

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1325,8 +1325,7 @@ void log_thread_context(std::string_view ctx)
     log_message_for_thread(thread, LogTypes::ThreadContext, LOG_LEVEL_VERBOSE(1), ctx);
 }
 
-#undef log_yaml
-void log_yaml(char levelchar, const char *yaml)
+void log_thread_yaml(int thread_num, char levelchar, const char *yaml)
 {
     LogLevelVerbosity level = status_level(levelchar);
     if (levelchar == 'E')
@@ -1344,6 +1343,12 @@ void log_yaml(char levelchar, const char *yaml)
     log_message_for_thread(thread, LogTypes::RawYaml, level, '\n', yaml);
     if (levelchar == 'E')
         logging_run_callback();
+}
+
+#undef log_yaml
+void log_yaml(char levelchar, const char *yaml)
+{
+    log_thread_yaml(thread_num, levelchar, yaml);
 }
 
 void logging_mark_knob_used(std::string_view key, YamlFormatter::SimpleValue value, KnobOrigin origin)

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1325,21 +1325,28 @@ void log_thread_context(std::string_view ctx)
     log_message_for_thread(thread, LogTypes::ThreadContext, LOG_LEVEL_VERBOSE(1), ctx);
 }
 
-void log_thread_yaml(int thread_num, char levelchar, const char *yaml)
+static PerThreadData::Common *log_yaml_common(int thread_num, char levelchar)
 {
-    LogLevelVerbosity level = status_level(levelchar);
     if (levelchar == 'E')
         logging_mark_thread_failed(thread_num);
     if (!SandstoneConfig::Debug && levelchar == 'd')
-        return;             // no Debug in non-debug build
+        return nullptr;     // no Debug in non-debug build
     if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
-        return;             // short-circuit
+        return nullptr;     // short-circuit
 
     PerThreadData::Common *thread = sApp->thread_data(thread_num);
     std::atomic<int> &messages_logged = thread->messages_logged;
     if (messages_logged.load(std::memory_order_relaxed) >= sApp->shmem->cfg.max_messages_per_thread)
-        return;
+        return nullptr;     // enough messages
+    return thread;
+}
 
+void log_thread_yaml(int thread_num, char levelchar, const char *yaml)
+{
+    LogLevelVerbosity level = status_level(levelchar);
+    PerThreadData::Common *thread = log_yaml_common(thread_num, levelchar);
+    if (!thread)
+        return;
     log_message_for_thread(thread, LogTypes::RawYaml, level, '\n', yaml);
     if (levelchar == 'E')
         logging_run_callback();
@@ -1349,6 +1356,25 @@ void log_thread_yaml(int thread_num, char levelchar, const char *yaml)
 void log_yaml(char levelchar, const char *yaml)
 {
     log_thread_yaml(thread_num, levelchar, yaml);
+}
+
+void log_yaml(char levelchar, std::string_view description,
+              const std::map<std::string, YamlFormatter::SimpleValue> &values)
+{
+    assert(description.find('\n') == std::string::npos
+           && "YAML descriptions should not include a newline");
+    if (values.empty())
+        log_yaml(levelchar, description.data());
+
+    PerThreadData::Common *thread = log_yaml_common(thread_num, levelchar);
+    if (!thread)
+        return;
+
+    std::string payload = format_yaml(values);
+    log_message_for_thread(thread, LogTypes::RawYaml, status_level(levelchar),
+                           '\n', description, '\n', payload);
+    if (levelchar == 'E')
+        logging_run_callback();
 }
 
 void logging_mark_knob_used(std::string_view key, YamlFormatter::SimpleValue value, KnobOrigin origin)

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -12,6 +12,7 @@
 #include "sandstone_iovec.h"
 #include "sandstone_utils.h"
 #include "sandstone_virt.h"
+#include "sandstone_yaml.h"
 
 #if SANDSTONE_SSL_BUILD
 #  include "sandstone_ssl.h"
@@ -1345,7 +1346,7 @@ void log_yaml(char levelchar, const char *yaml)
         logging_run_callback();
 }
 
-void logging_mark_knob_used(std::string_view key, TestKnobValue value, KnobOrigin origin)
+void logging_mark_knob_used(std::string_view key, YamlFormatter::SimpleValue value, KnobOrigin origin)
 {
     if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
         return;             // short-circuit
@@ -1370,40 +1371,9 @@ void logging_mark_knob_used(std::string_view key, TestKnobValue value, KnobOrigi
     if (!sApp->shmem->cfg.log_test_knobs)
         return;
 
-    struct Visitor {
-        std::string operator()(uint64_t v)
-        {
-            if (v < 4096)
-                return stdprintf("%u", unsigned(v));
-            else
-                return stdprintf("0x%" PRIx64, v);
-        }
-        std::string operator()(int64_t v)
-        {
-            if (v >= 0)
-                return operator()(uint64_t(v));
-            else if (v >= -4096)
-                return stdprintf("%d", int(v));
-            else
-                return stdprintf("-0x%" PRIx64, -v);
-        }
-        std::string operator()(double v)
-        {
-            return stdprintf("%.17g", double(v));
-        }
-        std::string operator()(std::string_view v)
-        {
-            if (v.data() == nullptr) {
-                return "null";
-            } else {
-                return stdprintf("'%s'", escape_for_single_line(v).data());
-            }
-        }
-    };
-    std::string formatted = std::visit(Visitor{}, value);
     PerThreadData::Common *thread = sApp->thread_data(thread_num);
     log_message_for_thread(thread, LogTypes::UsedKnobValue, UsedKnobValueLoggingLevel,
-                           key, ": ", formatted);
+                           format_yaml(key, value));
 }
 
 static void print_content_indented(int fd, std::string_view indent, std::string_view content)

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -467,7 +467,7 @@ extern void log_data(const char *message, const void *data, size_t size);
 extern void log_thread_context(const char *msg, ...) ATTRIBUTE_PRINTF(1, 2);
 /// Logs pre-formatted YAML to the logs.
 extern void log_yaml(char levelchar, const char *yaml);
-#define log_yaml(level, yaml)       log_yaml(level[0], yaml)
+#define log_yaml(level, ...)        log_yaml(level[0], __VA_ARGS__)
 
 /// retrieves the physical address of a given pointer.  Currently
 /// this function is only supported on Linux and requires root
@@ -767,7 +767,7 @@ memcmp_or_fail(const T *actual, const T *expected, size_t count, const char *fmt
 #  define log_error(...)                    log_message(thread_num, SANDSTONE_LOG_ERROR "")
 #  define log_warning(...)                  (void)0
 #  define log_info(...)                     (void)0
-#  define log_yaml(level, yaml)             log_yaml(level[0], NULL)
+#  define log_yaml(level, ...)              log_yaml(level[0], NULL)
 #  define report_fail(test)                 _report_fail(test, NULL, 0)
 #  define report_fail_msg(...)              _report_fail_msg(NULL, 0, NULL)
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -625,6 +625,7 @@ void logging_restricted(LogLevelVerbosity level, const char *fmt, ...);
 void logging_printf(LogLevelVerbosity level, const char *msg, ...) ATTRIBUTE_PRINTF(2, 3);
 void logging_mark_thread_failed(int thread_num) noexcept;
 void logging_mark_thread_skipped(int thread_num) noexcept;
+void logging_mark_knob_used(std::string_view key, TestKnobValue value, KnobOrigin origin);
 void logging_cleanup_failure_callback() noexcept;
 void logging_run_callback();
 void logging_report_mismatched_data(enum DataType type, const uint8_t *actual, const uint8_t *expected,

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -30,6 +30,7 @@
 #include <sandstone_chrono.h>
 #include <sandstone_iovec.h>
 #include <sandstone_utils.h>
+#include <sandstone_yaml.h>
 
 #include "gettid.h"
 #include "test_data.h"
@@ -625,7 +626,7 @@ void logging_restricted(LogLevelVerbosity level, const char *fmt, ...);
 void logging_printf(LogLevelVerbosity level, const char *msg, ...) ATTRIBUTE_PRINTF(2, 3);
 void logging_mark_thread_failed(int thread_num) noexcept;
 void logging_mark_thread_skipped(int thread_num) noexcept;
-void logging_mark_knob_used(std::string_view key, TestKnobValue value, KnobOrigin origin);
+void logging_mark_knob_used(std::string_view key, YamlFormatter::SimpleValue value, KnobOrigin origin);
 void logging_cleanup_failure_callback() noexcept;
 void logging_run_callback();
 void logging_report_mismatched_data(enum DataType type, const uint8_t *actual, const uint8_t *expected,

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -616,6 +616,7 @@ extern "C" initfunc group_kvm_init(void) noexcept;
 #endif
 
 /* logging.cpp */
+void log_message_yaml(int thread_num, char levelchar, const char *yaml);
 void log_message_preformatted(int thread_num, LogLevelVerbosity level, std::string_view msg);
 int logging_stdout_fd(void);
 void logging_init_global(void);

--- a/framework/sandstone_utils.cpp
+++ b/framework/sandstone_utils.cpp
@@ -201,3 +201,51 @@ std::string stdprintf(const char *fmt, ...)
 {
     return va_start_and_stdprintf(fmt);
 }
+
+namespace YamlFormatter {
+std::string_view escape_for_single_line(std::string_view message, std::string &storage)
+{
+    const char quote = '\'';
+    size_t pos = message.find(quote);
+    if (pos == std::string_view::npos)
+        return message;
+
+    // Message contains apostrophes, so we need to double the single
+    // quotes. Do that by looping over the string copying it in chunks
+    // delimited by apostrophes, with the apostrophes being copied twice
+    // (that means we're inefficient for back-to-back apostrophes, but
+    // that's not common English text)
+    storage.resize(0);          // just in case
+    storage.reserve(message.size() + message.size() / 16);  // 1/16th is guesstimate
+
+    while (pos != std::string_view::npos) {
+        storage += message.substr(0, pos + 1);
+        message.remove_prefix(pos);
+        pos = message.find(quote, 1);
+    }
+
+    storage += message;     // copy the last chunk (if any)
+    return storage;
+}
+
+static void escape_multi_line(std::string &append_to, int indent, std::string_view message)
+{
+    append_to += '|';
+    if (message.ends_with('\n'))
+        append_to += '+';
+    append_to += '\n';
+
+    ptrdiff_t nl = message.find('\n');
+    while (nl >= 0) {
+        append_to.append(indent + 2, ' ');
+
+        // write the newline too
+        ++nl;
+        append_to += message.substr(0, nl);
+        message.remove_prefix(nl);
+        nl = message.find('\n');
+    }
+    append_to.append(indent + 2, ' ');
+    append_to += message;
+}
+} // namespace YamlFormatter

--- a/framework/sandstone_utils.cpp
+++ b/framework/sandstone_utils.cpp
@@ -9,10 +9,11 @@
 //     All unit tests should be put in framework/unit-tests/sandstone_utils_tests.cpp
 
 #include "sandstone_utils.h"
+#include "sandstone_yaml.h"
 
-#include <stdexcept>
 #include <string>
 
+#include <inttypes.h>
 #include <math.h>
 #include <string.h>
 #include <time.h>
@@ -247,5 +248,124 @@ static void escape_multi_line(std::string &append_to, int indent, std::string_vi
     }
     append_to.append(indent + 2, ' ');
     append_to += message;
+}
+
+struct FormatSimpleValue
+{
+    FormatSimpleValue(std::string &append_to, std::string_view key,
+                      const YamlFormatter::SimpleValue &value, int indent = 0)
+        : append_to(append_to), indent(indent)
+    {
+        append_to.append(indent, ' ');
+        append_to += key;
+        append_to += ": ";
+        prefix_len = indent + key.size() + 3;
+        std::visit(*this, value);
+    }
+
+    void operator()(bool v)
+    {
+        append_to += v ? "true" : "false";
+    }
+
+    void operator()(uint64_t v)
+    {
+        if (v < 4096)
+            append_to += stdprintf("%u", unsigned(v));
+        else
+            append_to += stdprintf("0x%" PRIx64, v);
+    }
+    void operator()(int64_t v)
+    {
+        if (v >= 0)
+            operator()(uint64_t(v));
+        else if (v >= -4096)
+            append_to += stdprintf("%d", int(v));
+        else
+            append_to += stdprintf("-0x%" PRIx64, -(uint64_t(v)));
+    }
+    void operator()(double v)
+    {
+        Float64 u(v);
+        int cl = fpclassify(v);
+        if (cl == FP_INFINITE) {
+            if (v < 0)
+                append_to += '-';
+            append_to += ".inf";
+            return;
+        }
+
+        std::string r;
+        auto pad_string = [&] {
+            // align to the right with spaces
+            size_t size = prefix_len + r.size() + 15;
+            size = size / 16 * 16;
+            r.resize(size - prefix_len, ' ');
+        };
+        if (cl == FP_NAN) {
+            Float64 qnan(std::numeric_limits<double>::quiet_NaN());
+            r = ".nan";
+            if (u.as_hex != qnan.as_hex) {
+                pad_string();
+                r += stdprintf(" # %s%s(%#" PRIx64 ")",
+                               u.as_nan.sign ? "-" : "",
+                               u.as_nan.quiet ? "nan" : "snan",
+                               u.as_nan.payload);
+            }
+        } else {
+            r = stdprintf("%.17g", v);
+            if (!r.contains('.'))
+                r += ".0";
+            pad_string();
+            r += stdprintf(" # %a", v);
+        }
+
+        append_to += std::move(r);
+    }
+    void operator()(std::string_view v)
+    {
+        if (v.data() == nullptr) {
+            append_to += "null";
+            return;
+        }
+        if (v.ends_with('\n'))
+            v.remove_suffix(1);
+        if (v.contains('\n')) {
+            escape_multi_line(append_to, indent, v);
+        } else {
+            append_to += '\'';
+            append_to += escape_for_single_line(v);
+            append_to += '\'';
+        }
+    }
+
+private:
+    std::string &append_to;
+    int indent;
+    int prefix_len;
+};
+
+static std::string format_yaml(const std::map<std::string, YamlFormatter::SimpleValue> &values, int indent)
+{
+    std::string result;
+
+    for (auto &[key, value]: values) {
+        if (result.size())
+            result += '\n';
+        FormatSimpleValue(result, key, value, indent);
+    }
+    return result;
+}
+
+std::string format_yaml(std::string_view key, const SimpleValue &value)
+{
+    std::string result;
+    FormatSimpleValue(result, key, value);
+    return result;
+}
+
+std::string format_yaml(const std::map<std::string, YamlFormatter::SimpleValue> &values)
+{
+    return format_yaml(values, 0);
 }
 } // namespace YamlFormatter

--- a/framework/sandstone_utils.h
+++ b/framework/sandstone_utils.h
@@ -55,6 +55,16 @@ inline int dprintf(int fd, const char *fmt, ...)
 }
 #endif
 
+namespace YamlFormatter {
+/// Escapes \c{message} suitable for a single-quote YAML line and returns it.
+/// The \c{storage} parameter is used in case we need to do escaping.
+std::string_view escape_for_single_line(std::string_view message, std::string &storage);
+inline std::string_view escape_for_single_line(std::string_view msg, std::string &&storage = {})
+{
+    return escape_for_single_line(msg, storage);
+}
+}
+
 struct AutoClosingFile
 {
     FILE *f = nullptr;

--- a/framework/sandstone_yaml.h
+++ b/framework/sandstone_yaml.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SANDSTONE_YAML_H
+#define SANDSTONE_YAML_H
+
+#include <map>
+#include <string>
+#include <variant>
+
+#include <stdint.h>
+
+namespace YamlFormatter {
+using SimpleValue = std::variant<bool, int64_t, uint64_t, double, std::string_view, std::string>;
+
+std::string format_yaml(std::string_view key, const YamlFormatter::SimpleValue &value);
+std::string format_yaml(const std::map<std::string, YamlFormatter::SimpleValue> &values);
+}
+
+using YamlFormatter::format_yaml;
+
+#endif // SANDSTONE_YAML_H

--- a/framework/sandstone_yaml.h
+++ b/framework/sandstone_yaml.h
@@ -21,4 +21,8 @@ std::string format_yaml(const std::map<std::string, YamlFormatter::SimpleValue> 
 
 using YamlFormatter::format_yaml;
 
+// parentheses because log_yaml may be a macro here
+void (log_yaml)(char levelchar, std::string_view descr,
+                const std::map<std::string, YamlFormatter::SimpleValue> &values);
+
 #endif // SANDSTONE_YAML_H

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -704,10 +704,13 @@ template <typename T> static int selftest_datacomparefail_run(struct test *, int
     values[diff] = make_datacompare_value<T>();
 
     auto formatter = [&](ptrdiff_t idx) {
-        return stdprintf("data of type '%s' at index %td\n"
-                         "rare: false\n"
-                         "modified_at: %d\n"
-                         "count: %zu", type_name, idx, diff, Count);
+        std::map<std::string, YamlFormatter::SimpleValue> map = {
+            { "rare", false },
+            { "modified_at", diff },
+            { "count", Count },
+        };
+        return stdprintf("data of type '%s' at index %td\n", type_name, idx)
+                + format_yaml(map);
     };
 
     if constexpr (std::is_same_v<T, uint8_t>) {
@@ -719,7 +722,7 @@ template <typename T> static int selftest_datacomparefail_run(struct test *, int
                        "data of type '%s'\n"
                        "rare: false\n"
                        "modified_at: %d\n"
-                       "count: %zu", type_name, diff, Count);
+                       "count: %zu\n", type_name, diff, Count);
     } else if constexpr (std::is_integral_v<T>) {
         // use the C++ way with a lambda
         memcmp_or_fail(values, values + 1, Count, formatter);

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -203,6 +203,17 @@ static int selftest_lograwyaml_run(struct test *test, int cpu)
     return EXIT_SUCCESS;
 }
 
+static int selftest_logformattedyaml_run(struct test *test, int cpu)
+{
+    std::map<std::string, YamlFormatter::SimpleValue> map = {
+        { "cpu", cpu },
+        { "random", random64() },
+        { "text", std::string_view("foo bar") },
+    };
+    log_yaml(SANDSTONE_LOG_INFO, "Some details from the test", map);
+    return EXIT_SUCCESS;
+}
+
 static int selftest_logs_options_init(struct test *test)
 {
     const char *strvalue = get_testspecific_knob_value_string(test, "StringValue", "DefaultValue");
@@ -1417,9 +1428,17 @@ static struct test selftests_array[] = {
 },
 {
     .id = "selftest_log_raw_yaml",
-    .description = "Logs YAML content",
+    .description = "Logs YAML content (raw string)",
     .groups = DECLARE_TEST_GROUPS(&group_positive),
     .test_run = selftest_lograwyaml_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_log_formatted_yaml",
+    .description = "Logs YAML content (using format_yaml)",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_run = selftest_logformattedyaml_run,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -1424,15 +1424,6 @@ static struct test selftests_array[] = {
     .quality_level = TEST_QUALITY_PROD,
 },
 {
-    .id = "selftest_log_raw_yaml_with_cb",
-    .description = "Logs YAML content (with callback active)",
-    .groups = DECLARE_TEST_GROUPS(&group_positive),
-    .test_init = selftest_log_platform_init,
-    .test_run = selftest_lograwyaml_run,
-    .desired_duration = -1,
-    .quality_level = TEST_QUALITY_PROD,
-},
-{
     .id = "selftest_logs_options",
     .description = "Logs some command-line options",
     .groups = DECLARE_TEST_GROUPS(&group_positive),

--- a/framework/test_knobs.cpp
+++ b/framework/test_knobs.cpp
@@ -5,9 +5,8 @@
 
 #include "test_knobs.h"
 
-#include "sandstone.h"
+#include "sandstone_p.h"
 
-#include <map>
 #include <string>
 #include <vector>
 #include <boost/algorithm/string.hpp>

--- a/framework/test_knobs.h
+++ b/framework/test_knobs.h
@@ -55,7 +55,6 @@ static inline const char *get_test_knob_value_string(const char *key, const char
 } // extern "C"
 
 enum class KnobOrigin { Options, Defaulted };
-using TestKnobValue = std::variant<std::string_view, uint64_t, int64_t, double>;
 #endif
 
 #endif //FRAMEWORK_TEST_KNOBS_H

--- a/framework/test_knobs.h
+++ b/framework/test_knobs.h
@@ -54,10 +54,8 @@ static inline const char *get_test_knob_value_string(const char *key, const char
 #ifdef __cplusplus
 } // extern "C"
 
-// implemented in logging.cpp (or unit test)
 enum class KnobOrigin { Options, Defaulted };
 using TestKnobValue = std::variant<std::string_view, uint64_t, int64_t, double>;
-void logging_mark_knob_used(std::string_view key, TestKnobValue value, KnobOrigin origin);
 #endif
 
 #endif //FRAMEWORK_TEST_KNOBS_H

--- a/framework/unit-tests/sandstone_utils_tests.cpp
+++ b/framework/unit-tests/sandstone_utils_tests.cpp
@@ -8,6 +8,7 @@
 #include "sandstone_chrono.h"
 #include "sandstone_data.h"
 #include "sandstone_utils.h"
+#include "sandstone_yaml.h"
 
 #include <limits.h>
 #include <locale.h>
@@ -749,4 +750,122 @@ TEST(FloatGeneration, new_random_float_prototypes) {
     // briefly verify C interface
     ASSERT_EQ(0, test_floats_prototypes_c());
     ASSERT_EQ(0, test_floats_prototypes_cpp());
+}
+
+TEST(YamlFormatter, booleans) {
+    EXPECT_EQ(format_yaml("key", false), "key: false");
+    EXPECT_EQ(format_yaml("key", true), "key: true");
+}
+
+TEST(YamlFormatter, integer) {
+    EXPECT_EQ(format_yaml("key", 0), "key: 0");
+    EXPECT_EQ(format_yaml("key", 1), "key: 1");
+    EXPECT_EQ(format_yaml("key", -1), "key: -1");
+    EXPECT_EQ(format_yaml("key", 4095), "key: 4095");
+    EXPECT_EQ(format_yaml("key", -4096), "key: -4096");
+    EXPECT_EQ(format_yaml("key", 4096), "key: 0x1000");
+    EXPECT_EQ(format_yaml("key", -4097), "key: -0x1001");
+    EXPECT_EQ(format_yaml("key", INT_MAX), "key: 0x7fffffff");
+    EXPECT_EQ(format_yaml("key", INT_MIN), "key: -0x80000000");
+    EXPECT_EQ(format_yaml("key", int64_t(INT_MAX) + 1), "key: 0x80000000");
+    EXPECT_EQ(format_yaml("key", int64_t(INT_MIN) - 1), "key: -0x80000001");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<int64_t>::max()), "key: 0x7fffffffffffffff");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<int64_t>::min()), "key: -0x8000000000000000");
+
+    EXPECT_EQ(format_yaml("key", uint64_t(0)), "key: 0");
+    EXPECT_EQ(format_yaml("key", uint64_t(1)), "key: 1");
+    EXPECT_EQ(format_yaml("key", uint64_t(4095)), "key: 4095");
+    EXPECT_EQ(format_yaml("key", uint64_t(4096)), "key: 0x1000");
+    EXPECT_EQ(format_yaml("key", uint64_t(INT_MAX)), "key: 0x7fffffff");
+    EXPECT_EQ(format_yaml("key", uint64_t(std::numeric_limits<int64_t>::max())), "key: 0x7fffffffffffffff");
+    EXPECT_EQ(format_yaml("key", uint64_t(std::numeric_limits<int64_t>::min())), "key: 0x8000000000000000");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<uint64_t>::max()), "key: 0xffffffffffffffff");
+}
+
+TEST(YamlFormatter, floating_point) {
+    EXPECT_EQ(format_yaml("key", 0.), "key: 0.0        # 0x0p+0");
+    EXPECT_EQ(format_yaml("key", 1.), "key: 1.0        # 0x1p+0");
+    EXPECT_EQ(format_yaml("key", 1.5), "key: 1.5        # 0x1.8p+0");
+    EXPECT_EQ(format_yaml("key", -1.), "key: -1.0       # -0x1p+0");
+    EXPECT_EQ(format_yaml("key", -1.5), "key: -1.5       # -0x1.8p+0");
+    EXPECT_EQ(format_yaml("key", 12345678.), "key: 12345678.0 # 0x1.78c29cp+23");
+    EXPECT_EQ(format_yaml("key", 123456789.),
+              "key: 123456789.0                # 0x1.d6f3454p+26");
+    EXPECT_EQ(format_yaml("key", 1234567890.),
+              "key: 1234567890.0               # 0x1.26580b48p+30");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<double>::max()),
+              "key: 1.7976931348623157e+308    # 0x1.fffffffffffffp+1023");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<double>::epsilon()),
+              "key: 2.2204460492503131e-16     # 0x1p-52");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<double>::min()),
+              "key: 2.2250738585072014e-308    # 0x1p-1022");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<double>::denorm_min()),
+              "key: 4.9406564584124654e-324    # 0x0.0000000000001p-1022");
+
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<double>::infinity()), "key: .inf");
+    EXPECT_EQ(format_yaml("key", -std::numeric_limits<double>::infinity()), "key: -.inf");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<double>::quiet_NaN()), "key: .nan");
+
+    EXPECT_EQ(format_yaml("key", __builtin_nan("1")),
+              "key: .nan       # nan(0x1)");
+    EXPECT_EQ(format_yaml("key", -__builtin_nan("1")),
+              "key: .nan       # -nan(0x1)");
+    EXPECT_EQ(format_yaml("key", -std::numeric_limits<double>::quiet_NaN()),
+              "key: .nan       # -nan(0)");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<double>::signaling_NaN()),
+              "key: .nan       # snan(0x4000000000000)");
+    EXPECT_EQ(format_yaml("key", -std::numeric_limits<double>::signaling_NaN()),
+              "key: .nan       # -snan(0x4000000000000)");
+    EXPECT_EQ(format_yaml("key", __builtin_nans("1")),
+              "key: .nan       # snan(0x1)");
+    EXPECT_EQ(format_yaml("key", -__builtin_nans("1")),
+              "key: .nan       # -snan(0x1)");
+}
+
+TEST(YamlFormatter, strings) {
+    using namespace std::string_view_literals;
+    EXPECT_EQ(format_yaml("key", std::string_view()), "key: null");
+    EXPECT_EQ(format_yaml("key", "value"sv), "key: 'value'");
+    EXPECT_EQ(format_yaml("key", "it's enough"sv), "key: 'it''s enough'");
+
+    // single, trailing newline is chopped off
+    EXPECT_EQ(format_yaml("key", "value\n"sv), "key: 'value'");
+
+    // multiline
+    EXPECT_EQ(format_yaml("key", "Hello\nWorld"sv), "key: |\n  Hello\n  World");
+    EXPECT_EQ(format_yaml("key", "Hello\nWorld\n"sv), "key: |\n  Hello\n  World");
+    EXPECT_EQ(format_yaml("key", "Hello\n\nWorld\n\n"sv), "key: |+\n  Hello\n  \n  World\n  ");
+}
+
+TEST(YamlFormatter, map) {
+    using namespace std::string_view_literals;
+    std::map<std::string, YamlFormatter::SimpleValue> map;
+    std::string expected;
+    EXPECT_EQ(format_yaml(map), expected);
+
+    map["1"] = 1;
+    expected = "1: 1";
+    ASSERT_EQ(format_yaml(map), expected);
+
+    map["a"] = "a"sv;
+    expected += "\na: 'a'";
+    ASSERT_EQ(format_yaml(map), expected);
+
+    map["double"] = 0.0;
+    map["doublenan"] = -std::numeric_limits<double>::quiet_NaN();
+    expected += "\ndouble: 0.0     # 0x0p+0";
+    expected += "\ndoublenan: .nan # -nan(0)";
+    ASSERT_EQ(format_yaml(map), expected);
+
+    map["multiline"] = "Hello\nWorld"sv;
+    expected += "\nmultiline: |\n  Hello\n  World";
+    ASSERT_EQ(format_yaml(map), expected);
+
+    map["nulled"] = std::string_view();
+    expected += "\nnulled: null";
+    ASSERT_EQ(format_yaml(map), expected);
+
+    map["snan"] = std::numeric_limits<double>::signaling_NaN();
+    expected += "\nsnan: .nan      # snan(0x4000000000000)";
+    ASSERT_EQ(format_yaml(map), expected);
 }

--- a/framework/unit-tests/test_knob_tests.cpp
+++ b/framework/unit-tests/test_knob_tests.cpp
@@ -5,6 +5,7 @@
 
 #include "gtest/gtest.h"
 #include "sandstone.h"       // for struct test
+#include <sandstone_yaml.h>
 #include "test_knobs.h"
 
 #include <algorithm>
@@ -12,6 +13,7 @@
 
 void clear_test_knobs();
 
+using TestKnobValue = YamlFormatter::SimpleValue;
 struct UsedKeyValues
 {
     std::string key;
@@ -103,21 +105,22 @@ TEST_F(KnobTestSuite, test_can_retrieve_int_value) {
     assertKnobWasUsed("NegOne", INT64_C(-1), KnobOrigin::Options);
 }
 
+using namespace std::string_view_literals;
 TEST_F(KnobTestSuite, test_can_retrieve_string_value) {
     set_knob_from_key_value_string("Key1=Key1_Value");
     EXPECT_STREQ(get_test_knob_value_string("Key1", "X"), "Key1_Value");
-    assertKnobWasUsed("Key1", std::string("Key1_Value"), KnobOrigin::Options);
+    assertKnobWasUsed("Key1", "Key1_Value"sv, KnobOrigin::Options);
 }
 
 TEST_F(KnobTestSuite, if_key_exists_default_string_ignored) {
     set_knob_from_key_value_string("Key1=Key1_Value");
     EXPECT_STREQ(get_test_knob_value_string("Key1", "Default"), "Key1_Value");
-    assertKnobWasUsed("Key1", std::string("Key1_Value"), KnobOrigin::Options);
+    assertKnobWasUsed("Key1", "Key1_Value"sv, KnobOrigin::Options);
 }
 
 TEST_F(KnobTestSuite, if_key_does_not_exists_default_string_used){
     EXPECT_STREQ(get_test_knob_value_string("NonExistingKey", "Default"), "Default");
-    assertKnobWasUsed("NonExistingKey", std::string("Default"), KnobOrigin::Defaulted);
+    assertKnobWasUsed("NonExistingKey", "Default"sv, KnobOrigin::Defaulted);
 }
 
 TEST_F(KnobTestSuite, test_name_prepended_to_key) {
@@ -127,8 +130,8 @@ TEST_F(KnobTestSuite, test_name_prepended_to_key) {
 
     EXPECT_STREQ(get_testspecific_knob_value_string(&t, "Key1", "Default"), "Key1_Value");
     EXPECT_STREQ(get_testspecific_knob_value_string(&t, "NonExistingKey", "Default"), "Default");
-    assertKnobWasUsed("TestName.Key1", std::string("Key1_Value"), KnobOrigin::Options);
-    assertKnobWasUsed("TestName.NonExistingKey", std::string("Default"), KnobOrigin::Defaulted);
+    assertKnobWasUsed("TestName.Key1", "Key1_Value"sv, KnobOrigin::Options);
+    assertKnobWasUsed("TestName.NonExistingKey", "Default"sv, KnobOrigin::Defaulted);
 }
 
 TEST_F(KnobTestSuite, read_knob_from_cmdline_argument_string){


### PR DESCRIPTION
This PR adds both `format_yaml()` to format to string and an overload of `log_yaml()` (q.v. PR #869) to format a simple `std::map` to YAML. Supported data types are:
* boolean
* integer (`int64_t` and `uint64_t`)
* floating point (printed as both decimal and hexfloat, or in the case of NaNs, the payload)
* strings (including multiline support) - null strings print as `null`

No nested types are supported, though it shouldn't be too difficult to add. I wrote the code with support for indentation, but ended up not needing it.

Sample outputs:
```yaml
1: 1
a: 'a'
double: 0.0     # 0x0p+0
doublenan: .nan # -nan(0)
multiline: |
  Hello
  World
nulled: null
snan: .nan      # snan(0x4000000000000)
```