### PR TITLE
FW: Make `-O` work in `-f exec` mode (Windows, GPU mode)

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -680,10 +680,6 @@ function selftest_log_skip_init_common() {
 }
 
 @test "selftest_logs_options" {
-    run $SANDSTONE -n1 --selftests -e selftest_logs_options -O dummy=dummy
-    if [[ $status == 64 ]]; then
-       skip "Not supported"
-    fi
     declare -A yamldump
     sandstone_selftest -vvv --max-messages=0 -e selftest_logs_options
     [[ "$status" -eq 0 ]]

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -544,20 +544,20 @@ static int exec_mode_run(int argc, char **argv)
         }
         return int(n);
     };
-    int child_number = parse_int(argv[3]);
+    int child_number = parse_int(argv[0]);
 
-    attach_shmem(parse_int(argv[2]));
+    attach_shmem(parse_int(argv[1]));
     device_info = sApp->shmem->device_info;
     sApp->thread_count = sApp->shmem->total_thread_count;
     rebuild_topology();
     sApp->user_thread_data.resize(sApp->thread_count);
 
     test_set = new SandstoneTestSet({ .is_selftest = sApp->shmem->cfg.selftest, }, SandstoneTestSet::enable_all_tests);
-    std::vector<struct test *> tests_to_run = test_set->lookup(argv[0]);
+    std::vector<struct test *> tests_to_run = test_set->lookup(argv[2]);
     if (tests_to_run.size() != 1) return EX_DATAERR;
 
     logging_init_global_child();
-    random_init_global(argv[1]);
+    random_init_global(argv[3]);
     make_rescheduler(sApp->shmem->cfg.reschedule_mode);
 
     load_test_knob_args({ argv + 4, argv + argc });

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -560,6 +560,8 @@ static int exec_mode_run(int argc, char **argv)
     random_init_global(argv[1]);
     make_rescheduler(sApp->shmem->cfg.reschedule_mode);
 
+    load_test_knob_args({ argv + 4, argv + argc });
+
     return test_result_to_exit_code(child_run(tests_to_run.at(0), child_number));
 }
 
@@ -998,14 +1000,6 @@ int main(int argc, char **argv)
         sApp->shmem->cfg.reschedule_mode = RescheduleMode::none;
     }
     make_rescheduler(sApp->shmem->cfg.reschedule_mode);
-
-    if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::exec_each_test) {
-        if (sApp->shmem->cfg.log_test_knobs) {
-            fprintf(stderr, "%s: error: --test-option is not supported in this configuration\n",
-                    program_invocation_name);
-            return EX_USAGE;
-        }
-    }
 
     signals_init_global();
     resource_init_global();

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -660,6 +660,10 @@ TestResult child_run(/*nonconst*/ struct test *test, int child_number);
 struct test_cfg_info;
 TestResult run_one_test(const test_cfg_info &test_cfg, PerThreadFailures &per_thread_failures);
 
