### PR TITLE
FW: finish decoupling `thread`/`device_count`

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1050,9 +1050,9 @@ int main(int argc, char **argv)
     if (sApp->total_retest_count < -1 || sApp->retest_count == 0)
         sApp->total_retest_count = 10 * sApp->retest_count; // by default, 100
 
-    if (unsigned(opts.thread_count) < unsigned(sApp->device_count))
-        restrict_topology({ 0, opts.thread_count }); // TODO: Remove this when thread_count and device_count are decoupled
-    sApp->thread_count = sApp->device_count;
+    if (unsigned(opts.device_count) < unsigned(sApp->device_count))
+        restrict_topology({ 0, opts.device_count });
+    sApp->thread_count = sApp->device_count; // TODO: Temporary 1:1
     slice_plan_init(opts.max_cores_per_slice);
     commit_shmem();
 

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -898,7 +898,7 @@ struct ProgramOptionsParser {
                     .range_mode = OutOfRangeMode::Saturate
             }(value);
             if (maybe_int) {
-                opts.thread_count = maybe_int.value();
+                opts.device_count = maybe_int.value();
             } else {
                 return EX_USAGE;
             }

--- a/framework/sandstone_opts.hpp
+++ b/framework/sandstone_opts.hpp
@@ -22,7 +22,6 @@ struct ProgramOptions {
 
     const char* seed = nullptr;
     int max_cores_per_slice = 0;
-    int thread_count = -1;
     int device_count = -1;
     bool fatal_errors = false;
     const char* on_hang_arg = nullptr;
@@ -54,7 +53,6 @@ struct ProgramOptions {
     void apply_restrictions() {
         seed = nullptr;
         max_cores_per_slice = 0;
-        thread_count = -1;
         device_count = -1;
         fatal_errors = true;
         on_hang_arg = nullptr;

--- a/framework/unit-tests/opts_parser_tests.cpp
+++ b/framework/unit-tests/opts_parser_tests.cpp
@@ -410,7 +410,7 @@ TEST(ProgramOptionsParser, saturation_works__thread_count)
 
         auto ret = opts.parse(2, argv, &cfg);
         EXPECT_EQ(ret, EXIT_SUCCESS);
-        EXPECT_EQ(opts.thread_count, 48);
+        EXPECT_EQ(opts.device_count, 48);
         sb.check_eq("unittests: warning: value out of range for option '-n / --threads': 49 (minimum is 1, maximum 48)");
     }
 
@@ -428,7 +428,7 @@ TEST(ProgramOptionsParser, saturation_works__thread_count)
 
         auto ret = opts.parse(2, argv, &cfg);
         EXPECT_EQ(ret, EXIT_SUCCESS);
-        EXPECT_EQ(opts.thread_count, 1);
+        EXPECT_EQ(opts.device_count, 1);
         sb.check_eq("unittests: warning: value out of range for option '-n / --threads': -123 (minimum is 1, maximum 1000)");
     }
 
@@ -446,7 +446,7 @@ TEST(ProgramOptionsParser, saturation_works__thread_count)
 
         auto ret = opts.parse(2, argv, &cfg);
         EXPECT_EQ(ret, EXIT_SUCCESS);
-        EXPECT_EQ(opts.thread_count, 24);
+        EXPECT_EQ(opts.device_count, 24);
         sb.check_eq(EMPTY_STR); // no messages printed
     }
 }


### PR DESCRIPTION
During opts parsing, we parsed only `thread_count`, which I believe should be `device_count`. This commit removes the former from `ProgramOptions` since we parse only one of those values anyway (`-n`).