### PR TITLE
FW/YAML: change the formatting of large numeric values

### DIFF
--- a/framework/sandstone_utils.cpp
+++ b/framework/sandstone_utils.cpp
@@ -271,18 +271,18 @@ struct FormatSimpleValue
     void operator()(uint64_t v)
     {
         if (v < 4096)
-            append_to += stdprintf("%u", unsigned(v));
-        else
+            append_to += stdprintf("%" PRIu64, v);
+        else if (int64_t(v) >= 0)
             append_to += stdprintf("0x%" PRIx64, v);
+        else
+            append_to += stdprintf("'0x%" PRIx64 "'", v);
     }
     void operator()(int64_t v)
     {
         if (v >= 0)
             operator()(uint64_t(v));
-        else if (v >= -4096)
-            append_to += stdprintf("%d", int(v));
         else
-            append_to += stdprintf("-0x%" PRIx64, -(uint64_t(v)));
+            append_to += stdprintf("%" PRId64, v);
     }
     void operator()(double v)
     {

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -209,6 +209,8 @@ static int selftest_logformattedyaml_run(struct test *test, int cpu)
         { "cpu", cpu },
         { "random", random64() },
         { "text", std::string_view("foo bar") },
+        { "large_number", int64_t(LLONG_MAX) },
+        { "small_number", int64_t(LLONG_MIN) },
     };
     log_yaml(SANDSTONE_LOG_INFO, "Some details from the test", map);
     return EXIT_SUCCESS;

--- a/framework/unit-tests/sandstone_utils_tests.cpp
+++ b/framework/unit-tests/sandstone_utils_tests.cpp
@@ -764,13 +764,13 @@ TEST(YamlFormatter, integer) {
     EXPECT_EQ(format_yaml("key", 4095), "key: 4095");
     EXPECT_EQ(format_yaml("key", -4096), "key: -4096");
     EXPECT_EQ(format_yaml("key", 4096), "key: 0x1000");
-    EXPECT_EQ(format_yaml("key", -4097), "key: -0x1001");
+    EXPECT_EQ(format_yaml("key", -4097), "key: -4097");
     EXPECT_EQ(format_yaml("key", INT_MAX), "key: 0x7fffffff");
-    EXPECT_EQ(format_yaml("key", INT_MIN), "key: -0x80000000");
+    EXPECT_EQ(format_yaml("key", INT_MIN), "key: -2147483648");
     EXPECT_EQ(format_yaml("key", int64_t(INT_MAX) + 1), "key: 0x80000000");
-    EXPECT_EQ(format_yaml("key", int64_t(INT_MIN) - 1), "key: -0x80000001");
+    EXPECT_EQ(format_yaml("key", int64_t(INT_MIN) - 1), "key: -2147483649");
     EXPECT_EQ(format_yaml("key", std::numeric_limits<int64_t>::max()), "key: 0x7fffffffffffffff");
-    EXPECT_EQ(format_yaml("key", std::numeric_limits<int64_t>::min()), "key: -0x8000000000000000");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<int64_t>::min()), "key: -9223372036854775808");
 
     EXPECT_EQ(format_yaml("key", uint64_t(0)), "key: 0");
     EXPECT_EQ(format_yaml("key", uint64_t(1)), "key: 1");
@@ -778,8 +778,11 @@ TEST(YamlFormatter, integer) {
     EXPECT_EQ(format_yaml("key", uint64_t(4096)), "key: 0x1000");
     EXPECT_EQ(format_yaml("key", uint64_t(INT_MAX)), "key: 0x7fffffff");
     EXPECT_EQ(format_yaml("key", uint64_t(std::numeric_limits<int64_t>::max())), "key: 0x7fffffffffffffff");
-    EXPECT_EQ(format_yaml("key", uint64_t(std::numeric_limits<int64_t>::min())), "key: 0x8000000000000000");
-    EXPECT_EQ(format_yaml("key", std::numeric_limits<uint64_t>::max()), "key: 0xffffffffffffffff");
+
+    // we always print as signed quantities because some YAML parsers don't like
+    // numbers out of the int64_t range
+    EXPECT_EQ(format_yaml("key", uint64_t(std::numeric_limits<int64_t>::min())), "key: '0x8000000000000000'");
+    EXPECT_EQ(format_yaml("key", std::numeric_limits<uint64_t>::max()), "key: '0xffffffffffffffff'");
 }
 
 TEST(YamlFormatter, floating_point) {


### PR DESCRIPTION
Amends commit 195c83d846a117c7f6f36aff0d91a16853274249, which introduced this. Some YAML parsers[1] don't like numbers too big:

```
$ yq -ojson . <<<'random: 0x8000000000000000'
strconv.ParseInt: parsing "8000000000000000": value out of range
$ yq -ojson . <<<'random: -0x1'
strconv.ParseInt: parsing "-0x1": invalid syntax
```

So let's print large unsigned numbers as strings and all negative numbers as decimals.

[1] https://github.com/mikefarah/yq