### PR TITLE
FW/NoLogging: simplify `test_init()` when preinit causes skips

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -178,12 +178,11 @@ static void preinit_tests()
         return e.replacement;
     };
 
-    int preinit_ret = EXIT_SUCCESS;
-    bool truncate_log = false; // preinit may clutter the main thread's log file
-
     for (test_cfg_info &cfg : *test_set) {
+        int preinit_ret = EXIT_SUCCESS;
+        bool truncate_log = false; // preinit may clutter the main thread's log file
         struct test *test = cfg.test;
-        preinit_ret = EXIT_SUCCESS;
+
         if (test->test_preinit) {
             sApp->main_thread_data()->init();
             preinit_ret = test->test_preinit(test);
@@ -230,7 +229,6 @@ static void preinit_tests()
 
         if (truncate_log) {
             AbstractLogger::truncate_log(sApp->thread_data(-1));
-            truncate_log = false;
         }
     }
 }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -186,6 +186,7 @@ static void preinit_tests()
         if (test->test_preinit) {
             sApp->main_thread_data()->init();
             preinit_ret = test->test_preinit(test);
+            assert(preinit_ret <= EXIT_SUCCESS && "preinit functions cannot fail");
             test->test_preinit = nullptr;   // don't rerun in case the test is re-added
             truncate_log = true;
         }
@@ -210,21 +211,29 @@ static void preinit_tests()
         // Skip from group init has precendence over preinit.
         if (!init_replaced && preinit_ret != EXIT_SUCCESS) {
             test->flags = test->flags | test_init_in_parent; // for -fexec
-            std::string skip_message = AbstractLogger::get_skip_message(-1);
-            assert(SandstoneConfig::NoLogging || (!skip_message.empty() && "Internal error: Skip in preinit must provide a skip reason"));
+            if (SandstoneConfig::NoLogging) {
+                test->test_init = [](struct test *test) {
+                    // category doesn't matter, there's no logging
+                    log_skip(UnknownSkipCategory, nullptr);
+                    return EXIT_SKIP;
+                };
+            } else {
+                std::string skip_message = AbstractLogger::get_skip_message(-1);
+                assert(!skip_message.empty() && "Internal error: Skip in preinit must provide a skip reason");
 
-            char* msg_ptr = strdup(skip_message.c_str());
-            test->data = msg_ptr;
+                char* msg_ptr = strdup(skip_message.c_str());
+                test->data = msg_ptr;
 
-            test->test_init = [](struct test* test) {
-                auto msg_ptr = static_cast<const char*>(test->data);
-                log_skip(static_cast<SkipCategory>(msg_ptr[0]), "%s", msg_ptr + 1);
-                return EXIT_SKIP;
-            };
-            test->test_postcleanup = [](struct test* test) {
-                free(std::exchange(test->data, nullptr));
-                return EXIT_SUCCESS;
-            };
+                test->test_init = [](struct test* test) {
+                    auto msg_ptr = static_cast<const char*>(test->data);
+                    log_skip(static_cast<SkipCategory>(msg_ptr[0]), "%s", msg_ptr + 1);
+                    return EXIT_SKIP;
+                };
+                test->test_postcleanup = [](struct test* test) {
+                    free(std::exchange(test->data, nullptr));
+                    return EXIT_SUCCESS;
+                };
+            }
         }
 
         if (truncate_log) {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -194,14 +194,14 @@ static void preinit_tests()
         // If the group_init function decides that the group cannot run at all,
         // it will return a pointer to a replacement function that will in turn
         // cause the test to fail or skip during test_init().
-        bool group_init_failed = false;
+        bool init_replaced = false;
         if (test->groups) {
             for (auto ptr = test->groups; *ptr; ++ptr) {
                 const struct test_group *group = *ptr;
                 initfunc group_init_replacement = cached_replacement(group);
                 if (!group_init_replacement)
                     continue;
-                group_init_failed = true;
+                init_replaced = true;
                 test->test_init = group_init_replacement;
                 test->flags = test->flags | test_init_in_parent;
                 break;
@@ -209,7 +209,7 @@ static void preinit_tests()
         }
 
         // Skip from group init has precendence over preinit.
-        if (!group_init_failed && preinit_ret != EXIT_SUCCESS) {
+        if (!init_replaced && preinit_ret != EXIT_SUCCESS) {
             test->flags = test->flags | test_init_in_parent; // for -fexec
             std::string skip_message = AbstractLogger::get_skip_message(-1);
             assert(SandstoneConfig::NoLogging || (!skip_message.empty() && "Internal error: Skip in preinit must provide a skip reason"));


### PR DESCRIPTION
Amends commit a62d62f22be67144c4c44eecd69508a31be88492 (PR #1030). When we aren't logging, there's no logged message from the preinit (as seen in the `assert()` that was there) and therefore nothing to be strdup'ed.