### PR TITLE
FW/logging: Remove redundant inner loop count log_message

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -342,9 +342,10 @@ selftest_pass() {
     test_yaml_regexp "/tests/1/result" skip
 }
 
-@test "selftest_pass has main thread at -vvv" {
+@test "selftest_pass has main thread and loop-count at -vvv" {
     # Verify that at least 1 main thread exists with runtime
     # and resource-usage when running at -vvv verbosity.
+    # Also confirm loop-count is printed for silent threads.
     declare -A yamldump
     sandstone_selftest -vvv -e selftest_pass
     [[ "$status" -eq 0 ]]
@@ -353,6 +354,9 @@ selftest_pass() {
     if ! $is_windows; then
         test_yaml_regexp "/tests/0/threads/0/resource-usage" '\{.*\}'
     fi
+    for ((i = 1; i <= MAX_PROC; ++i)); do
+        test_yaml_numeric "/tests/0/threads/$i/loop-count" 'value >= 0'
+    done
 }
 
 @test "selftest_preinit" {

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -778,11 +778,6 @@ static uintptr_t thread_runner(int thread_number)
     this_thread->effective_freq_mhz = CPUTimeFreqStamp::EffectiveFrequencyMHz(before, after);
 #endif
 
-    if (sApp->shmem->cfg.verbosity >= 3)
-        log_message(thread_number, SANDSTONE_LOG_INFO "inner loop count for thread %d = %u\n",
-                    thread_number, this_thread->inner_loop_count);
-
-
     // our caller doesn't care what we return, but the returned value helps if
     // you're running strace
     return ret;


### PR DESCRIPTION
The inner loop count is already reported in the YAML output via the per-thread loop-count field. The log_message call duplicated this information as a verbose info message, adding noise without value.

[ChangeLog][Logging] Remove redundant inner loop count log_message.