### PR TITLE
FW/child_debug: print the 32 bytes around $pc when showing a crash

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1892,6 +1892,53 @@ selftest_crash_common() {
     fi
 }
 
+crash_code_dump_common() {
+    local testname=$1 signame=$2
+    if $is_windows; then
+        skip "Unix-only test"
+    fi
+    check_gdb_usable
+    sandstone_selftest -n1 -e $testname --on-crash=context
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+    test_yaml_regexp "/tests/0/result" crash
+    local signum=`kill -l $signame`
+    test_yaml_regexp "/tests/0/threads/1/messages/0/text" \
+        ".*Received signal $signum \(.*\) code=[0-9]+.* RIP = 0x.*"
+    test_yaml_regexp "/tests/0/threads/1/messages/2/text" \
+        "Code around RIP \(0x[0-9a-f]+\):"
+}
+
+@test "crash code dump (sigill near unreadable)" {
+    declare -A yamldump
+    crash_code_dump_common selftest_sigill_near_unreadable ILL
+    # RIP row: some readable hex bytes followed by ??
+    test_yaml_regexp "/tests/0/threads/1/messages/2/text" \
+        " +0x[0-9a-f]+: ([0-9a-f]{2} )+(\?\? )+\?\?"
+}
+
+@test "crash code dump (sigsegv readable-unreadable)" {
+    declare -A yamldump
+    crash_code_dump_common selftest_sigsegv_readable_unreadable SEGV
+    # First row: some readable bytes then ??
+    test_yaml_regexp "/tests/0/threads/1/messages/2/text" \
+        " +0x[0-9a-f]+: ([0-9a-f]{2} )+(\?\? )+\?\?"
+    # RIP row: entirely ??
+    test_yaml_regexp "/tests/0/threads/1/messages/2/text" \
+        " +0x[0-9a-f]+: (\?\? )+\?\?"
+}
+
+@test "crash code dump (sigsegv unreadable-readable)" {
+    declare -A yamldump
+    crash_code_dump_common selftest_sigsegv_unreadable_readable SEGV
+    # Row 0: entirely ?? (RIP page unmapped)
+    test_yaml_regexp "/tests/0/threads/1/messages/2/text" \
+        " +0x[0-9a-f]+: (\?\? )+\?\?"
+    # Row 1: some ?? followed by readable bytes
+    test_yaml_regexp "/tests/0/threads/1/messages/2/text" \
+        " +0x[0-9a-f]+: (\?\? )+([0-9a-f]{2} )+[0-9a-f]{2}"
+}
+
 @test "crash backtrace" {
     check_gdb_usable
     declare -A yamldump

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1894,17 +1894,21 @@ selftest_crash_common() {
 
 crash_code_dump_common() {
     local testname=$1 signame=$2
-    if $is_windows; then
-        skip "Unix-only test"
+    if ! $is_windows; then
+        check_gdb_usable
     fi
-    check_gdb_usable
     sandstone_selftest -n1 -e $testname --on-crash=context
     [[ "$status" -eq 1 ]]
     test_yaml_regexp "/exit" fail
     test_yaml_regexp "/tests/0/result" crash
-    local signum=`kill -l $signame`
-    test_yaml_regexp "/tests/0/threads/1/messages/0/text" \
-        ".*Received signal $signum \(.*\) code=[0-9]+.* RIP = 0x.*"
+    if $is_windows; then
+        test_yaml_regexp "/tests/0/threads/1/messages/0/text" \
+            ".*Received exception 0x[0-9a-f]+ \(.*\), RIP = 0x.*"
+    else
+        local signum=`kill -l $signame`
+        test_yaml_regexp "/tests/0/threads/1/messages/0/text" \
+            ".*Received signal $signum \(.*\) code=[0-9]+.* RIP = 0x.*"
+    fi
     test_yaml_regexp "/tests/0/threads/1/messages/2/text" \
         "Code around RIP \(0x[0-9a-f]+\):"
 }

--- a/bats/sanity-check/helpers.bash
+++ b/bats/sanity-check/helpers.bash
@@ -124,10 +124,19 @@ selftest_crash_context_common() {
     fi
 
     if [[ `uname -m` = x86_64 ]]; then
-        # OpenDCDiag's built-in register dumper is only implemented for x86-64
-        msgidx=$((yamldump[/tests/0/threads/$threadidx/messages@len] - 1))
-        test_yaml_regexp "/tests/0/threads/$threadidx/messages/$msgidx/level" "info"
-        test_yaml_regexp "/tests/0/threads/$threadidx/messages/$msgidx/text" "Registers:"
-        test_yaml_regexp "/tests/0/threads/$threadidx/messages/$msgidx/text" " rax += 0x[0-9a-f]{16}.*"
+        # OpenDCDiag's built-in register dumper is only implemented for x86-64.
+        # Scan messages to find the one containing "Registers:".
+        local msgcount=$((yamldump[/tests/0/threads/$threadidx/messages@len]))
+        local regmsgidx=-1
+        for ((i = 0; i < msgcount; ++i)); do
+            if [[ "${yamldump[/tests/0/threads/$threadidx/messages/$i/text]}" = *"Registers:"* ]]; then
+                regmsgidx=$i
+                break
+            fi
+        done
+        (( regmsgidx >= 0 ))
+        test_yaml_regexp "/tests/0/threads/$threadidx/messages/$regmsgidx/level" "info"
+        test_yaml_regexp "/tests/0/threads/$threadidx/messages/$regmsgidx/text" "Registers:"
+        test_yaml_regexp "/tests/0/threads/$threadidx/messages/$regmsgidx/text" " rax += 0x[0-9a-f]{16}.*"
     fi
 }

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -264,6 +264,8 @@ if target_machine.system() == 'darwin'
     ]
 endif
 
+framework_extra_cpp_args = []
+
 if target_machine.system() != 'windows' and target_machine.system() != 'cygwin'
     subdir('sysdeps/unix')
 endif
@@ -316,6 +318,7 @@ framework_a = static_library(
         march_flags,
         default_cpp_flags,
         default_cpp_warn,
+        framework_extra_cpp_args,
     ],
 )
 