+/* test_knobs.cpp */
+void load_test_knob_args(std::span<const char *const> args);
+void save_test_knob_args(std::vector<const char *> &argv, std::string_view test_id);
+
 /*
  * Called from sandstone_main() before logging_global_init() and before
  * logging_global_finish(). Feel free to add your own banner or footer. Be

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1341,36 +1341,31 @@ static StartedChild call_forkfd()
     return { .pid = pid, .fd = ffd };
 }
 
-static StartedChild spawn_child(const struct test *test, int child_number,
-                                const std::vector<const char *> &common_args)
+static StartedChild spawn_child(int child_number, const std::vector<const char *> &common_args)
 {
     assert(sApp->shmemfd != -1);
-    std::string shmemfdstr = stdprintf("%d", sApp->shmemfd);
     std::string childnumstr = stdprintf("%d", child_number);
-    std::string random_seed = random_format_seed();
 
     StartedChild ret = {};
-#ifdef _WIN32
-    if (sApp->gdb_server_comm.size()) {
-        // we need the actual Windows handle, because the file
-        // descriptors don't inherit properly via gdbserver
-       shmemfdstr = stdprintf("h%tx", _get_osfhandle(sApp->shmemfd));
-    }
-#endif
+
     // argument order must match exec_mode_run()
     std::vector argv = {
         static_cast<const char *>(program_invocation_name), "-x", childnumstr.c_str(),
-        shmemfdstr.c_str(), test->id, random_seed.c_str(),
     };
+    argv.insert(argv.end(), common_args.begin(), common_args.end());
+    assert(argv.back() == nullptr);
 
     if (sApp->gdb_server_comm.size()) {
-        argv.insert(argv.begin(), {
+#ifdef _WIN32
+        // we need the actual Windows handle, because the file
+        // descriptors don't inherit properly via gdbserver
+       static std::string shmemfdstr = stdprintf("h%tx", _get_osfhandle(sApp->shmemfd));
+       argv[3] = shmemfdstr.c_str();
+#endif
+       argv.insert(argv.begin(), {
             "gdbserver", "--no-startup-with-shell", sApp->gdb_server_comm.c_str(),
         });
     }
-
-    argv.insert(argv.end(), common_args.begin(), common_args.end());
-    argv.push_back(nullptr);
 
 #ifdef _WIN32
     // save stderr
@@ -1470,10 +1465,13 @@ static void run_one_test_children(ChildrenList &children, const struct test *tes
             }
         }
     } else {
-        std::vector<const char *> common_args;
+        std::string shmemfdstr = stdprintf("%d", sApp->shmemfd);
+        std::string random_seed = random_format_seed();
+        std::vector<const char *> common_args = { shmemfdstr.c_str(), test->id, random_seed.c_str() };
         save_test_knob_args(common_args, test->id);
+        common_args.push_back(nullptr);
         for (int i = 0; i < child_count; ++i)
-            children.add(spawn_child(test, i, common_args));
+            children.add(spawn_child(i, common_args));
     }
 
     /* wait for the children */

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1350,29 +1350,26 @@ static StartedChild spawn_child(const struct test *test, int child_number)
 
     StartedChild ret = {};
 #ifdef _WIN32
-    // _spawn on Windows requires argv elements to be quoted if they contain space.
-    const char * const argv0 = SANDSTONE_EXECUTABLE_NAME ".exe";
     if (sApp->gdb_server_comm.size()) {
         // we need the actual Windows handle, because the file
         // descriptors don't inherit properly via gdbserver
        shmemfdstr = stdprintf("h%tx", _get_osfhandle(sApp->shmemfd));
     }
-#else
-    const char * const argv0 = SANDSTONE_EXECUTABLE_NAME;
 #endif
-    const char *argv[] = {
-        // argument order must match exec_mode_run()
-        argv0, "-x", test->id, random_seed.c_str(),
+    // argument order must match exec_mode_run()
+    std::vector argv = {
+        static_cast<const char *>(program_invocation_name), "-x", test->id, random_seed.c_str(),
         shmemfdstr.c_str(),
         childnumstr.c_str(),
-        nullptr
     };
 
-    const char *gdbserverargs[std::size(argv) + 3] = {
-        "gdbserver", "--no-startup-with-shell", sApp->gdb_server_comm.c_str(),
-        program_invocation_name
-    };
-    std::copy(argv + 1, std::end(argv), gdbserverargs + 4);
+    if (sApp->gdb_server_comm.size()) {
+        argv.insert(argv.begin(), {
+            "gdbserver", "--no-startup-with-shell", sApp->gdb_server_comm.c_str(),
+        });
+    }
+
+    argv.push_back(nullptr);
 
 #ifdef _WIN32
     // save stderr
@@ -1380,10 +1377,9 @@ static StartedChild spawn_child(const struct test *test, int child_number)
     logging_init_child_preexec();
 
     if (sApp->gdb_server_comm.size()) {
-        // launch gdbserver instead
-        ret.pid = _spawnvp(_P_NOWAIT, gdbserverargs[0], const_cast<char **>(gdbserverargs));
+        ret.pid = _spawnvp(_P_NOWAIT, argv[0], const_cast<char **>(argv.data()));
     } else {
-        ret.pid = _spawnv(_P_NOWAIT, path_to_exe(), argv);
+        ret.pid = _spawnv(_P_NOWAIT, path_to_exe(), const_cast<char **>(argv.data()));
     }
 
     int saved_errno = errno;
@@ -1402,11 +1398,10 @@ static StartedChild spawn_child(const struct test *test, int child_number)
         logging_init_child_preexec();
 
         if (sApp->gdb_server_comm.size()) {
-            // launch gdbserver instead
-            execvp(gdbserverargs[0], const_cast<char **>(gdbserverargs));
+            execvp(argv[0], const_cast<char **>(argv.data()));
         }
 
-        execv(path_to_exe(), const_cast<char **>(argv));
+        execv(path_to_exe(), const_cast<char **>(argv.data()));
         /* does not return */
         perror("execv");
         _exit(EX_OSERR);

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1341,7 +1341,8 @@ static StartedChild call_forkfd()
     return { .pid = pid, .fd = ffd };
 }
 
