### PR TITLE
copilot: fix instruction files and add sandstone API reference in markdown

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,9 +3,14 @@ parts of the system on a live running system for manufacturing and other
 defects.
 
 
-The central header file for this project is `framework/sandstone.h` and this
-file should be loaded in the context immediately as it describes all the
-interactions between components in this project.
+The central header file for this project is `framework/sandstone.h`. When reviewing
+code, use the following order of preference:
+
+1. **If you can read files directly** (agentic/chat mode): load `framework/sandstone.h`
+   from the repository root as the authoritative API and architectural reference.
+2. **Otherwise** (web review / no file access): refer to the
+   `.github/instructions/sandstone-api*.instructions.md` files, which contain the
+   full API reference extracted from that header.
 
 
 # Code review general rules
@@ -17,5 +22,4 @@ Use the Markdown files from the table below as rules for any code review:
 | `.github/instructions/style.instructions.md` | Coding style guide |
 | `.github/instructions/general-c++.instructions.md` | C++ coding rules |
 | `.github/instructions/test.instructions.md` | Test specific coding guidelines |
-
 

--- a/.github/instructions/general-c++.instructions.md
+++ b/.github/instructions/general-c++.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "**/*.cpp,**/*.hpp,**/*.h,**/*.c"
+---
+
 # C++ coding guidelines
 
 These coding rules apply to all C++ code in the project.

--- a/.github/instructions/sandstone-api-cpp.instructions.md
+++ b/.github/instructions/sandstone-api-cpp.instructions.md
@@ -1,0 +1,97 @@
+---
+applyTo: "**"
+---
+# sandstone.h — C++ API
+
+## TestRunner<T>
+
+`TestRunner<T>` is a static helper class that manages the lifecycle of a C++ test
+class `T` through `test->data`.
+
+```cpp
+// T must provide:
+//   T(struct test *test)          constructor
+//   int init(struct test *test)   return EXIT_SKIP or EXIT_SUCCESS
+//   int run(struct test *test, int cpu)
+//   int cleanup(struct test *test)
+
+DECLARE_TEST(mytest, "description")
+    .test_init    = TestRunner<MyTest>::init,
+    .test_run     = TestRunner<MyTest>::run,
+    .test_cleanup = TestRunner<MyTest>::cleanup,
+END_DECLARE_TEST
+```
+
+**Ownership rules:**
+- `TestRunner<T>::init` heap-allocates `T` and stores the pointer in `test->data`.
+  It asserts that `test->data` is null on entry — do not pre-set `test->data` when
+  using `TestRunner`.
+- `TestRunner<T>::cleanup` deletes `T` and sets `test->data = nullptr`.
+- `TestRunner<T>::run` and `TestRunner<T>::cleanup` assert `test->data != nullptr`.
+
+## CpuNotSupported / OsNotSupported
+
+Convenience classes for use with `TestRunner` when a test cannot run on the
+current CPU or OS:
+
+```cpp
+// skip unconditionally with the appropriate SkipCategory
+.test_init = TestRunner<CpuNotSupported>::init,
+.test_init = TestRunner<OsNotSupported>::init,
+```
+
+Both call `log_skip` with the corresponding category and return `EXIT_SKIP`.
+Their `run` methods call `__builtin_unreachable()`.
+
+Note: `CpuNotSupported::init` logs the message `"Not supported on this OS"` — this
+is a known copy-paste error in the header; the skip category (`CpuNotSupportedSkipCategory`)
+is correct.
+
+## operator| for test_flags
+
+```cpp
+constexpr test_flags operator|(test_flag f1, test_flag f2);
+```
+
+Allows combining flags without a cast:
+```cpp
+.flags = test_schedule_sequential | test_is_optional,
+```
+
+## C++ install_failure_callback
+
+```cpp
+template <typename Callback>
+void install_failure_callback(Callback cb)
+    requires std::is_invocable_v<Callback>;
+```
+
+Accepts any invocable (lambda, function pointer, etc.) with signature `void()`.
+- Stateless callables (convertible to `void (*)()`) are passed as a function pointer
+  with no allocation.
+- Stateful callables (lambdas capturing variables, etc.) are heap-allocated; the
+  framework deletes the copy after `test_cleanup` runs.
+
+**Must be called from the main thread** (typically `test_init`).
+
+## FormatterFunction concept and test_formatter
+
+```cpp
+template <typename Callback> concept FormatterFunction =
+    std::is_invocable_r_v<std::string, Callback>
+    || std::is_invocable_r_v<std::string, Callback, ptrdiff_t>
+    || std::is_null_pointer_v<Callback>;
+```
+
+The formatter passed to `memcmp_or_fail` must satisfy `FormatterFunction`:
+either `std::string fn()` (no index) or `std::string fn(ptrdiff_t idx)` (with
+the index of the first mismatch).
+
+```cpp
+bool test_formatter(std::function<std::string()> cb, size_t max);
+bool test_formatter(std::function<std::string(ptrdiff_t)> cb, size_t max);
+```
+
+`test_formatter` is called internally in debug builds to validate that the
+formatter does not crash when invoked for every element index up to `max`.
+It is a no-op in release builds. Tests do not call it directly.

