### PR TITLE
FW/Logging: don't assert that `memcmp_or_fail` cannot have newlines

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1551,10 +1551,6 @@ function selftest_logerror_common() {
     local testlist=($($SANDSTONE --selftests --list-tests | sed -n '/^selftest_datacomparefail_/{s/\r$//;p;}'))
     ((${#testlist[@]} > 0))      # ensure we've found at least one
     for test in ${testlist[@]}; do
-        if [[ "$test" = *_float* ]]; then
-            # test temporarily broken
-            continue
-        fi
         printf '# %s\n' "$test" >&3     # print as progress report
 
         type=${test#selftest_datacomparefail_}

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -396,7 +396,7 @@ struct test {
 };
 
 /* internal functions; see C macro and C++ templates at the end of this file */
-extern bool _memcmp_or_fail_check_fmt_nonewline(const char *fmt, ...);
+extern bool _memcmp_or_fail_check_fmt(const char *fmt, ...);
 extern bool _memcmp_fail_check_cb(char *(*cb)(void *token, ptrdiff_t), void *, size_t);
 extern void _memcmp_fail_report_cb(const void *actual, const void *expected, size_t size,
                                    enum DataType, char *(*cb)(void *token, ptrdiff_t), void *)
@@ -703,8 +703,6 @@ memcmp_or_fail(const T *actual, const T *expected, size_t count, const char *fmt
     if constexpr (!std::is_same_v<T, void>)
         elemSize = sizeof(T);
 
-    assert(_memcmp_or_fail_check_fmt_nonewline(fmt, std::forward<FmtArgs>(args)...)
-           && "Data descriptions should not include a newline");
     if (SandstoneConfig::NoLogging)
         fmt = nullptr;
     if (!fmt)
@@ -713,6 +711,7 @@ memcmp_or_fail(const T *actual, const T *expected, size_t count, const char *fmt
     // printf style instead
     if (__builtin_memcmp(actual, expected, count * elemSize) != 0)
         _memcmp_fail_report(actual, expected, count * elemSize, type, fmt, std::forward<FmtArgs>(args)...);
+    assert(_memcmp_or_fail_check_fmt(fmt, std::forward<FmtArgs>(args)...));
 }
 #pragma GCC diagnostic pop
 
@@ -724,8 +723,6 @@ memcmp_or_fail(const T *actual, const T *expected, size_t count, const char *fmt
         _Pragma("GCC diagnostic push");                             \
         _Pragma("GCC diagnostic ignored \"-Wformat-security\"");    \
         _Pragma("GCC diagnostic ignored \"-Wunused-variable\"");    \
-        assert(_memcmp_or_fail_check_fmt_nonewline((fmt), ##__VA_ARGS__) \
-               && "Data descriptions should not include a newline");\
         _memcmp_fail_report((actual), (expected), _size2, _type,    \
                             *(fmt) ? (fmt) : NULL, ##__VA_ARGS__);  \
         _Pragma("GCC diagnostic pop");                              \
@@ -738,6 +735,7 @@ memcmp_or_fail(const T *actual, const T *expected, size_t count, const char *fmt
         size_t _size = sizeof(*_actual) * (size);                   \
         if (__builtin_memcmp(_actual, _expected, _size) != 0)       \
             memcmp_fail_report(_actual, _expected, (size), fmt, ##__VA_ARGS__); \
+        assert(_memcmp_or_fail_check_fmt((fmt), ##__VA_ARGS__));    \
     })
 #define memcmp_or_fail(actual, expected, size, ...) \
     _memcmp_or_fail(actual, expected, size, "" __VA_ARGS__)

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -225,28 +225,15 @@ static ptrdiff_t memcmp_offset(const uint8_t *d1, const uint8_t *d2, size_t size
 }
 
 #ifndef NDEBUG
-bool _memcmp_or_fail_check_fmt_nonewline(const char *fmt, ...)
+// we can only rely on the CI for this
+bool _memcmp_or_fail_check_fmt(const char *fmt, ...)
 {
-    bool ok = true;
-    size_t size = 256;
-    while (fmt) {
-        char buf[size];  // nowarn: -Wvla-cxx-extension, -Wvla
-        va_list va;
-        va_start(va, fmt);
-        int n = vsnprintf(buf, size, fmt, va);
-        va_end(va);
-        if (n < size) {
-            ok = strchr(buf, '\n') == nullptr;
-            break;
-        }
-
-        // insufficient buffer, try again
-        size = n;
-    }
-    return ok;
+    std::string msg = va_start_and_stdprintf(fmt);
+    if (msg.contains('\n'))
+        log_yaml(SANDSTONE_LOG_DEBUG, ("memcmp_or_fail: " + msg).c_str());
+    return true;
 }
 
-// we can only rely on the CI for this
 bool SandstoneMemcmpOrFail::test_formatter(std::function<std::string ()> cb, size_t)
 {
     log_yaml(SANDSTONE_LOG_DEBUG, ("memcmp_or_fail: " + cb()).c_str());


### PR DESCRIPTION
They can, since commit 674018bc206ba3fe84237d84e7acd45763f1efe4 (PR #1035):
```yaml
- test: selftest_datacomparefail_float
  threads:
  - thread: 0
    messages:
    - level: error
      data-miscompare:
       description: 'data of type ''float'''
       type:        float
       offset:      [ 0, 3 ]
       address:     '0x7ff3ba7fec73'
       actual:      '0x3f000000 (0x1p-1)'
       expected:    '0x00000000 (0x0p+0)'
       mask:        '0x3f000000'
       details:
         rare: false
         modified_at: 0
         count: 16
```

This reverts commit 08ac99db17dd4f6a63c3c210dad6b381c2d3781f (PR #1035).