### PR TITLE
Introduce device_count to decouple devices and threads tracking

### DIFF
--- a/framework/device/cpu/cpu_device.cpp
+++ b/framework/device/cpu/cpu_device.cpp
@@ -43,7 +43,7 @@ void dump_device_info()
            detected, sApp->hwinfo.family, sApp->hwinfo.model, sApp->hwinfo.stepping,
            device_features_to_string(device_features).c_str());
     printf("# CPU\tPkgID\tCoreID\tThrdID\tModId\tNUMAId\tApicId\tMicrocode\tPPIN\n");
-    for (i = 0; i < num_cpus(); ++i) {
+    for (i = 0; i < device_count(); ++i) {
         printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t0x%" PRIx64, device_info[i].cpu_number,
                device_info[i].package_id, device_info[i].core_id, device_info[i].thread_id,
                device_info[i].module_id, device_info[i].numa_id, device_info[i].hwid,
@@ -58,7 +58,7 @@ void dump_device_info()
 TestResult prepare_test_for_device(struct test *test)
 {
     auto has_smt = []() -> bool {
-        for(int idx = 0; idx < thread_count() - 1; idx++) {
+        for(int idx = 0; idx < device_count() - 1; idx++) {
             if (device_info[idx].package_id == device_info[idx + 1].package_id &&
                 device_info[idx].core_id == device_info[idx + 1].core_id)
                 return true;

--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -196,7 +196,7 @@ typedef struct cpu_info_t device_info_t;
 /// device_info is an array of cpu_info_t structures.  Each element of the array
 /// contains information about a logical CPU that will be used to
 /// execute a test's test_run function.  The size of this array is
-/// equal to the value returned by num_cpus().
+/// equal to the value returned by device_count().
 extern struct cpu_info_t *device_info;
 // Interim alias for compatibility.
 extern struct cpu_info_t *cpu_info asm("device_info");

--- a/framework/device/cpu/frequency_manager.hpp
+++ b/framework/device/cpu/frequency_manager.hpp
@@ -177,7 +177,7 @@ public:
         populate_frequency_levels(min_max_frequency, true, total_core_frequency_levels);
 
         // save states
-        for (int cpu = 0; cpu < num_cpus(); cpu++) {
+        for (int cpu = 0; cpu < device_count(); cpu++) {
             //save scaling governor for every cpu
             std::string scaling_governor_path = BASE_CORE_FREQ_PATH;
             scaling_governor_path += std::to_string(device_info[cpu].cpu_number);
@@ -205,7 +205,7 @@ public:
             std::unordered_set<int> found_socket_ids;
             uint16_t total_sockets = 0;
 
-            for (int cpu = 0; cpu < num_cpus(); cpu++) {
+            for (int cpu = 0; cpu < device_count(); cpu++) {
                 int socket_id = device_info[cpu].package_id;
                 if (found_socket_ids.count(socket_id) == 0) {
                     total_sockets++;
@@ -242,7 +242,7 @@ public:
 #ifdef __linux__
         current_set_frequency = core_frequency_levels[core_frequency_level_idx++ % total_core_frequency_levels];
 
-        for (int cpu = 0; cpu < num_cpus(); cpu++) {
+        for (int cpu = 0; cpu < device_count(); cpu++) {
             std::string scaling_setspeed = BASE_CORE_FREQ_PATH;
             scaling_setspeed += std::to_string(device_info[cpu].cpu_number);
             scaling_setspeed += SCALING_SETSPEED;
@@ -271,7 +271,7 @@ public:
     void restore_core_frequency_initial_state()
     {
 #ifdef __linux__
-        for (int cpu = 0; cpu < num_cpus(); cpu++) {
+        for (int cpu = 0; cpu < device_count(); cpu++) {
             //restore saved scaling governor for every cpu
             std::string scaling_governor_path = BASE_CORE_FREQ_PATH;
             scaling_governor_path += std::to_string(device_info[cpu].cpu_number);

--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -360,7 +360,7 @@ auto thread_core_spacing()
         struct { int logical, core; } result = { 1, 1 };
         int max_core_id = 0;
         int max_logical_id = 0;
-        for (int i = 0; i < thread_count(); ++i) {
+        for (int i = 0; i < device_count(); ++i) {
             if (device_info[i].cpu_number > max_logical_id)
                 max_logical_id = device_info[i].cpu_number;
             if (device_info[i].core_id > max_core_id)

--- a/framework/device/cpu/slicing.cpp
+++ b/framework/device/cpu/slicing.cpp
@@ -99,7 +99,7 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
 
     if (max_cores_per_slice == 0) {
         // set to full system
-        std::vector plan = { DeviceRange{ 0, thread_count() } };
+        std::vector plan = { DeviceRange{ 0, device_count() } };
         plans.fill(plan);
     } else {
         // dumb plan, not *cores*

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -120,7 +120,7 @@ static void update_topology(std::span<const cpu_info_t> new_cpu_info,
 
 int num_cpus()
 {
-    return thread_count();
+    return device_count();
 }
 
 int num_packages()
@@ -170,8 +170,8 @@ void BarrierDeviceScheduler::reschedule_to_next_device()
     std::unique_lock lock(groups_mutex);
     // Initialize groups on first run
     if (groups.empty()) {
-        int full_groups = num_cpus() / members_per_group;
-        int partial_group_members = num_cpus() % members_per_group;
+        int full_groups = device_count() / members_per_group;
+        int partial_group_members = device_count() % members_per_group;
 
         groups.reserve(full_groups + (partial_group_members > 0));
         for (int i=0; i<full_groups; i++) {
@@ -243,7 +243,7 @@ void QueueDeviceScheduler::shuffle_queue()
     // Must be called with mutex locked
     if (queue.size() == 0) {
         // First use: populate queue with the indexes available
-        for (int i=0; i<num_cpus(); i++)
+        for (int i=0; i<device_count(); i++)
             queue.push_back(i);
     }
 
@@ -254,7 +254,7 @@ void QueueDeviceScheduler::shuffle_queue()
 void RandomDeviceScheduler::reschedule_to_next_device()
 {
     // Select a random cpu index among the ones available
-    int next_idx = unsigned(random()) % num_cpus();
+    int next_idx = unsigned(random()) % device_count();
     pin_to_next_cpu(device_info[next_idx].cpu_number);
 
     return;
@@ -378,7 +378,7 @@ static bool cpu_compare(const cpu_info_t &cpu1, const cpu_info_t &cpu2)
 __attribute__((noinline))
 void TopologyDetector::sort()
 {
-    std::sort(device_info, device_info + num_cpus(), cpu_compare);
+    std::sort(device_info, device_info + device_count(), cpu_compare);
 }
 
 bool TopologyDetector::old_create_mock_topology(const char *topo)
@@ -398,7 +398,7 @@ bool TopologyDetector::old_create_mock_topology(const char *topo)
 
     int cpu_count = 0;
     while (topo && *topo) {
-        if (cpu_count == sApp->thread_count)
+        if (cpu_count == sApp->device_count)
             break;      // can't add more
 
         cpu_info_t *info = &device_info[cpu_count];
@@ -428,7 +428,7 @@ bool TopologyDetector::old_create_mock_topology(const char *topo)
             continue;
     }
 
-    sApp->thread_count = cpu_count;
+    sApp->device_count = cpu_count;
     return true;
 }
 
@@ -455,7 +455,7 @@ bool TopologyDetector::create_mock_topology(const char *topo)
 
     int cpu_count = 0;
     while (topo && *topo) {
-        if (cpu_count == sApp->thread_count)
+        if (cpu_count == sApp->device_count)
             break;      // can't add more
 
         cpu_info_t *info = &device_info[cpu_count];
@@ -519,7 +519,7 @@ bool TopologyDetector::create_mock_topology(const char *topo)
             ++topo;
     }
 
-    sApp->thread_count = cpu_count;
+    sApp->device_count = cpu_count;
     return true;
 }
 
@@ -666,7 +666,7 @@ bool TopologyDetector::detect_numa()
 
         // Parse the list. This will *usually* be one or two ranges.
         cpu_info_t *cpu = &device_info[0];
-        const cpu_info_t *const end = device_info + sApp->thread_count;
+        const cpu_info_t *const end = device_info + sApp->device_count;
         const char *ptr = cpulist.c_str();
         while (*ptr && cpu != end) {
             auto [start, stop] = parse_cpulist_range(ptr);
@@ -675,7 +675,7 @@ bool TopologyDetector::detect_numa()
             // At this point, the device_info array is sorted by cpu_number and,
             // if we're running over the entire system, the array index
             // matches the cpu_number too.
-            if (start < sApp->thread_count && device_info[start].cpu_number == start) {
+            if (start < sApp->device_count && device_info[start].cpu_number == start) {
                 cpu = &device_info[start];
             } else {
                 // no such luck, scan forward from the last cpu we marked
@@ -814,7 +814,7 @@ bool TopologyDetector::detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP rel
             std::numeric_limits<KAFFINITY>::digits;
 
     cpu_info_t *const info = device_info;
-    std::span infos(info, info + num_cpus());
+    std::span infos(info, info + device_count());
     auto first_cpu_for_group = [infos](unsigned group) -> cpu_info_t * {
         for (cpu_info_t &info : infos) {
             if (info.cpu_number / CpusPerGroup == group)
@@ -1337,7 +1337,7 @@ void apply_deviceset_param(const char *param)
     if (SandstoneConfig::RestrictedCommandLine)
         return;
 
-    std::span<cpu_info_t> old_cpu_info(device_info, sApp->thread_count);
+    std::span<cpu_info_t> old_cpu_info(device_info, sApp->device_count);
     std::vector<cpu_info_t> new_cpu_info;
     int total_matches = 0;
 
@@ -1507,14 +1507,14 @@ void apply_deviceset_param(const char *param)
 
 void TopologyDetector::detect(const LogicalProcessorSet &enabled_cpus)
 {
-    assert(sApp->thread_count);
-    assert(sApp->thread_count == enabled_cpus.count());
+    assert(sApp->device_count);
+    assert(sApp->device_count == enabled_cpus.count());
     device_info = sApp->shmem->device_info;
 
     // detect this CPU's family - it's impossible for them to be different
     detect_family_via_cpuid();
 
-    int count = sApp->thread_count;
+    int count = sApp->device_count;
     [[assume(count > 0)]];
 
     // fill in device_info first
@@ -1550,7 +1550,7 @@ void TopologyDetector::detect(const LogicalProcessorSet &enabled_cpus)
 
     auto detect = [](void *ptr) -> void * {
         auto self = static_cast<TopologyDetector *>(ptr);
-        int count = sApp->thread_count;
+        int count = sApp->device_count;
         [[assume(count > 0)]];
         for (Topology::Thread &cpu : std::span(device_info, count)) {
             pin_to_logical_processor(LogicalProcessor(cpu.cpu_number));
@@ -1602,7 +1602,7 @@ static void populate_core_group(Topology::CoreGrouping *group, const Topology::T
 static Topology build_topology()
 {
     const cpu_info_t *info = device_info;
-    const cpu_info_t *const end = device_info + num_cpus();
+    const cpu_info_t *const end = device_info + device_count();
 
     std::vector<Topology::Package> packages;
     if (int max_package_id = end[-1].package_id; max_package_id >= 0)
@@ -1663,7 +1663,7 @@ const Topology &Topology::topology()
 Topology::Data Topology::clone() const
 {
     Data result;
-    result.all_threads.assign(device_info, device_info + num_cpus());
+    result.all_threads.assign(device_info, device_info + device_count());
     result.packages = packages;
 
     // now update all spans to point to the data we carry
@@ -1697,11 +1697,11 @@ void update_topology(std::span<const cpu_info_t> new_cpu_info,
         end = std::copy_if(new_cpu_info.begin(), new_cpu_info.end(), device_info, matching);
     }
 
-    int new_thread_count = end - device_info;
-    if (int excess = sApp->thread_count - new_thread_count; excess > 0)
+    int new_device_count = end - device_info;
+    if (int excess = sApp->device_count - new_device_count; excess > 0)
         std::fill_n(end, excess, (cpu_info_t){});
 
-    sApp->thread_count = new_thread_count;
+    sApp->device_count = new_device_count;
     cached_topology() = build_topology();
 }
 
@@ -1709,15 +1709,15 @@ template <>
 LogicalProcessorSet detect_devices<LogicalProcessorSet>()
 {
     LogicalProcessorSet result = ambient_logical_processor_set();
-    sApp->thread_count = result.count();
-    if (sApp->thread_count == 0) [[unlikely]] {
+    sApp->device_count = result.count();
+    if (sApp->device_count == 0) [[unlikely]] {
         fprintf(stderr, "%s: internal error: ambient logical processor set appears to be empty!\n",
                 program_invocation_name);
         return result;
     }
-    sApp->user_thread_data.resize(sApp->thread_count);
+    sApp->user_thread_data.resize(sApp->device_count);
 #ifdef M_ARENA_MAX
-    mallopt(M_ARENA_MAX, sApp->thread_count * 2);
+    mallopt(M_ARENA_MAX, sApp->device_count * 2);
 #endif
 
     return result;
@@ -1734,12 +1734,12 @@ void setup_devices<LogicalProcessorSet>(const LogicalProcessorSet &enabled_devic
 
 void restrict_topology(DeviceRange range)
 {
-    assert(range.starting_device + range.device_count <= sApp->thread_count);
+    assert(range.starting_device + range.device_count <= sApp->device_count);
     auto old_cpu_info = std::exchange(device_info, sApp->shmem->device_info + range.starting_device);
-    int old_thread_count = std::exchange(sApp->thread_count, range.device_count);
+    int old_device_count = std::exchange(sApp->device_count, range.device_count);
 
     Topology &topo = cached_topology();
-    if (old_cpu_info != device_info || old_thread_count != sApp->thread_count ||
+    if (old_cpu_info != device_info || old_device_count != sApp->device_count ||
             topo.packages.size() == 0)
         topo = build_topology();
 }

--- a/framework/device/gpu/topology.cpp
+++ b/framework/device/gpu/topology.cpp
@@ -86,13 +86,13 @@ int parse_int(char*& arg, const char* orig_arg) {
 void update_topology(std::span<const gpu_info_t> new_gpu_info)
 {
     gpu_info_t* end = std::copy(new_gpu_info.begin(), new_gpu_info.end(), device_info);
-    int new_thread_count = new_gpu_info.size();
-    if (int excess = sApp->thread_count - new_thread_count; excess > 0) {
+    int new_device_count = new_gpu_info.size();
+    if (int excess = sApp->device_count - new_device_count; excess > 0) {
         // reset excess entries
         std::fill_n(end, excess, gpu_info_t{});
     }
 
-    sApp->thread_count = new_thread_count;
+    sApp->device_count = new_device_count;
     cached_topology() = build_topology();
 }
 }
@@ -114,7 +114,7 @@ void apply_deviceset_param(const char *param)
         { return gpu.gpu_number == gpu_number; }
     };
 
-    std::span<gpu_info_t> old_gpu_info(device_info, sApp->thread_count);
+    std::span<gpu_info_t> old_gpu_info(device_info, sApp->device_count);
     std::vector<gpu_info_t> new_gpu_info;
     int total_matches = 0;
 
@@ -295,10 +295,10 @@ GpusSet detect_devices<GpusSet>()
 
     if (const char* mock_topo = getenv("SANDSTONE_MOCK_TOPOLOGY"); SandstoneConfig::Debug && mock_topo && *mock_topo) {
         // our selftests use mock topologies of up to 4 GPUs, so we need to prepare enough space in device_info
-        static constexpr auto MAX_MOCK_THREAD_COUNT = 4;
-        sApp->thread_count = MAX_MOCK_THREAD_COUNT;
-        sApp->user_thread_data.resize(sApp->thread_count);
-        for (auto i = 0; i < MAX_MOCK_THREAD_COUNT; i++) {
+        static constexpr auto MAX_MOCK_DEVICE_COUNT = 4;
+        sApp->device_count = MAX_MOCK_DEVICE_COUNT;
+        sApp->user_thread_data.resize(sApp->device_count);
+        for (auto i = 0; i < MAX_MOCK_DEVICE_COUNT; i++) {
             enabled_devices.emplace(MultiSliceGpu{.gpu_number = i}, ZeDeviceCtx{}); // fill with anything, we will check !empty() later
         }
         return enabled_devices;
@@ -327,8 +327,8 @@ GpusSet detect_devices<GpusSet>()
         return enabled_devices;
     }
 
-    sApp->thread_count = enabled_devices.size();
-    sApp->user_thread_data.resize(sApp->thread_count);
+    sApp->device_count = enabled_devices.size();
+    sApp->user_thread_data.resize(sApp->device_count);
 
     return enabled_devices;
 }
@@ -522,7 +522,7 @@ void create_mock_topology(const char *topo)
             ++topo;
     }
 
-    sApp->thread_count = gpu_count;
+    sApp->device_count = gpu_count;
 }
 
 /// Builds whole device_info array, then builds topology based on that.
@@ -536,9 +536,9 @@ void setup_devices<GpusSet>(const GpusSet &enabled_devices)
         return;
     }
 
-    assert(enabled_devices.size() == thread_count());
+    assert(enabled_devices.size() == device_count());
     gpu_info_t* info = device_info;
-    [[maybe_unused]] const gpu_info_t* cend = device_info + thread_count();
+    [[maybe_unused]] const gpu_info_t* cend = device_info + device_count();
 
     auto enabled_cpus = to_vector(ambient_logical_processor_set());
     if (enabled_cpus.size() < enabled_devices.size()) {
@@ -587,24 +587,24 @@ void setup_devices<GpusSet>(const GpusSet &enabled_devices)
     cached_topology() = build_topology();
 }
 
-/// Called after apply_deviceset_param(). Means we have smaller thread_count and a new range of devices.
+/// Called after apply_deviceset_param(). Means we have smaller device_count and a new range of devices.
 /// Changes pointer of device_info, as sApp->shmem has moved. Must also rebuild topology (built upon device_info).
 /// TODO: It's very similar to the CPU version. Should we abstract build_topology(), rather than restrict_topology()?
 void restrict_topology(DeviceRange range)
 {
-    assert(range.starting_device + range.device_count <= sApp->thread_count);
+    assert(range.starting_device + range.device_count <= sApp->device_count);
     auto old_gpu_info = std::exchange(device_info, sApp->shmem->device_info + range.starting_device);
-    int old_thread_count = std::exchange(sApp->thread_count, range.device_count);
+    int old_device_count = std::exchange(sApp->device_count, range.device_count);
 
     Topology &topo = cached_topology();
-    if (old_gpu_info != device_info || old_thread_count != sApp->thread_count /*|| topo.devices.size() == 0  TODO: why would we check that? */) {
+    if (old_gpu_info != device_info || old_device_count != sApp->device_count /*|| topo.devices.size() == 0  TODO: why would we check that? */) {
         topo = build_topology();
     }
 }
 
 void rebuild_topology()
 {
-    assert(device_info && sApp->thread_count && "device_info must be filled at this point");
+    assert(device_info && sApp->device_count && "device_info must be filled at this point");
     cached_topology() = build_topology();
 }
 

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2270,7 +2270,7 @@ void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, 
 #else
     logging_printf(LOG_LEVEL_VERBOSE(1), "device-info:\n");
 #endif
-    for (int i = 0; i < thread_count(); ++i) {
+    for (int i = 0; i < device_count(); ++i) {
         logging_printf(LOG_LEVEL_VERBOSE(1), "- %s   # %d\n",
                        thread_id_header_for_device(i, LOG_LEVEL_VERBOSE(2)).c_str(), i);
     }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -835,6 +835,11 @@ int thread_count()
     return sApp->thread_count;
 }
 
+int device_count()
+{
+    return sApp->device_count;
+}
+
 int8_t sandstone_verbosity_level()
 {
     return std::to_underlying(sApp->shmem->cfg.verbosity);

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -318,15 +318,15 @@ static void init_shmem()
             "PerThreadData::Test size grew, please check if it was intended");
     assert(sApp->current_fork_mode() != SandstoneApplication::ForkMode::child_exec_each_test);
     assert(sApp->shmem == nullptr);
-    assert(thread_count());
+    assert(device_count());
 
     unsigned per_thread_size = sizeof(PerThreadData::Main);
     per_thread_size = ROUND_UP_TO(per_thread_size, alignof(PerThreadData::Test));
-    per_thread_size += sizeof(PerThreadData::Test) * thread_count();
+    per_thread_size += sizeof(PerThreadData::Test) * device_count();
     per_thread_size = ROUND_UP_TO_PAGE(per_thread_size);
 
     unsigned thread_data_offset = sizeof(SandstoneApplication::SharedMemory) +
-            sizeof(Topology::Thread) * thread_count();
+            sizeof(Topology::Thread) * device_count();
     thread_data_offset = ROUND_UP_TO_PAGE(thread_data_offset);
 
     size_t size = thread_data_offset;
@@ -357,6 +357,7 @@ static void commit_shmem()
     size_t main_thread_count = plan.size();
     sApp->shmem->main_thread_count = main_thread_count;
     sApp->shmem->total_thread_count = thread_count();
+    sApp->shmem->total_device_count = device_count();
 
     // unmap the current area, because Windows doesn't allow us to have two
     // blocks for this file
@@ -381,7 +382,7 @@ static void commit_shmem()
     }
 
     // sApp->shmem has probably moved
-    restrict_topology({ 0, thread_count() });
+    restrict_topology({ 0, device_count() });
 }
 
 static void attach_shmem(int fd)
@@ -586,6 +587,7 @@ static int exec_mode_run(int argc, char **argv)
     attach_shmem(parse_int(argv[1]));
     device_info = sApp->shmem->device_info;
     sApp->thread_count = sApp->shmem->total_thread_count;
+    sApp->device_count = sApp->shmem->total_device_count;
     rebuild_topology();
     sApp->user_thread_data.resize(sApp->thread_count);
 
@@ -1048,12 +1050,13 @@ int main(int argc, char **argv)
     if (sApp->total_retest_count < -1 || sApp->retest_count == 0)
         sApp->total_retest_count = 10 * sApp->retest_count; // by default, 100
 
-    if (unsigned(opts.thread_count) < unsigned(sApp->thread_count))
-        restrict_topology({ 0, opts.thread_count });
+    if (unsigned(opts.thread_count) < unsigned(sApp->device_count))
+        restrict_topology({ 0, opts.thread_count }); // TODO: Remove this when thread_count and device_count are decoupled
+    sApp->thread_count = sApp->device_count;
     slice_plan_init(opts.max_cores_per_slice);
     commit_shmem();
 
-    if (std::to_underlying(sApp->shmem->cfg.reschedule_mode) > std::to_underlying(RescheduleMode::none) && thread_count() < 2) {
+    if (std::to_underlying(sApp->shmem->cfg.reschedule_mode) > std::to_underlying(RescheduleMode::none) && device_count() < 2) {
         logging_printf(LOG_LEVEL_QUIET, "# WARNING: --reschedule is only useful with at least 2 cores, ignoring\n");
         sApp->shmem->cfg.reschedule_mode = RescheduleMode::none;
     }

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -591,6 +591,10 @@ extern __thread int thread_num __attribute__((tls_model("initial-exec")));
 /// restricts the number of CPUs sandstone can see.
 int thread_count() __attribute__((pure));
 
+/// Returns the number of devices (CPUs or GPUs) available to a test.
+/// Normally equal to thread_count(), but tracked separately.
+int device_count() __attribute__((pure));
+
 /// Returns the number of physical CPU packages (a.k.a. sockets) available to a
 /// test.
 int num_packages() __attribute__((pure));

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -894,7 +894,7 @@ struct ProgramOptionsParser {
             auto maybe_int = ParseIntArgument<>{
                     .name = "-n / --threads",
                     .min = 1,
-                    .max = app_cfg->thread_count,
+                    .max = app_cfg->device_count,
                     .range_mode = OutOfRangeMode::Saturate
             }(value);
             if (maybe_int) {

--- a/framework/sandstone_opts.hpp
+++ b/framework/sandstone_opts.hpp
@@ -23,6 +23,7 @@ struct ProgramOptions {
     const char* seed = nullptr;
     int max_cores_per_slice = 0;
     int thread_count = -1;
+    int device_count = -1;
     bool fatal_errors = false;
     const char* on_hang_arg = nullptr;
     const char* on_crash_arg = nullptr;
@@ -54,6 +55,7 @@ struct ProgramOptions {
         seed = nullptr;
         max_cores_per_slice = 0;
         thread_count = -1;
+        device_count = -1;
         fatal_errors = true;
         on_hang_arg = nullptr;
         on_crash_arg = nullptr;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -313,6 +313,7 @@ struct SandstoneApplicationConfig {
     int thermal_throttle_temp = DefaultTemperatureThreshold;
 
     int thread_count;
+    int device_count;
 };
 
 struct SandstoneApplication : SandstoneApplicationConfig, public test_the_test_data<SandstoneConfig::Debug>
@@ -409,6 +410,7 @@ struct SandstoneApplication::SharedMemory
     // per-thread & variable length
     int main_thread_count = 0;
     int total_thread_count = 0;
+    int total_device_count = 0;
     alignas(64) device_info_t device_info[];         // C99 Flexible Array Member
 
 #if 0

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1217,6 +1217,7 @@ TestResult child_run(/*nonconst*/ struct test *test, int child_number)
         sApp->select_main_thread(child_number);
         pin_to_logical_processors(sApp->main_thread_data()->device_range, "control");
         restrict_topology(sApp->main_thread_data()->device_range);
+        sApp->thread_count = sApp->device_count; // TODO: Update when thread_count and device_count are decoupled
         signals_init_child();
         debug_init_child();
     }
@@ -1415,7 +1416,7 @@ static int slices_for_test(const struct test *test)
         return SlicePlans::Heuristic;
     }();
     if (type == SlicePlans::FullSystem) {
-        sApp->main_thread_data()->device_range = { 0, sApp->thread_count };
+        sApp->main_thread_data()->device_range = { 0, sApp->device_count };
         return 1;
     }
 

--- a/framework/sandstone_unittests_utils.cpp
+++ b/framework/sandstone_unittests_utils.cpp
@@ -6,11 +6,13 @@
 #include "sandstone.h"
 
 #define UNITTESTS_THREAD_COUNT 16
+#define UNITTESTS_DEVICE_COUNT UNITTESTS_THREAD_COUNT
 
 /* Define dummy setup struct that can be used by unittests when needed */
 device_info_t *device_info = nullptr;
 
 /* Define dummy number of dummy threads */
+int device_count() { return UNITTESTS_DEVICE_COUNT; }
 int thread_count() { return UNITTESTS_THREAD_COUNT; }
 int num_cpus() { return thread_count(); }
 

--- a/framework/unit-tests/opts_parser_tests.cpp
+++ b/framework/unit-tests/opts_parser_tests.cpp
@@ -406,7 +406,7 @@ TEST(ProgramOptionsParser, saturation_works__thread_count)
         };
 
         // simulate init_cpus() before parsing
-        cfg.thread_count = 48;
+        cfg.device_count = 48;
 
         auto ret = opts.parse(2, argv, &cfg);
         EXPECT_EQ(ret, EXIT_SUCCESS);
@@ -424,7 +424,7 @@ TEST(ProgramOptionsParser, saturation_works__thread_count)
         };
 
         // simulate init_cpus() before parsing
-        cfg.thread_count = 1000;
+        cfg.device_count = 1000;
 
         auto ret = opts.parse(2, argv, &cfg);
         EXPECT_EQ(ret, EXIT_SUCCESS);
@@ -442,7 +442,7 @@ TEST(ProgramOptionsParser, saturation_works__thread_count)
         };
 
         // simulate init_cpus() before parsing
-        cfg.thread_count = 48;
+        cfg.device_count = 48;
 
         auto ret = opts.parse(2, argv, &cfg);
         EXPECT_EQ(ret, EXIT_SUCCESS);


### PR DESCRIPTION
Historically, the number of threads and the number of devices have been strongly tied — reducing thread_count also restricted the number of devices/CPUs to match and viceversa. This PR is the first step toward changing that behavior.

These commits introduce `device_count` and separate the device logic from the thread logic. In this step, the historic behavior is preserved:`thread_count` is still always equal to `device_count`. In coming PRs, this will no longer be the case.