--- a/.github/instructions/sandstone-api-failure.instructions.md
+++ b/.github/instructions/sandstone-api-failure.instructions.md
@@ -1,0 +1,66 @@
+---
+applyTo: "**"
+---
+# sandstone.h — Failure Reporting
+
+All failure-reporting functions are `noreturn`: they kill the calling thread and
+cause the test to exit with a failure result. They must only be called from `test_run`.
+
+## report_fail / report_fail_msg
+
+```c
+report_fail(test);                    // annotates with __FILE__ and __LINE__
+report_fail_msg(fmt, ...);            // annotates with printf-style message + file/line
+```
+
+Use `report_fail_msg` when additional context helps diagnose the failure.
+
+## memcmp_or_fail
+
+Compares `actual` and `expected` arrays of `count` elements. If they differ, kills
+the calling thread and logs the first mismatch with hex dump and element index.
+`count` is the **number of elements**, not bytes.
+
+```c
+// C and C++ — no annotation
+memcmp_or_fail(actual, expected, count);
+
+// C and C++ — printf annotation (useful when a test does multiple comparisons)
+memcmp_or_fail(actual, expected, count, fmt, ...);
+
+// C++ only — formatter callback: std::string fn() or std::string fn(ptrdiff_t idx)
+memcmp_or_fail(actual, expected, count, formatter);
+
+// C only — low-level callback variant
+memcmp_or_fail_cb(actual, expected, count, cb, token);
+```
+
+`actual` and `expected` must point to typed arrays (any `ValidDataType`); the type
+is inferred. The formatter callback receives the index of the first mismatch and
+returns a `std::string` with extra diagnostic info.
+
+## install_failure_callback
+
+```c
+// C
+void install_failure_callback(void (*cb)(void *), void *token, void (*cleanup)(void *));
+
+// C++ — accepts any invocable (lambda, function pointer, etc.)
+install_failure_callback(callable);
+```
+
+- **Must be called from the main thread** (typically `test_init`).
+- `cb` is called **at most once per thread** on the first failure event in that thread.
+  Failure events: `memcmp_or_fail`, `log_error`, `report_fail_msg`, thrown exception,
+  or `test_run` returning failure.
+- `cleanup` (may be null) is called from the main thread after `test_cleanup`.
+- The C++ template overload manages lifetime automatically for non-stateless callables
+  (heap-allocates a copy; `cleanup` deletes it).
+
+## SANDSTONE_NO_LOGGING effects on failure functions
+
+When `SANDSTONE_NO_LOGGING` is defined:
+- `report_fail` / `report_fail_msg` still terminate the thread but suppress log output.
+- `memcmp_or_fail` still detects mismatches and terminates; formatter/fmt args are ignored.
+- `memcmp_or_fail_cb` uses null callback and token.
+- `install_failure_callback` becomes a no-op (`(void)cb`).