-static StartedChild spawn_child(const struct test *test, int child_number)
+static StartedChild spawn_child(const struct test *test, int child_number,
+                                const std::vector<const char *> &common_args)
 {
     assert(sApp->shmemfd != -1);
     std::string shmemfdstr = stdprintf("%d", sApp->shmemfd);
@@ -1369,6 +1370,7 @@ static StartedChild spawn_child(const struct test *test, int child_number)
         });
     }
 
+    argv.insert(argv.end(), common_args.begin(), common_args.end());
     argv.push_back(nullptr);
 
 #ifdef _WIN32
@@ -1469,8 +1471,10 @@ static void run_one_test_children(ChildrenList &children, const struct test *tes
             }
         }
     } else {
+        std::vector<const char *> common_args;
+        save_test_knob_args(common_args, test->id);
         for (int i = 0; i < child_count; ++i)
-            children.add(spawn_child(test, i));
+            children.add(spawn_child(test, i, common_args));
     }
 
     /* wait for the children */

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1359,9 +1359,8 @@ static StartedChild spawn_child(const struct test *test, int child_number,
 #endif
     // argument order must match exec_mode_run()
     std::vector argv = {
-        static_cast<const char *>(program_invocation_name), "-x", test->id, random_seed.c_str(),
-        shmemfdstr.c_str(),
-        childnumstr.c_str(),
+        static_cast<const char *>(program_invocation_name), "-x", childnumstr.c_str(),
+        shmemfdstr.c_str(), test->id, random_seed.c_str(),
     };
 
     if (sApp->gdb_server_comm.size()) {

--- a/framework/test_knobs.cpp
+++ b/framework/test_knobs.cpp
@@ -9,6 +9,7 @@
 
 #include <map>
 #include <string>
+#include <span>
 #include <vector>
 #include <boost/algorithm/string.hpp>
 
@@ -76,12 +77,35 @@ public:
     {
         instance().test_knobs.clear();
     }
+
+    static void append_knob_argv(std::vector<const char *> &argv, std::string_view test_id)
+    {
+        for (const auto &e : instance().test_knobs) {
+            size_t dot_pos = e.key.find('.');
+            bool is_for_test = dot_pos == test_id.size() && e.key.starts_with(test_id);
+            if (dot_pos == std::string::npos || is_for_test) {
+                argv.push_back(e.key.c_str());
+                argv.push_back(e.value.c_str());
+            }
+        }
+    }
 };
 }  // end anonymous namespace
 
 
 void clear_test_knobs(){
     TestKnobSingleton::clear();
+}
+
+void load_test_knob_args(std::span<const char *const> args)
+{
+    for (size_t i = 0; i + 1 < args.size(); i += 2)
+        TestKnobSingleton::set_knob(args[i], args[i + 1]);
+}
+
+void save_test_knob_args(std::vector<const char *> &argv, std::string_view test_id)
+{
+    TestKnobSingleton::append_knob_argv(argv, test_id);
 }
 
 // external interface methods


### PR DESCRIPTION
Previously, `-O key=value` was explicitly rejected with a usage error when running in `-f exec` mode because we didn't have a way to accessing the data in the child (it was only visible in the `fork()`ing mode).  This meant there was no way to tune test behaviour on Windows or for GPUs.

This series lifts that restriction by serialising active knobs into the child process's argv and reloading them in `exec_mode_run()`. Plus a bit of refactoring to make the starting of multiple children avoid duplicate work.

No `[ChangeLog]` because we don't advertise the `-O` feature to users.
