### PR TITLE
FW/Logging: guard against truncated `LogMessage`s messages

### DIFF
--- a/framework/logging.h
+++ b/framework/logging.h
@@ -47,6 +47,10 @@ public:
         void *base = nullptr;
         size_t size = 0;            // actual size, not rounded up to page
     public:
+        struct sentinel {
+            const char *end_ptr;
+        };
+
         struct const_iterator {
             const LogMessage *ptr;
 
@@ -54,7 +58,6 @@ public:
             using value_type = LogMessage;
             using iterator_category = std::forward_iterator_tag;
 
-            friend auto operator<=>(const_iterator, const_iterator) = default;
             const LogMessage &operator*() const { return *ptr; }
             const LogMessage *operator->() const { return ptr; }
             // pre-increment
@@ -62,6 +65,20 @@ public:
                 ptr = reinterpret_cast<const LogMessage*>(ptr->payload + ptr->msglen);
                 return *this;
             }
+
+            friend auto operator<=>(const_iterator, const_iterator) = default;
+            friend bool operator==(const_iterator it, sentinel end) noexcept
+            {
+                // the log file may be incomplete if the child crashed while
+                // writing, so we need to check whether this message is fully
+                // present or not.
+                auto hdrend = reinterpret_cast<const char *>(it.ptr + 1);
+                if (hdrend > end.end_ptr)
+                    return true;                                // header incomplete
+                return hdrend + it.ptr->msglen > end.end_ptr;   // payload incomplete
+            }
+            friend bool operator!=(const_iterator it, sentinel end) noexcept
+            { return !(it == end); }
         };
 
         LogMessagesFile() noexcept {}
@@ -75,8 +92,8 @@ public:
         bool empty() const { return size == 0; }
         const_iterator begin() const
         { return { static_cast<const LogMessage *>(base) }; }
-        const_iterator end() const
-        { return { reinterpret_cast<const LogMessage *>(bytes() + size) }; }
+        sentinel end() const
+        { return { bytes() + size }; }
 
         size_t size_bytes() const { return size; }
         const char *bytes() const { return static_cast<const char *>(base); }

--- a/framework/sandstone_utils.cpp
+++ b/framework/sandstone_utils.cpp
@@ -343,6 +343,9 @@ private:
     std::string &append_to;
     int indent;
     int prefix_len;
+
+    void append_with_comment(std::string_view value, std::string_view comment);
+    void append_with_comment(const char *fmtvalue, const char *fmtcomment, ...);
 };
 
 static std::string format_yaml(const std::map<std::string, YamlFormatter::SimpleValue> &values, int indent)


### PR DESCRIPTION
`log_message_for_thread()` calls `writev()` with the `LogMessage` header as one iovec and the payload as subsequent iovecs. This write is not atomic: on Windows the `writev()` emulation issues each iovec as a separate `_write()` call; on Unix, the OS iterates iovecs internally and another thread calling `_exit()` (e.g. after a crash) can race with an in-progress `writev()` on a sibling thread. In either case the log file can be left with a complete header (`msglen = N`) and no payload.

The previous `LogMessagesFile::const_iterator` compared `end()` by pointer equality. `operator++()` advances by `payload + msglen`, so with `msglen > 0` and no payload present it overshoots `end()`. The loop condition `(it != end)` never becomes true, causing the parent process to read beyond the mmap and possibly segfault. This was observed in the CI, on Windows:

```yaml
  tests:
  - test: selftest_sigfpe
    details: { quality: production, description: "Crashes with SIGFPE" }
    threads:
    - thread: 1
      id: { logical-group:  0, logical:  1, package: 0, numa_node: 0, module: 0, core: 0, thread: 1, family: 25, model: 0x1, stepping: 1, microcode: null, ppin: null }
      loop-count: 0
      freq_mhz: 0.0
    - thread: 2
      id: { logical-group:  0, logical:  2, package: 0, numa_node: 0, module: 1, core: 1, thread: 0, family: 25, model: 0x1, stepping: 1, microcode: null, ppin: null }
      loop-count: 0
      messages:
      - { level: info, text: '' }
# Tool exited with unknown "exit: "
```

We fix this by making `end()` return a a sentinel whose `operator==` stops the loop in three cases:
  1. `ptr` has reached or overshot `end_ptr`
  2. fewer than `sizeof(LogMessage)` bytes remain (truncated header)
  3. current message's payload extends past `end_ptr` (truncated payload)

Case 3 is the primary fix for the described bug: thread 1 is the crashing one, thread 2's message was empty (which is not possible), and attempting to print thread 3 is likely the reason for the crash.