--- a/.github/instructions/sandstone-api-flags.instructions.md
+++ b/.github/instructions/sandstone-api-flags.instructions.md
@@ -1,0 +1,37 @@
+---
+applyTo: "**"
+---
+# sandstone.h — TestQuality and test_flags Enums
+
+## TestQuality enum
+
+| Value | Integer | Meaning |
+| ----- | ------- | ------- |
+| `TEST_QUALITY_SKIP` | `-1` | Never run. |
+| `TEST_QUALITY_BETA` | `0` | Run only with `--beta` flag (default for new tests). |
+| `TEST_QUALITY_PROD` | `2` | Run by default. |
+
+Note: value `1` is intentionally absent from the enum.
+
+## test_flags enum
+
+| Flag | Value | Meaning |
+| ---- | ----- | ------- |
+| `test_schedule_default` | `0` | Framework picks best scheduling heuristic. |
+| `test_schedule_sequential` | `1` | Threads run sequentially, not in parallel. |
+| `test_schedule_fullsystem` | `2` | All logical processors in one child process. |
+| `test_schedule_isolate_socket` | `3` | One child process per socket, all cores. |
+| `test_schedule_isolate_numa_domain` | `4` | One child process per NUMA domain per socket. |
+| `test_flag_ignore_memory_use` | `0x0010` | `--test-tests`: ignore memory consumption check. |
+| `test_flag_ignore_test_overtime` | `0x0020` | `--test-tests`: ignore >25% over requested duration. |
+| `test_flag_ignore_test_undertime` | `0x0040` | `--test-tests`: ignore >25% under requested duration. |
+| `test_flag_ignore_loop_timing` | `0x0080` | `--test-tests`: ignore inner loop timing checks. |
+| `test_flag_ignore_do_while` | `0x0100` | `--test-tests`: ignore early `test_time_condition()` detection. |
+| `test_failure_package_only` | `0x1000` | Failure attributed to package, not thread/core. |
+| `test_is_optional` | `0x2000` | Only run with `--include-optional`. |
+| `test_requires_smt` | `0x4000` | Requires SMT/Hyperthreading enabled. |
+| `test_init_in_parent` | `0x10000` | Run `test_init` in parent; do not use random generator or cause memory side-effects. |
+| `test_in_parent` | `0x20000` | Entire test runs in parent regardless of mode. |
+
+Multiple flags may be combined with `|`. In C++, `operator|` is provided for
+`test_flag` values and returns `test_flags` without requiring a cast.

--- a/.github/instructions/sandstone-api-lifecycle.instructions.md
+++ b/.github/instructions/sandstone-api-lifecycle.instructions.md
@@ -1,0 +1,57 @@
+---
+applyTo: "**"
+---
+# sandstone.h — Test Lifecycle and Loop Control
+
+## Lifecycle phases
+
+Phases execute sequentially. No two phases run concurrently. A phase only starts
+if the previous phase completed without error.
+
+| Order | Function | Where it runs | Notes |
+| ----- | -------- | -------------- | ----- |
+| 1 | `test_preinit(test)` | Parent process, once per application run | May set `test->data` to a skip-message string and return `EXIT_SKIP`. Do not use the random generator here. |
+| 2 | `test_init(test)` | Child main thread | Allocate resources; store in `test->data`. Return `EXIT_SKIP` to skip. Runs in parent if `test_init_in_parent` flag is set (do not use random generator or cause memory side-effects in that case). |
+| 3 | `test_run(test, thread)` | Child, all threads in parallel | Called one or more times. Must use `TEST_LOOP` for time-bounded execution. Return `EXIT_SUCCESS` or `EXIT_FAILURE`. |
+| 4 | `test_cleanup(test)` | Child main thread | Free resources allocated in `test_init`. |
+| 5 | `test_postcleanup(test)` | Child main thread, once per application run | Mirror of `test_preinit`. |
+
+## TEST_LOOP
+
+```c
+TEST_LOOP(test, N) {
+    /* body executed N times per outer iteration */
+}
+```
+
+- `N` **must be a power of 2** (enforced by convention; `static_assert(N > 0)` is present).
+- The framework checks elapsed time after every N body executions. If the time slot
+  has expired, the loop exits; otherwise it runs another N iterations.
+- `TEST_LOOP` internally calls `test_loop_start()` and `test_loop_end()` —
+  these are **framework-internal**; tests must not call them directly.
+- Every `test_run` function that loops over time **must** use `TEST_LOOP`. Do not
+  hand-roll a loop around `test_time_condition()`.
+
+## Timing functions
+
+`bool test_time_condition()` — returns `true` if time remains. Prefer `TEST_LOOP`.
+`test_time_condition(test)` (with an argument) is also valid; a macro wrapper
+silently drops the argument and calls the no-argument form.
+Calling `test_time_condition()` before doing any work in the loop is flagged by
+`--test-tests` unless `test_flag_ignore_do_while` is set.
+
+`bool test_loop_condition(int N)` — called by `TEST_LOOP`; not for direct use.
+When idle-cycle injection is configured, this function may call `usleep()`.
+
+## desired_duration and fracture_loop_count interaction
+
+- `desired_duration < 0`: test is expected to run exactly once; set
+  `test_flag_ignore_test_undertime` or `--test-tests` will warn.
+- `fracture_loop_count > 1`: the framework splits the run into sub-runs at the
+  specified inner-loop count boundary, allowing finer-grained failure attribution.
+
+## Retry
+
+`bool test_is_retry()` — returns `true` if the current invocation is a retry of a
+previously failed run. Tests may use this to adjust behaviour (e.g., reduce work to
+isolate the failing thread faster), but must not skip correctness checks.

