### PR TITLE
FW/Win32: fix mmap() with non-zero offset

### DIFF
--- a/framework/sysdeps/windows/mman.c
+++ b/framework/sysdeps/windows/mman.c
@@ -166,8 +166,9 @@ void *mmap(void *addr, size_t length, int prot, int flags, int fildes, off_t off
         hFile = (HANDLE)_get_osfhandle(fildes);
     }
 
-    uint32_t lsize = length & 0xFFFFFFFF;
-    uint32_t hsize = (length >> 32) & 0xFFFFFFFF;
+    size_t map_size = (size_t)off + length;
+    uint32_t lsize = map_size & 0xFFFFFFFF;
+    uint32_t hsize = ((uint64_t)map_size >> 32) & 0xFFFFFFFF;
     LPSECURITY_ATTRIBUTES lpFileMappingAttributes = NULL;
     LPCWSTR lpName = NULL;
     DWORD flMaxProtect = map_max_protection(prot, flags);


### PR DESCRIPTION
CreateFileMappingW's dwMaximumSizeHigh/Low parameters describe the total size of the file mapping object.  Passing only `length` means that any view mapped at a non-zero offset that reaches beyond `length` bytes from the start of the file returns ERROR_ACCESS_DENIED from MapViewOfFileEx.

Fix by computing the required mapping object size as off + length. Amends commit ea0080dd71a40d91c59ca8d043639fee4a2a0ae0 in the old repository.