--- a/framework/sandstone_child_debug_common.h
+++ b/framework/sandstone_child_debug_common.h
@@ -7,8 +7,10 @@
 #define SANDSTONE_CHILD_DEBUG_COMMON_H
 
 #include "sandstone_context_dump.h"
+#include "sandstone_utils.h"
 
 #include <stdint.h>
+#include <string>
 
 #ifdef __x86_64__
 #  include "xsave_states.h"
@@ -57,5 +59,34 @@ static int get_xsave_size()
     return 0;
 }
 #endif // x86_64
+
+struct CodeDump
+{
+    static constexpr size_t TotalBytes   = 32;
+    static constexpr size_t BytesBefore  = 16;  // bytes before RIP
+
+    uint8_t bytes[TotalBytes] = {};
+    size_t valid_start = 0;
+    size_t valid_end   = 0;
+
+    bool has_data() const { return valid_start < valid_end; }
+};
+
+inline std::string format_code_dump(const void *rip, const CodeDump &dump)
+{
+    if (!dump.has_data())
+        return {};
+    uintptr_t base = uintptr_t(rip) - CodeDump::BytesBefore;
+    std::string log = stdprintf("Code around RIP (0x%tx):\n", uintptr_t(rip));
+    for (size_t row = 0; row < CodeDump::TotalBytes; row += 16) {
+        log += stdprintf("  0x%tx:", base + row);
+        for (size_t i = row; i < row + 16; ++i) {
+            bool valid = (i >= dump.valid_start && i < dump.valid_end);
+            log += valid ? stdprintf(" %02x", dump.bytes[i]) : std::string(" ??");
+        }
+        log += "\n";
+    }
+    return log;
+}
 
 #endif // SANDSTONE_CHILD_DEBUG_COMMON_H

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -981,8 +981,74 @@ static void cause_sigsegv_noncanonical()
 
 static void cause_sigsegv_instruction()
 {
-    uintptr_t ptr = rand() & 0xfff;
+    // Jump near a page boundary so that both the page containing the address
+    // and the adjacent page are unmapped.
+    uintptr_t ptr = 0xff0 + (rand() & 0xf);
     force_call(ptr);
+}
+
+static void cause_sigill_partial()
+{
+    constexpr size_t page_size = 4096;
+    // Map writable first so we can write the instruction bytes.
+    auto *pages = static_cast<uint8_t *>(
+            mmap(nullptr, 2 * page_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (pages == MAP_FAILED) {
+        log_skip(SelftestSkipCategory, "mmap failed: %s", strerror_for_mmap());
+        return;
+    }
+
+    // Write a guaranteed-crash instruction 8 bytes before the page boundary
+    // (offset 0xff8) so that RIP is valid/readable but the 8 bytes after it
+    // cross into PROT_NONE, producing a partial code dump.
+    uint8_t *insn = pages + page_size - 8;
+#if defined(__x86_64__)
+    insn[0] = 0x0f; insn[1] = 0x0b;    // UD2
+#elif defined(__aarch64__)
+    insn[0] = 0x00; insn[1] = 0x00; insn[2] = 0x00; insn[3] = 0x00;   // UDF #0
+#else
+    log_skip(SelftestSkipCategory, "unsupported architecture");
+    munmap(pages, 2 * page_size);
+    return;
+#endif
+
+    if (mprotect(pages, page_size, PROT_READ | PROT_EXEC) < 0
+            || mprotect(pages + page_size, page_size, PROT_NONE) < 0) {
+        log_skip(SelftestSkipCategory, "mprotect failed: %s", strerror_for_mmap());
+        munmap(pages, 2 * page_size);
+        return;
+    }
+    force_call(uintptr_t(insn));
+    munmap(pages, 2 * page_size);
+}
+
+static void cause_sigsegv_readable_unreadable()
+{
+    constexpr size_t page_size = 4096;
+    // First page readable, second PROT_NONE. Jump 4 bytes into the unreadable
+    // page: row 1 of the dump shows readable bytes then ??, row 2 is all ??.
+    auto *pages = static_cast<uint8_t *>(
+            mmap(nullptr, 2 * page_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (pages == MAP_FAILED || mprotect(pages, page_size, PROT_READ | PROT_EXEC) < 0) {
+        log_skip(SelftestSkipCategory, "mmap/mprotect failed: %s", strerror_for_mmap());
+        return;
+    }
+    force_call(uintptr_t(pages + page_size + 4));
+    munmap(pages, 2 * page_size);
+}
+
+static void cause_sigsegv_unreadable_readable()
+{
+    constexpr size_t page_size = 4096;
+    // First page PROT_NONE, second readable. Jump 4 bytes before the readable page.
+    auto *pages = static_cast<uint8_t *>(
+            mmap(nullptr, 2 * page_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (pages == MAP_FAILED || mprotect(pages + page_size, page_size, PROT_READ | PROT_EXEC) < 0) {
+        log_skip(SelftestSkipCategory, "mmap/mprotect failed: %s", strerror_for_mmap());
+        return;
+    }
+    force_call(uintptr_t(pages + page_size - 4));
+    munmap(pages, 2 * page_size);
 }
 
 static void cause_sigtrap_int3()
@@ -2282,6 +2348,30 @@ FOREACH_DATATYPE(DATACOMPARE_TEST)
     .description = "Crashes with SIGSEGV (instruction)",
     .groups = DECLARE_TEST_GROUPS(&group_negative),
     .test_run = selftest_crash_run<cause_sigsegv_instruction>,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_sigill_near_unreadable",
+    .description = "Crashes with SIGILL (UD2/UDF instruction) near a readable/unmapped page boundary",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_run = selftest_crash_run<cause_sigill_partial>,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_sigsegv_readable_unreadable",
+    .description = "Crashes with SIGSEGV (instruction) jumping from a readable page into an unmapped page",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_run = selftest_crash_run<cause_sigsegv_readable_unreadable>,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_sigsegv_unreadable_readable",
+    .description = "Crashes with SIGSEGV (instruction) on an unmapped page adjacent to a readable page",
+    .groups = DECLARE_TEST_GROUPS(&group_negative),
+    .test_run = selftest_crash_run<cause_sigsegv_unreadable_readable>,
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -260,11 +260,9 @@ static void child_crash_handler(int signum, siginfo_t *si, void *ucontext)
         // let parent process know
         CrashContext::send(socket, si, ucontext);
 
-        if (on_crash_action & attach_gdb_on_crash) {
-            // now wait for the parent process to be done with us
-            while (thread_state.load(std::memory_order_relaxed) == thread_failed)
-                futex_wait(&thread_state, int(thread_failed));
-        }
+        // wait for the parent process to be done with us
+        while (thread_state.load(std::memory_order_relaxed) == thread_failed)
+            futex_wait(&thread_state, int(thread_failed));
     }
 
     // restore the signal handler so we can be killed
@@ -1125,10 +1123,8 @@ void debug_crashed_child(std::span<const pid_t> children)
         // release the child
         auto &thread_state = sApp->main_thread_data(slice)->thread_state;
         thread_state.load(std::memory_order_acquire);
-        if (on_crash_action != context_on_crash) {
-            thread_state.store(thread_debugged, std::memory_order_relaxed);
-            futex_wake_all(&thread_state);
-        }
+        thread_state.store(thread_debugged, std::memory_order_relaxed);
+        futex_wake_all(&thread_state);
     }
 }
 

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -912,6 +912,48 @@ static bool print_signal_info(const CrashContext::Fixed &ctx)
     return true;
 }
 
+static std::string dump_code_around_pc(pid_t pid, const void *pc)
+{
+#if HAVE_PROCESS_VM_READV
+    CodeDump dump;
+
+    uintptr_t base = uintptr_t(pc) - CodeDump::BytesBefore;
+    uintptr_t last = base + CodeDump::TotalBytes - 1;
+
+    static constexpr uintptr_t PageMask = 4096 - 1;
+
+    if ((base & ~PageMask) == (last & ~PageMask)) {
+        // All bytes fall on the same page: single call suffices.
+        struct iovec local_iov  = { dump.bytes,                         CodeDump::TotalBytes };
+        struct iovec remote_iov = { reinterpret_cast<void *>(base),     CodeDump::TotalBytes };
+        ssize_t n = process_vm_readv(pid, &local_iov, 1, &remote_iov, 1, 0);
+        if (n <= 0)
+            return {};
+        dump.valid_start = 0;
+        dump.valid_end   = n;
+    } else {
+        // The range spans a page boundary: read each page independently so
+        // that an unmapped page on one side doesn't suppress the other.
+        size_t first_len  = (base | PageMask) + 1 - base;
+        size_t second_len = CodeDump::TotalBytes - first_len;
+        struct iovec local1  = { dump.bytes,              first_len  };
+        struct iovec remote1 = { reinterpret_cast<void *>(base),              first_len  };
+        struct iovec local2  = { dump.bytes + first_len,  second_len };
+        struct iovec remote2 = { reinterpret_cast<void *>(base + first_len),  second_len };
+        ssize_t n1 = process_vm_readv(pid, &local1, 1, &remote1, 1, 0);
+        ssize_t n2 = process_vm_readv(pid, &local2, 1, &remote2, 1, 0);
+        if (n1 <= 0 && n2 <= 0)
+            return {};
+        dump.valid_start = (n1 > 0) ? 0          : first_len;
+        dump.valid_end   = (n2 > 0) ? first_len + n2 : n1;
+    }
+
+    return format_code_dump(pc, dump);
+#else
+    return {};
+#endif  // HAVE_PROCESS_VM_READV
+}
+
 static void print_crash_info(int slice, const char *pidstr, CrashContext &ctx)
 {
     int thread = -1;
@@ -933,8 +975,11 @@ static void print_crash_info(int slice, const char *pidstr, CrashContext &ctx)
         generate_backtrace(pidstr, slice, handle, thread);
     }
 
+    if (!handle)
+        return;
+
     // now include the register state
-    if (handle && ctx.contents & CrashContext::MachineContext) {
+    if (ctx.contents & CrashContext::MachineContext) {
         std::string log;
 
 #ifdef __x86_64__
@@ -947,6 +992,11 @@ static void print_crash_info(int slice, const char *pidstr, CrashContext &ctx)
             log_message_preformatted(thread, LOG_LEVEL_VERBOSE(2), log);
         }
     }
+
+    // Dump code bytes around RIP.
+    if (std::string code_log = dump_code_around_pc(ctx.fixed.pid, ctx.fixed.rip);
+            !code_log.empty())
+        log_message_preformatted(thread, LOG_LEVEL_VERBOSE(2), code_log);
 }
 
 void debug_init_global(const char *on_hang_arg, const char *on_crash_arg)

--- a/framework/sysdeps/unix/meson.build
+++ b/framework/sysdeps/unix/meson.build
@@ -15,3 +15,7 @@ framework_files += files(
 if get_option('cpp_link_args').contains('-static')
     framework_config.set10('SANDSTONE_STATIC', true)
 endif
+
+if cpp.has_function('process_vm_readv', prefix: '#include <sys/uio.h>')
+    framework_extra_cpp_args += ['-DHAVE_PROCESS_VM_READV=1']
+endif

--- a/framework/sysdeps/windows/child_debug.cpp
+++ b/framework/sysdeps/windows/child_debug.cpp
@@ -44,6 +44,7 @@ struct CrashContext
             CONTEXT_FULL;
 
     Header header;
+    CodeDump code_dump;
     EXCEPTION_RECORD exceptionRecord;
     alignas(64) CONTEXT fixedContext;
     char xsave_area[];      // C99 Flexible Array Member
@@ -102,6 +103,40 @@ close_hslot:
     return false;
 }
 
+static CodeDump dump_code_around_pc(const void *pc)
+{
+    // ReadProcessMemory on the current process handles unmapped pages
+    // gracefully (returns FALSE); read each page independently so that
+    // an unmapped page on one side doesn't suppress the other.
+    CodeDump dump;
+    if (!pc)
+        return dump;
+
+    static constexpr uintptr_t PageMask = 4096 - 1;
+    uintptr_t base = uintptr_t(pc) - CodeDump::BytesBefore;
+    uintptr_t last = base + CodeDump::TotalBytes - 1;
+    if ((base & ~PageMask) == (last & ~PageMask)) {
+        SIZE_T n = 0;
+        if (ReadProcessMemory(GetCurrentProcess(), LPCVOID(base), dump.bytes, CodeDump::TotalBytes, &n)) {
+            dump.valid_start = 0;
+            dump.valid_end   = n;
+        }
+    } else {
+        size_t first_len  = (base | PageMask) + 1 - base;
+        size_t second_len = CodeDump::TotalBytes - first_len;
+        SIZE_T n1 = 0, n2 = 0;
+        bool ok1 = ReadProcessMemory(GetCurrentProcess(), LPCVOID(base),
+                                     dump.bytes, first_len, &n1);
+        bool ok2 = ReadProcessMemory(GetCurrentProcess(), LPCVOID(base + first_len),
+                                     dump.bytes + first_len, second_len, &n2);
+        if (ok1 || ok2) {
+            dump.valid_start = ok1 ? 0          : first_len;
+            dump.valid_end   = ok2 ? first_len + n2 : n1;
+        }
+    }
+    return dump;
+}
+
 static LONG WINAPI handler(EXCEPTION_POINTERS *info)
 {
     // Ignore non-error or user-defined exceptions. See
@@ -138,6 +173,13 @@ static LONG WINAPI handler(EXCEPTION_POINTERS *info)
     if (uintptr_t(info->ExceptionRecord->ExceptionAddress) >= executableImageStart
             && uintptr_t(info->ExceptionRecord->ExceptionAddress) < executableImageEnd)
         ctx->header.baseAddress = executableImageStart;
+
+    // Read code bytes around the PC before the process exits.
+    void *pc = nullptr;
+#ifdef __x86_64__
+    pc = reinterpret_cast<void *>(ctx->fixedContext.Rip);
+#endif
+    ctx->code_dump = dump_code_around_pc(pc);
 
     if (!WriteFile(HANDLE(sApp->shmem->child_debug_socket), ctx, context_size, nullptr, nullptr))
         win32_perror("WriteFile for mailslot");
@@ -334,6 +376,14 @@ void debug_crashed_child(std::span<const pid_t> children)
             log.insert(0, "Registers:\n");
             log_message_preformatted(thread, LOG_LEVEL_VERBOSE(2), log);
         }
+
+        void *pc = nullptr;
+#ifdef __x86_64__
+        pc = reinterpret_cast<void *>(ctx->fixedContext.Rip);
+#endif
+        if (std::string code_log = format_code_dump(pc, ctx->code_dump);
+                !code_log.empty())
+            log_message_preformatted(thread, LOG_LEVEL_VERBOSE(2), code_log);
     }
 
     // got here on failure


