### PR TITLE
FW/cpuset: Error and exit when topology selection matches no CPU

### DIFF
--- a/bats/sanity-check/25-cpu-topology.bats
+++ b/bats/sanity-check/25-cpu-topology.bats
@@ -492,6 +492,23 @@ selftest_cpuset_negated() {
     selftest_cpuset_negated \!p${cpuinfo[1]}c${cpuinfo[2]}t${cpuinfo[3]} ${cpuinfo[0]}
 }
 
+@test "cpuset=number (not all match) " {
+    if $is_windows; then
+        skip "taskset does not apply to Windows"
+    fi
+    run taskset -c 0 $SANDSTONE --cpuset=0,1 --dump-cpu-info
+    [[ $status = 64 ]]
+    [[ "$output" = *"error: Invalid CPU set parameter"* ]]
+}
+
+@test "cpuset=topology (not all match) " {
+    # Get the first logical processor
+    local -a cpuinfo=(`$SANDSTONE --dump-cpu-info | sed -n '/^[0-9]/{p;q;}'`)
+    run $SANDSTONE --cpuset=p${cpuinfo[1]}c${cpuinfo[2]}t${cpuinfo[3]},p${cpuinfo[1]}c16777216t3
+    [[ $status = 64 ]]
+    [[ "$output" = *"error: CPU selection"*"matched nothing" ]]
+}
+
 # Test if multiple --cpuset accumulate properly
 # e.g. --cpuset=p0 --cpuset=c0 should be the same as --cpuset=p0c0
 function selftest_cpuset_accumulate() {

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1480,9 +1480,11 @@ void apply_deviceset_param(const char *param)
                 ++match_count;
             }
 
-            if (match_count == 0)
-                fprintf(stderr, "%s: warning: CPU selection '%s' matched nothing\n",
+            if (match_count == 0) {
+                fprintf(stderr, "%s: error: CPU selection '%s' matched nothing\n",
                         program_invocation_name, orig_arg);
+                exit(EX_USAGE);
+            }
         }
     }
 


### PR DESCRIPTION
When using --cpuset with topology selectors (e.g. --cpuset=p0c0,p0c99), each comma-separated entry must match at least one CPU. Previously, entries using package/core/thread notation that matched nothing only emitted a warning and continued execution, allowing --cpuset to succeed (exit 0) as long as at least one other entry in the list matched. This is inconsistent with the behavior for logical CPU numbers, which already error immediately when a specified CPU does not exist. Promote the warning to an error making the behavior uniform across all selector types.

```
# Previous behavior
$ ./builddir-release/opendcdiag --dump-cpu-info --cpuset=p0c0,p0c1
./builddir-release/opendcdiag: warning: CPU selection 'p0c1' matched nothing
Detected CPU: Sierra Forest; family-model-stepping (hex): 06-c6-02; CPU features: clflush,sse2,pclmul,fma,sse4.2,movbe,popcnt,aes,avx,f16c,rdrnd,fsgsbase,bmi,avx2,bmi2,rdseed,adx,clflushopt,clwb,sha,ospke,waitpkg,shstk,gfni,vaes,vpclmulqdq,movdiri,movdir64b,uintr,serialize,hybrid,ibt,sha512,sm3,sm4,avxvnni,cmpccxadd,avxifma,lam,avxvnniint8,avxneconvert,avxvnniint16,lzcnt
# CPU	PkgID	CoreID	ThrdID	ModId	NUMAId	ApicId	Microcode	PPIN
0	0	0	0	0	0	0	0x11b
```

```
# Fix
$ ./builddir-release/opendcdiag --dump-cpu-info --cpuset=p0c0,p0c1
./builddir-release/opendcdiag: error: CPU selection 'p0c1' matched nothing
```