### PR TITLE
FW/Selftests: fix build with older GCCs

### DIFF
--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -727,7 +727,7 @@ template <typename T> static int selftest_datacomparefail_run(struct test *, int
     if constexpr (std::is_same_v<T, uint8_t>) {
         // stateless comparison with no description
         memcmp_or_fail(values, values + 1, Count);
-    } else if constexpr (std::is_same_v<T, _Float16>) {
+    } else if constexpr (std::is_same_v<T, float>) {
         // older, printf-like formatting
         memcmp_or_fail(values, values + 1, Count,
                        "data of type '%s'\n"


### PR DESCRIPTION
On some older versions, we don't have `_Float16`. So just use `float` here - it doesn't matter what the type is, we just want one of the types so we can test different paths.

Amends commit eb60797894403a1405d3942925a76ae9983dcb3e.