--- a/.github/instructions/sandstone-api-logging.instructions.md
+++ b/.github/instructions/sandstone-api-logging.instructions.md
@@ -1,0 +1,62 @@
+---
+applyTo: "**"
+---
+# sandstone.h — Logging
+
+All logging macros are printf-style. Use `<inttypes.h>` format specifiers
+(e.g. `PRIu64`) for `<stdint.h>` types such as `uint64_t`. Alternatively, cast
+to `size_t`/`ptrdiff_t`/`long long`/`unsigned long long` and use `%zu`/`%td`/`%lld`/`%llu`.
+
+## Call-ordering constraints (enforced by convention)
+
+1. `log_thread_context(fmt, ...)` — **must be the very first log call** in the thread.
+   Its argument must be a single line of properly-formatted YAML. Omit if the thread
+   has no device context to report.
+2. `log_skip(category, fmt, ...)` — must come immediately after `log_thread_context`
+   (if used), before any other log call, and before returning `EXIT_SKIP`.
+
+Violating this order produces malformed YAML in the log output.
+
+## Log macros
+
+| Macro | Prefix | Notes |
+| ----- | ------ | ----- |
+| `log_error(fmt, ...)` | `E> ` | Always emitted. |
+| `log_warning(fmt, ...)` | `W> ` | Always emitted. |
+| `log_info(fmt, ...)` | `I> ` | Always emitted. |
+| `log_debug(fmt, ...)` | `d> ` | **No-op in release builds** (`NDEBUG`). Generates no code. |
+| `log_skip(cat, fmt, ...)` | — | Logs skip reason; see SkipCategory below. |
+| `log_thread_context(fmt, ...)` | — | Single YAML line describing thread's device context. C++ also accepts `std::string_view`. |
+| `log_platform_message(fmt, ...)` | `Platform issue:` | For OS/platform failures (memory alloc, file creation), not device failures. |
+| `log_data(msg, data, size)` | — | Hex-dumps `size` bytes from `data` with label `msg`. |
+| `log_yaml(level, yaml)` | — | Emits pre-formatted YAML at the given level character. |
+
+`log_message(thread_num, fmt, ...)` is the raw underlying function; prefer the macros.
+
+## SkipCategory enum
+
+Use the most specific category available:
+
+| Value | When to use |
+| ----- | ----------- |
+| `CpuNotSupportedSkipCategory` | CPU lacks required instruction set or features. |
+| `CpuTopologyIssueSkipCategory` | CPU topology does not meet test requirements. |
+| `TestResourceIssueSkipCategory` | Test-specific resource unavailable (e.g., a required file or device node). |
+| `OSResourceIssueSkipCategory` | OS resource unavailable (memory, file descriptors, etc.). |
+| `OsNotSupportedSkipCategory` | OS does not support what the test requires. |
+| `DeviceNotFoundSkipCategory` | Required device (GPU, accelerator) not present. |
+| `DeviceNotConfiguredSkipCategory` | Device present but not configured for testing. |
+| `RuntimeSkipCategory` | Runtime condition prevents the test (e.g., insufficient privileges). |
+| `TestObsoleteSkipCategory` | Test is obsolete and should not run. |
+| `IgnoredMceCategory` | MCE detected but ignored per policy. |
+| `SelftestSkipCategory` | Skip during framework self-test mode. |
+| `UnknownSkipCategory` | Use only when no other category applies. |
+
+## SANDSTONE_NO_LOGGING effects
+
+When `SANDSTONE_NO_LOGGING` is defined:
+- `log_warning`, `log_info`, `log_debug`, `log_data` become no-ops.
+- `log_yaml` is redefined to call the underlying function with a null yaml string (not a true no-op).
+- `log_error` emits a bare `E>` marker with no message.
+- `log_platform_message` emits a bare `E>` marker only when the message starts with `E>`.
+- `log_skip` passes a null message.

