### PR TITLE
FW: add `strerror_for_mmap()`

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -83,6 +83,36 @@ static void perror_for_mmap(const char *msg)
 #endif
 }
 
+const char *strerror_for_mmap()
+{
+#if defined(__GLIBC__) && (__GLIBC__ * 10000 + __GLIBC_MINOR__ >= 20032)
+    // no need for thread-local variable, just use the static string in glibc
+    return strerrordesc_np(errno);
+#elif defined(_WIN32)
+    // initializing a thread_local on Windows overwrites GetLastError!!!
+    DWORD last = GetLastError();
+    static thread_local std::string s;
+    s = win32_strerror(last);
+    return s.c_str();
+#else
+    // There are two flavors of strerror_r():
+    char buf[512];
+    auto assign = [&](auto res) -> const char * {
+        if constexpr (std::is_pointer_v<decltype(res)>) {
+            // GNU variant, which we usually see on Linux, which may write to
+            // buf or return a constant message
+            if (res != buf)
+                return res;
+        }
+        // the POSIX variant always writes to buf
+        static thread_local std::string s;
+        s = buf;
+        return s.c_str();
+    };
+    return assign(strerror_r(errno, buf, sizeof(buf)));
+#endif
+}
+
 static int open_runtime_file_internal(const char *name, int flags, int mode)
 {
     assert(strchr(name, '/') == nullptr);

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -474,6 +474,11 @@ extern void log_yaml(char levelchar, const char *yaml);
 /// privileges.
 uint64_t retrieve_physical_address(const volatile void *ptr);
 
+/// Returns the error message after the last mmap() call failed. This function
+/// must be called before anything overwrites @c errno or @c GetLastError().
+/// This is for mmap() because we implement a compatibility layer for Windows.
+const char *strerror_for_mmap();
+
 #if defined(__linux__) && defined(__x86_64__)
 /// reads the value of the MSR, specified by msr, of CPU cpu.
 /// The value is returned in the value parameter.  The function


### PR DESCRIPTION
In spite of #774, we may miss important details that `FormatMessage` can produce on Windows. This function can be used by tests.