### PR TITLE
forkfd: Add support for Linux M68k

### DIFF
--- a/framework/forkfd/forkfd_linux.c
+++ b/framework/forkfd/forkfd_linux.c
@@ -78,7 +78,7 @@ static int sys_clone(unsigned long cloneflags, int *ptid)
 #elif defined(__arc__) || defined(__arm__) || defined(__aarch64__) || defined(__mips__) || \
     defined(__nds32__) || defined(__hppa__) || defined(__powerpc__) || defined(__i386__) || \
     defined(__x86_64__) || defined(__xtensa__) || defined(__alpha__) || defined(__riscv) || \
-    defined(__loongarch__) || defined(__sparc__)
+    defined(__loongarch__) || defined(__sparc__) || defined(__m68k__)
     /* ctid and newtls are inverted on CONFIG_CLONE_BACKWARDS architectures,
      * but since both values are 0, there's no harm. */
     return syscall(__NR_clone, cloneflags, child_stack, ptid, ctid, newtls);


### PR DESCRIPTION
M68k is not a CLONE_BACKWARDS architecture.