--- a/.github/instructions/sandstone-api-random.instructions.md
+++ b/.github/instructions/sandstone-api-random.instructions.md
@@ -1,0 +1,78 @@
+---
+applyTo: "**"
+---
+# sandstone.h — Random, Utilities and Helpers
+
+## Integer random
+
+```c
+uint32_t    random32();    // uniform random 32-bit unsigned integer
+uint64_t    random64();    // uniform random 64-bit unsigned integer
+__uint128_t random128();   // uniform random 128-bit unsigned integer
+```
+
+## Buffer fill
+
+```c
+void *memset_random(void *dest, size_t n);  // fills n bytes at dest with random values; returns dest
+```
+
+## Floating-point random
+
+```c
+// Positive value between 0.0 and 1.0
+float       frandomf();
+double      frandom();
+long double frandoml();
+
+// Positive value between 0.0 and scale
+float       frandomf_scale(float scale);
+double      frandom_scale(double scale);
+long double frandoml_scale(long double scale);
+```
+
+All floating-point random functions return positive values only.
+
+## Bit-pattern random
+
+```c
+uint64_t set_random_bits(unsigned num_bits_to_set, uint32_t bitwidth);
+```
+
+Returns a `uint64_t` in which exactly `num_bits_to_set` bits are randomly set
+within the lowest `bitwidth` bits; all higher bits are zero.
+Example: `set_random_bits(2, 8)` returns a value with exactly 2 of the 8 LSBs set.
+
+## Aligned allocation
+
+```c
+void *aligned_alloc_safe(size_t alignment, size_t size);
+```
+
+Wrapper around `aligned_alloc` that rounds `size` up to the nearest multiple of
+`alignment` before calling, satisfying `aligned_alloc`'s precondition that size
+must be a multiple of alignment. Enforces `alignment >= sizeof(void*)`.
+
+## Alignment check
+
+```c
+IS_ALIGNED(ptr, alignment)   // expands to 1 if ptr is aligned; alignment must be a power of 2
+```
+
+Implemented as a bitmask check on the pointer cast to `uint64_t`.
+
+## Bitmask
+
+```c
+MASK(bits)   // bitmask with the lowest `bits` bits set; handles bits == 64 correctly
+```
+
+## Suppress unused-variable warnings
+
+```c
+IGNORE_RETVAL(call)           // discards the return value of call; suppresses nodiscard warnings
+UNUSED_ARGS(a, b, ...)        // casts up to 20 arguments to void; suppresses unused-parameter warnings
+```
+
+Use `IGNORE_RETVAL` instead of a bare cast to `void` when the intent needs to be
+explicit. Use `UNUSED_ARGS` in function bodies instead of `(void)param` chains.

