### PR TITLE
cpu_device: guard has_smt() against invalid topology

### DIFF
--- a/framework/device/cpu/cpu_device.cpp
+++ b/framework/device/cpu/cpu_device.cpp
@@ -57,14 +57,6 @@ void dump_device_info()
 
 TestResult prepare_test_for_device(struct test *test)
 {
-    auto has_core_id_defined = []() -> bool {
-        for(int idx = 0; idx < thread_count(); idx++) {
-            if (device_info[idx].core_id == -1)
-                return false;
-        }
-        return true;
-    };
-
     auto has_smt = []() -> bool {
         for(int idx = 0; idx < thread_count() - 1; idx++) {
             if (device_info[idx].package_id == device_info[idx + 1].package_id &&
@@ -75,7 +67,7 @@ TestResult prepare_test_for_device(struct test *test)
     };
 
     if (test->flags & test_requires_smt) {
-        if (!has_core_id_defined()) {
+        if (!Topology::topology().isValid()) {
             log_skip(CpuTopologyIssueSkipCategory, "Test requires topology information");
             return TestResult::Skipped;
         }


### PR DESCRIPTION
When topology detection fails all `core_id` and `package_id` fields are initialised to `-1`. The adjacent-entry comparison in `has_smt()` would evaluate `-1 == -1` as true and incorrectly report SMT as available, causing tests gated on `test_requires_smt` to run with invalid topology data.

Add an early-out using `Topology::topology().isValid()` so that `has_smt()` returns `false` whenever topology data is not available.

Fixes #1074