### PR TITLE
FW: fix condition on HWM in `test_tests_finish`

### DIFF
--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -396,7 +396,10 @@ inline void test_the_test_data<true>::test_tests_finish(const struct test *the_t
     MonotonicTimePoint now = std::chrono::steady_clock::now();
 
     size_t current_hwm = memfpt_current_high_water_mark();
-    if ((current_hwm == 0) != (hwm_at_start == 0) || current_hwm < hwm_at_start) {
+    if (current_hwm < hwm_at_start) {
+        // Also fires when current_hwm == 0 and hwm_at_start != 0 (tracking stopped).
+        // hwm_at_start == 0 is a valid zero baseline (freshly forked child had no
+        // private pages yet), so current_hwm >= 0 == hwm_at_start is not an error.
         log_warning("High water mark memory footprinting failed (%zu kB at start, %zu kB now)",
                     hwm_at_start, current_hwm);
     } else if (current_hwm) {


### PR DESCRIPTION
For freshly forked child process, the `hwm_at_start` can be 0. For CPUs, `prepare_test_for_device()` does not allocate private heap/mmap pages, so it can be 0 afterwards as well. This commit changes the warning condition to reflect that.