--- a/.github/instructions/sandstone-api-test-struct.instructions.md
+++ b/.github/instructions/sandstone-api-test-struct.instructions.md
@@ -1,0 +1,52 @@
+---
+applyTo: "**"
+---
+# sandstone.h — Test Structure and Declaration
+
+## DECLARE_TEST pattern
+
+```c
+DECLARE_TEST(test_id, "one-line description")
+    .quality_level  = TEST_QUALITY_PROD,
+    .test_preinit   = my_preinit,   /* optional */
+    .test_init      = my_init,      /* optional */
+    .test_run       = my_run,       /* required */
+    .test_cleanup   = my_cleanup,   /* optional */
+    .test_postcleanup = my_postcleanup, /* optional */
+    .flags          = test_schedule_sequential,
+    .desired_duration = 0,
+END_DECLARE_TEST
+```
+
+`DECLARE_TEST_GROUPS(...)` assigns the test to one or more `struct test_group*` groups;
+assign the result to `.groups`.
+
+## struct test fields
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `id` | `const char *` | Unique string identifier; set by macro. |
+| `description` | `const char *` | One-line human description; set by macro. |
+| `groups` | `const struct test_group * const *` | Array of group pointers; set via `DECLARE_TEST_GROUPS`. |
+| `test_preinit` | `initfunc` | Called once in parent process per application run. Optional. |
+| `test_init` | `initfunc` | Called in child main thread before run. Optional. |
+| `test_run` | `runfunc` | Called per thread in parallel. Required. Signature: `int fn(struct test *, int thread)`. |
+| `test_cleanup` | `cleanupfunc` | Called in child main thread after run. Optional. |
+| `test_postcleanup` | `cleanupfunc` | Called in child main thread, once per application run. Optional. |
+| `quality_level` | `test_quality` | See `sandstone-api-flags.instructions.md`. |
+| `flags` | `test_flags` | See `sandstone-api-flags.instructions.md`. |
+| `desired_duration` | `int` (ms) | `0`=default, `<0`=run once, `INT_MAX`=run forever (must be killed). |
+| `minimum_duration` | `int` (ms) | Lower bound on run time; `0`=no limit. Note: the header comment incorrectly says "upper bound" — the field name and semantic are authoritative. |
+| `maximum_duration` | `int` (ms) | Upper bound on run time; `0`=no limit. |
+| `fracture_loop_count` | `int` | `<0`=never fracture, `0`=auto, `>1`=fracture at that inner loop count. |
+| `minimum_cpu` | `device_features_t` | Minimum device feature set; test is skipped if device is older. |
+| `data` | `void *` | Test-lifetime opaque pointer. Set in `test_init`, read in `test_run`, freed in `test_cleanup`. If test was skipped in preinit, points to a skip message string. |
+| `per_thread` | `struct test_data_per_thread *` | Array indexed by `thread_num`; each element has a `void *data` slot for per-thread state. |
+
+`test_kvm_config` (KVM configuration callback) is intentionally omitted; it is
+only relevant to KVM-based tests.
+
+## EXIT_SKIP
+
+`EXIT_SKIP` (`-255`) — return this from `test_init` (or `test_preinit`) to skip the test.
+Always call `log_skip(category, ...)` before returning `EXIT_SKIP`.

--- a/.github/instructions/sandstone-api-threading.instructions.md
+++ b/.github/instructions/sandstone-api-threading.instructions.md
@@ -1,0 +1,80 @@
+---
+applyTo: "**"
+---
+# sandstone.h — Threading and Platform Access
+
+## Thread identity and topology
+
+```c
+/* GCC / non-LLVM: */
+extern __thread int thread_num __attribute__((tls_model("initial-exec")));
+/* Clang / LLVM: */
+extern thread_local int thread_num;
+```
+
+`thread_num` is always equal to the `thread` parameter passed to `test_run`.
+It may be used to index `test->per_thread[]`.
+
+```c
+int thread_count();    // number of HW threads assigned to the test
+int device_count();    // number of devices (CPUs or GPUs); normally == thread_count()
+int num_packages();    // number of physical CPU sockets
+```
+
+`thread_count()` may be lower than the total system thread count if `--cpuset` is
+used, if the test sets `.max_threads`, or if the OS restricts visible CPUs.
+
+`device_count()` is tracked separately from `thread_count()`; prefer `device_count()`
+when iterating over devices, and `thread_count()` when iterating over threads.
+
+## Verbosity
+
+```c
+int8_t sandstone_verbosity_level();  // current verbosity; 0 = normal
+```
+
+## Device features
+
+```c
+extern device_features_t device_features;  // features of the current device
+```
+
+## Device scheduler / reschedule
+
+```c
+void reschedule();
+```
+
+Yields the device scheduler slot. Call inside `test_run` when the test does not
+need the CPU for a period (e.g., waiting on a memory operation). Safe to call
+unconditionally; is a no-op when no `DeviceScheduler` is active.
+
+## MSR access (Linux x86-64 only, requires root)
+
+```c
+bool read_msr(int cpu, uint32_t msr, uint64_t *value);
+bool write_msr(int cpu, uint32_t msr, uint64_t value);
+```
+
+Both return `false` on non-Linux or non-x86-64 platforms (inline stubs that do nothing).
+On Linux x86-64, return `false` if the MSR cannot be accessed (e.g., insufficient
+privileges or the MSR does not exist).
+
+## Physical address retrieval (Linux only, requires root)
+
+```c
+uint64_t retrieve_physical_address(const volatile void *ptr);
+```
+
+Returns the physical address of a virtual pointer. Linux only; requires root.
+Result is undefined on other platforms.
+
+## mmap error reporting
+
+```c
+const char *strerror_for_mmap();
+```
+
+Returns the error message for the last failed `mmap()` call (or `VirtualAlloc` on
+Windows). **Must be called before anything overwrites `errno` or `GetLastError()`.**
+Use immediately after a failed `mmap()` in `test_init`.

