### PR TITLE
FW/logging: Fix main thread entries missing from stdout

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -342,6 +342,19 @@ selftest_pass() {
     test_yaml_regexp "/tests/1/result" skip
 }
 
+@test "selftest_pass has main thread at -vvv" {
+    # Verify that at least 1 main thread exists with runtime
+    # and resource-usage when running at -vvv verbosity.
+    declare -A yamldump
+    sandstone_selftest -vvv -e selftest_pass
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/tests/0/threads/0/thread" 'main'
+    test_yaml_numeric "/tests/0/threads/0/runtime" 'value >= 0'
+    if ! $is_windows; then
+        test_yaml_regexp "/tests/0/threads/0/resource-usage" '\{.*\}'
+    fi
+}
+
 @test "selftest_preinit" {
     declare -A yamldump
     sandstone_selftest -e selftest_preinit

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2212,9 +2212,13 @@ void YamlLogger::print_thread_messages()
         LogLevelVerbosity lowest_level =
                 print_one_thread_messages(file_log_fd, r, LogLevelVerbosity::Max);
 
-        if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
-            print_thread_header(real_stdout_fd, data, s_tid, sApp->shmem->cfg.verbosity);
-            print_one_thread_messages(real_stdout_fd, r, sApp->shmem->cfg.verbosity);
+        if (file_log_fd != real_stdout_fd) {
+            // print to stdout
+            bool has_messages = lowest_level <= sApp->shmem->cfg.verbosity;
+            if (want_print || has_messages)
+                print_thread_header(real_stdout_fd, data, s_tid, sApp->shmem->cfg.verbosity);
+            if (has_messages)
+                print_one_thread_messages(real_stdout_fd, r, sApp->shmem->cfg.verbosity);
         }
 
         munmap_and_truncate_log(data, r);


### PR DESCRIPTION
Main thread entries with no messages were not printed to stdout. The doprint lambda gated both header and message output behind lowest_level <= verbosity, but main threads with no messages have lowest_level = Max (127), so the condition always failed and the stdout output was silently skipped.

Decouple header printing from message printing for the stdout path: print the thread header when want_print or has_messages is true, and print messages only when has_messages is true. This ensures main thread entries (runtime, resource-usage) appear on stdout at -vvv verbosity even when the thread has no messages.

Also add a selftest "selftest_pass has main thread at -vvv" that verifies at least one main thread entry exists with runtime and resource-usage when running at -vvv verbosity.