### PR TITLE
bats: fix cpuset accumulate skip guards

### DIFF
--- a/bats/sanity-check/25-cpu-topology.bats
+++ b/bats/sanity-check/25-cpu-topology.bats
@@ -511,7 +511,7 @@ function selftest_cpuset_accumulate() {
 @test "cpuset accumulate (p0 c0)" {
     export SANDSTONE_MOCK_TOPOLOGY='p0c0 p0c1'
 
-    run $SANDSTONE --cpuset=p0c0,p1c1 --dump-cpu-info
+    run $SANDSTONE --cpuset=p0c0,p0c1 --dump-cpu-info
     if (( status != 0 )); then
         skip "Test only works with Debug builds (to mock the topology) or package 0 with cores 0 and 1"
     fi
@@ -523,7 +523,7 @@ function selftest_cpuset_accumulate() {
 @test "cpuset accumulate (p0 c0,c1)" {
     export SANDSTONE_MOCK_TOPOLOGY='p0c0 p0c1'
 
-    run $SANDSTONE --cpuset=p0c0,p1c1 --dump-cpu-info
+    run $SANDSTONE --cpuset=p0c0,p0c1 --dump-cpu-info
     if (( status != 0 )); then
         skip "Test only works with Debug builds (to mock the topology) or package 0 with cores 0 and 1"
     fi
@@ -534,7 +534,7 @@ function selftest_cpuset_accumulate() {
 @test "cpuset accumulate (p0 !c0 / p0 !c1)" {
     export SANDSTONE_MOCK_TOPOLOGY='p0c0 p0c1'
 
-    run $SANDSTONE --cpuset=p0c0,p1c1 --dump-cpu-info
+    run $SANDSTONE --cpuset=p0c0,p0c1 --dump-cpu-info
     if (( status != 0 )); then
         skip "Test only works with Debug builds (to mock the topology) or package 0 with cores 0 and 1"
     fi


### PR DESCRIPTION
The "cpuset accumulate" tests use SANDSTONE_MOCK_TOPOLOGY to create a fake 2-CPU topology (p0c0, p0c1). On non-debug builds where the mock is inactive, the tests fall back to real hardware and rely on a skip guard to bail out when the topology doesn't match.

The skip guard ran --cpuset=p0c0,p1c1 and checked the exit status. This had two problems:

1. The guard checked for p0c0 and p1c1 (two different packages), but the tests actually need p0c0 and p0c1 (same package, different cores). The guard was fixed to check for the correct topology: --cpuset=p0c0,p0c1

~~2. --cpuset succeeds (exit 0) as long as at least one of the comma-separated values matches. On systems where core ID does not match p0c0 or p0c1 only produces a warning, so the guard passes and the test proceeds causing failures.~~

```
builddir-release/opendcdiag: warning: CPU selection 'p1c1' matched nothing
Detected CPU: Sierra Forest; family-model-stepping (hex): 06-c6-02; CPU features: clflush,sse2,pclmul,fma,sse4.2,movbe,popcnt,aes,avx,f16c,rdrnd,fsgsbase,bmi,avx2,bmi2,rdseed,adx,clflushopt,clwb,sha,ospke,waitpkg,shstk,gfni,vaes,vpclmulqdq,movdiri,movdir64b,uintr,serialize,hybrid,ibt,sha512,sm3,sm4,avxvnni,cmpccxadd,avxifma,lam,avxvnniint8,avxneconvert,avxvnniint16,lzcnt
CPU	PkgID	CoreID	ThrdID	ModId	NUMAId	ApicId	Microcode	PPIN
0	0	0	0	0	0	0	0x11b
+ builddir-release/opendcdiag --on-crash=core --on-hang=kill --ignore-mce-errors --on-crash=core --on-hang=kill --ignore-mce-errors -Y -o - -n24 --ignore-mce-errors --selftests --timeout=20s --retest-on-failure=0 -Y2 -e selftest_skip --cpuset=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23
+ echo 0
```

```
+ builddir-release/opendcdiag --on-crash=core --on-hang=kill --ignore-mce-errors --on-crash=core --on-hang=kill --ignore-mce-errors -Y -o - -n24 --ignore-mce-errors --selftests --timeout=20s --retest-on-failure=0 -Y2 -e selftest_skip --cpuset=
builddir-release/opendcdiag: error: --cpuset matched nothing, this is probably not what you wanted.
+ echo 64
```

~~Fix the guards to also verify that exactly 2 CPUs are present in the output, which confirms the mock topology is active or that the real system matches the expected layout.~~