--- a/.github/instructions/sandstone-api.instructions.md
+++ b/.github/instructions/sandstone-api.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "**"
+---
+# sandstone.h API Reference — Index
+
+The files below document the full public API of `framework/sandstone.h`, organized by topic.
+Use them when `framework/sandstone.h` cannot be read directly.
+
+| File | Content |
+| ---- | ------- |
+| `sandstone-api-test-struct.instructions.md` | `DECLARE_TEST`/`END_DECLARE_TEST` pattern; all `struct test` fields; `EXIT_SKIP` |
+| `sandstone-api-flags.instructions.md` | `TestQuality` enum; `test_flags` enum with all values and bitmasks |
+| `sandstone-api-lifecycle.instructions.md` | Test lifecycle phases and concurrency rules; `TEST_LOOP`; timing; `test_is_retry` |
+| `sandstone-api-failure.instructions.md` | `report_fail*`; all `memcmp_or_fail` overloads; `install_failure_callback`; `SANDSTONE_NO_LOGGING` effects |
+| `sandstone-api-logging.instructions.md` | All `log_*` macros; `SkipCategory` enum; call-ordering constraints; `SANDSTONE_NO_LOGGING` silencing |
+| `sandstone-api-threading.instructions.md` | `thread_num`; `thread_count`/`device_count`/`num_packages`; MSR access; `retrieve_physical_address`; `reschedule` |
+| `sandstone-api-random.instructions.md` | `random*`; `memset_random`; `frandom*`; `set_random_bits`; `aligned_alloc_safe`; `IS_ALIGNED`; `MASK`; `IGNORE_RETVAL`; `UNUSED_ARGS` |
+| `sandstone-api-cpp.instructions.md` | `TestRunner<T>`; `CpuNotSupported`/`OsNotSupported`; C++ `install_failure_callback`; `FormatterFunction`; `test_formatter` |

--- a/.github/instructions/style.instructions.md
+++ b/.github/instructions/style.instructions.md
@@ -18,7 +18,7 @@ number when reporting out.
 - [ ]  **Anonymous namespaces** required around all test-internal structs/classes in C++.
 - [ ] Use a `testname_` prefix in C around all test-internal structs and functions
 - [ ] All code must compile **without warnings** (`-Wall -Wextra` are enabled; `-Werror=format-security` is
-    enforced, and `-Wno-unused-parameter` is used). 
+    enforced, and `-Wno-unused-parameter` is used).
     When doing code review, editing or creating new code, do a test build of the code
     to check for warnings.
 - [ ] All code must be cross-platform (Linux + Windows); use `_WIN32` / `__linux__` macros.

--- a/.github/instructions/test.instructions.md
+++ b/.github/instructions/test.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "tests/"
+applyTo: "tests/**"
 ---
 
 OpenDCDiag tests follow a rigid pattern and are declared with the
@@ -48,8 +48,16 @@ golden values, stores this in the test->data pointer for read-only consumption
 by the run function, and then frees this memory in the cleanup function.
 
 
-Mandatory step: Load `framework/sandstone.h` immediately into the review
-context.
+For the sandstone API reference, use the following order of preference:
+
+1. **If you can read files directly** (agentic/chat mode): load `framework/sandstone.h`
+   from the repository root as the authoritative API and architectural reference.
+2. **Otherwise** (web review / no file access): refer to
+   `.github/instructions/sandstone-api.instructions.md` and its companion
+   `sandstone-api-*.instructions.md` files as the authoritative contract for all API
+   usage checks in this review.
+
+Do not source both at the same time; pick one path and use it exclusively.
 
 Count how many rules this file contains, put this number in the context,
 and at the end, use this count to make sure no checks were missed. List this


### PR DESCRIPTION
This PR Fixes issues in the instruction files introduced by #1094 that would
prevent Copilot code review from working correctly, and adds a complete
sandstone API reference that Copilot can use during web-based reviews
without needing direct `framework/sandstone.h` file access.

Further details on each commit.