### PR DESCRIPTION
Because this isn't useful:
```yaml
    messages:
    - { level: error, text: 'E> Received signal 4 (Illegal instruction) code=2 (ILL_ILLOPN), RIP = 0x7ffff656f080, trap=6 (UD), error_code = 0x0' }
    - level: warning
      text: |1
       W> #3  0x00007ffff656f080 in ?? ()
       => 0x7ffff656f080:       (bad)
```

That doesn't tell me if it was a garbage/bad instruction, or if it was a good instruction not supported in the current machine that the user's gdb was unable to disassemble.

We use the Linux system call process_vm_readv(2) to read up to 32 bytes centered on $pc (16 bytes before, 16 bytes after) and print them to the log below the register state.

When the 32-byte window crosses a page boundary, each page is read independently so that an error reading page on one side does not suppress bytes from the other side. Bytes that could not be read are shown as "??". For example:
```yaml
    - level: info
      text: |1
       Code around RIP (0x7f0aea6a3ffc):
         0x7f0aea6a3fec: ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ??
         0x7f0aea6a3ffc: ?? ?? ?? ?? 00 00 00 00 00 00 00 00 00 00 00 00
```

This commit adds three new selftests to check those boundary conditions:
- `selftest_sigill_partial`: crash on valid RIP, but near unreadable bytes
- `selftest_sigsegv_readable_unreadable`: crash on invalid RIP with the unreadable page coming after the readable one.
- `selftest_sigsegv_unreadable_readable`: crash on invalid RIP with the unreadable page coming before the readable one.

Plus a modification to `selftest_sigsegv_instruction` so the crash is always near the page boundary. Assuming 0x1000 is also unreadable, this should cause both page reads to fail and no bytes to get logged.

[ChangeLog][Framework] Added a feature to print the bytes of the instructions whenever a crash is detected.

Exercise left for the reader: for architectures where instructions are fixed-size and aligned, like AArch64, consider aligning the value from $pc and printing as words instead of bytes.
