### PR TITLE
FW: Decouple thread_count from device_count in slice planning and logging

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -80,7 +80,7 @@ void KeyValuePairLogger::print(int tc)
     logging_flush();
 }
 
-void KeyValuePairLogger::print_thread_header(int fd, int device, const char *prefix)
+void KeyValuePairLogger::print_thread_header(int fd, int thread, int device, const char *prefix)
 {
     if (device < 0) {
         device = ~device;
@@ -94,51 +94,51 @@ void KeyValuePairLogger::print_thread_header(int fd, int device, const char *pre
 
     const cpu_info_t *info = device_info + device;
     const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(info->package_id);
-    PerThreadData::Test *thr = sApp->test_thread_data(device);
+    PerThreadData::Test *thr = sApp->test_thread_data(thread);
     if (std::string time = format_duration(thr->fail_time); time.size()) {
-        dprintf(fd, "%s_thread_%d_fail_time = %s\n", prefix, device, time.c_str());
-        dprintf(fd, "%s_thread_%d_loop_count = %u\n", prefix, device,
+        dprintf(fd, "%s_thread_%d_fail_time = %s\n", prefix, thread, time.c_str());
+        dprintf(fd, "%s_thread_%d_loop_count = %u\n", prefix, thread,
                 thr->inner_loop_count_at_fail);
     } else {
-        dprintf(fd, "%s_thread_%d_loop_count = %u\n", prefix, device,
+        dprintf(fd, "%s_thread_%d_loop_count = %u\n", prefix, thread,
                 thr->inner_loop_count);
     }
-    dprintf(fd, "%s_messages_thread_%d_cpu = %d\n", prefix, device, info->cpu_number);
-    dprintf(fd, "%s_messages_thread_%d_family_model_stepping = %02x-%02x-%02x\n", prefix, device,
+    dprintf(fd, "%s_messages_thread_%d_cpu = %d\n", prefix, thread, info->cpu_number);
+    dprintf(fd, "%s_messages_thread_%d_family_model_stepping = %02x-%02x-%02x\n", prefix, thread,
             sApp->hwinfo.family, sApp->hwinfo.model, sApp->hwinfo.stepping);
     dprintf(fd, "%s_messages_thread_%d_topology = phys %d, core %d, thr %d\n",
-            prefix, device, info->package_id, info->core_id, info->thread_id);
-    dprintf(fd, "%s_messages_thread_%d_microcode =", prefix, device);
+            prefix, thread, info->package_id, info->core_id, info->thread_id);
+    dprintf(fd, "%s_messages_thread_%d_microcode =", prefix, thread );
     if (info->microcode)
         dprintf(fd, " 0x%" PRIx64, info->microcode);
     dprintf(fd, "\n%s_messages_thread_%d_ppin =",
-            prefix, device);
+            prefix, thread);
     if (pkg && pkg->ppin)
         dprintf(fd, " 0x%" PRIx64, pkg->ppin);
-    dprintf(fd, "\n%s_messages_thread_%d = \\\n", prefix, device);
+    dprintf(fd, "\n%s_messages_thread_%d = \\\n", prefix, thread);
 }
 
 void KeyValuePairLogger::print_thread_messages()
 {
-    auto doprint = [this](PerThreadData::Common *data, int i) {
+    auto doprint = [this](PerThreadData::Common *data, int thread, int device=-1) {
         LogMessagesFile r = maybe_mmap_log(data);
 
         if (r.empty() && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
             return;           /* nothing to be printed, on any level */
 
-        print_thread_header(file_log_fd, i, timestamp_prefix.c_str());
+        print_thread_header(file_log_fd, thread, device, timestamp_prefix.c_str());
         LogLevelVerbosity lowest_level =
                 print_one_thread_messages_tdata(file_log_fd, data, r, LogLevelVerbosity::Max);
 
         if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
-            print_thread_header(real_stdout_fd, i, test->id);
+            print_thread_header(real_stdout_fd, thread, device, test->id);
             print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->cfg.verbosity);
         }
 
         munmap_and_truncate_log(data, r);
     };
     for_each_main_thread(doprint, slices.size());
-    for_each_test_thread(doprint);
+    for_each_test_thread(doprint, slices.size());
 }
 
 void KeyValuePairLogger::print_child_stderr()
@@ -272,20 +272,20 @@ void TapFormatLogger::maybe_print_yaml_marker(int fd)
         IGNORE_RETVAL(write(fd, fail_info.c_str(), fail_info.size()));
 }
 
-void TapFormatLogger::print_thread_header(int fd, int device, LogLevelVerbosity verbosity)
+void TapFormatLogger::print_thread_header(int fd, int thread, int device, LogLevelVerbosity verbosity)
 {
     maybe_print_yaml_marker(fd);
-    if (device < 0) {
-        device = ~device;
-        if (device == 0)
+    if (thread < 0) {
+        int slice = ~thread;
+        if (slice == 0)
             writeln(fd, "  Main thread:");
         else
-            dprintf(fd, "  Main thread %d:", device);
+            dprintf(fd, "  Main thread %d:", slice);
         return;
     }
 
     const cpu_info_t *info = device_info + device;
-    std::string line = stdprintf("  Thread %d on CPU %d (pkg %d, core %d, thr %d", device,
+    std::string line = stdprintf("  Thread %d on CPU %d (pkg %d, core %d, thr %d", thread,
             info->cpu_number, info->package_id, info->core_id, info->thread_id);
     if (const char *type = native_device_type(info))
         line += stdprintf(", core_type: %s", type);
@@ -309,7 +309,7 @@ void TapFormatLogger::print_thread_header(int fd, int device, LogLevelVerbosity 
     writeln(fd, line);
 
     if (verbosity > 1) {
-        PerThreadData::Test *thr = sApp->test_thread_data(device);
+        PerThreadData::Test *thr = sApp->test_thread_data(thread);
         if (std::string time = format_duration(thr->fail_time); time.size())
             writeln(fd, "  - failed: { time: ", time,
                     ", loop-count: ", std::to_string(thr->inner_loop_count_at_fail),
@@ -321,25 +321,25 @@ void TapFormatLogger::print_thread_header(int fd, int device, LogLevelVerbosity 
 
 void TapFormatLogger::print_thread_messages()
 {
-    auto doprint = [this](PerThreadData::Common *data, int i) {
+    auto doprint = [this](PerThreadData::Common *data, int thread, int device=-1) {
         LogMessagesFile r = maybe_mmap_log(data);
 
         if (r.empty() && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
             return;             /* nothing to be printed, on any level */
 
-        print_thread_header(file_log_fd, i, LogLevelVerbosity::Max);
+        print_thread_header(file_log_fd, thread, device, LogLevelVerbosity::Max);
         LogLevelVerbosity lowest_level =
                 print_one_thread_messages_tdata(file_log_fd, data, r, LogLevelVerbosity::Max);
 
         if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
-            print_thread_header(real_stdout_fd, i, sApp->shmem->cfg.verbosity);
+            print_thread_header(real_stdout_fd, thread, device, sApp->shmem->cfg.verbosity);
             print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->cfg.verbosity);
         }
 
         munmap_and_truncate_log(data, r);
     };
     for_each_main_thread(doprint, slices.size());
-    for_each_test_thread(doprint);
+    for_each_test_thread(doprint, slices.size());
 }
 
 void TapFormatLogger::print_child_stderr()
@@ -430,16 +430,16 @@ std::string AbstractLogger::thread_id_header_for_device(int thread, LogLevelVerb
     return full_cpu_info(LogicalProcessor(info->cpu_number), verbosity, info);
 }
 
-std::string AbstractLogger::thread_id_header_for_cpu(LogicalProcessor lp, int thread, LogLevelVerbosity verbosity)
+std::string AbstractLogger::thread_id_header_for_cpu(LogicalProcessor lp, int device, LogLevelVerbosity verbosity)
 {
     cpu_info_t *info = nullptr;
 
     // is this the correct info?
-    if (cpu_info[thread].cpu_number == int(lp)) {
-        info = cpu_info + thread;
+    if (cpu_info[device].cpu_number == int(lp)) {
+        info = cpu_info + device;
     } else {
         // see if we can find the full information about this CPU
-        for (int i = 0; !info && i < sApp->thread_count; ++i) {
+        for (int i = 0; !info && i < device_count(); ++i) {
             if (cpu_info[i].cpu_number == int(lp))
                 info = cpu_info + i;
         }

--- a/framework/device/cpu/logging_cpu.h
+++ b/framework/device/cpu/logging_cpu.h
@@ -24,7 +24,7 @@ private:
     std::string timestamp_prefix;
 
     void prepare_line_prefix();
-    void print_thread_header(int fd, int device, const char *prefix);
+    void print_thread_header(int fd, int thread, int device, const char *prefix);
     void print_thread_messages();
     void print_child_stderr();
 };
@@ -45,7 +45,7 @@ private:
     static const char *quality_string(const struct test *test);
     void maybe_print_yaml_marker(int fd);
     void print_thread_messages();
-    void print_thread_header(int fd, int device, LogLevelVerbosity verbosity);
+    void print_thread_header(int fd, int thread, int device, LogLevelVerbosity verbosity);
     void print_child_stderr();
     std::string format_status_code();
 };

--- a/framework/device/cpu/slicing.cpp
+++ b/framework/device/cpu/slicing.cpp
@@ -51,14 +51,14 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
         }
 
         // set up proper plans
-        std::vector<DeviceRange> &isolate_socket = plans[SlicePlans::IsolateSockets];
-        std::vector<DeviceRange> &isolate_numa = plans[SlicePlans::IsolateNuma];
-        std::vector<DeviceRange> &split = plans[SlicePlans::Heuristic];
-        auto push_to = [](std::vector<DeviceRange> &to, auto start, auto end) {
+        auto &isolate_socket = plans[SlicePlans::IsolateSockets];
+        auto &isolate_numa = plans[SlicePlans::IsolateNuma];
+        auto &split = plans[SlicePlans::Heuristic];
+        auto push_to = [](SlicePlans::Slices &to, auto start, auto end) {
             int start_cpu = start[0].threads.front().cpu();
             int end_cpu = end[-1].threads.back().cpu();
             assert(end_cpu >= start_cpu);
-            to.push_back(DeviceRange{ start_cpu, end_cpu + 1 - start_cpu });
+            to.push_back(SlicePlans::Slice{ DeviceRange{ start_cpu, end_cpu + 1 - start_cpu }, {} });
         };
 
         for (const Topology::Package &p : topology.packages) {
@@ -99,12 +99,12 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
 
     if (max_cores_per_slice == 0) {
         // set to full system
-        std::vector plan = { DeviceRange{ 0, device_count() } };
+        SlicePlans::Slices plan = { SlicePlans::Slice{ DeviceRange{ 0, device_count() }, {} } };
         plans.fill(plan);
     } else {
         // dumb plan, not *cores*
         int slice_count = (max_cpu - 1) / max_cores_per_slice + 1;
-        std::vector<DeviceRange> plan;
+        SlicePlans::Slices plan;
         plan.reserve(slice_count);
 
         int slice_size = max_cpu / slice_count;
@@ -112,8 +112,8 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
             ++slice_size;       // round up the slice size
         int cpu = 0;
         for ( ; cpu < max_cpu - slice_size; cpu += slice_size)
-            plan.push_back(DeviceRange{ cpu, slice_size });
-        plan.push_back(DeviceRange{ cpu, max_cpu - cpu });
+            plan.push_back(SlicePlans::Slice{ DeviceRange{ cpu, slice_size }, {} });
+        plan.push_back(SlicePlans::Slice{ DeviceRange{ cpu, max_cpu - cpu }, {} });
         plans.fill(plan);
     }
 }

--- a/framework/device/cpu/slicing.cpp
+++ b/framework/device/cpu/slicing.cpp
@@ -117,3 +117,11 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
         plans.fill(plan);
     }
 }
+
+void slice_plan_init_for_threads(SlicePlans::SlicesArray& plans)
+{
+    for (auto &plan : plans) {
+        for (auto &slice : plan)
+            slice.thread_range = { slice.device_range.starting_device, slice.device_range.device_count }; // 1:1 for now...
+    }
+}

--- a/framework/device/cpu/unit-tests/topology_tests.cpp
+++ b/framework/device/cpu/unit-tests/topology_tests.cpp
@@ -63,8 +63,8 @@ void expect_plan(const SlicePlans::Slices &actual, const std::vector<std::pair<i
 {
     ASSERT_EQ(actual.size(), expected.size());
     for (size_t i = 0; i < actual.size(); ++i) {
-        EXPECT_EQ(actual[i].starting_device, expected[i].first);
-        EXPECT_EQ(actual[i].device_count, expected[i].second);
+        EXPECT_EQ(actual[i].device_range.starting_device, expected[i].first);
+        EXPECT_EQ(actual[i].device_range.device_count, expected[i].second);
     }
 }
 }

--- a/framework/device/gpu/build_topology.cpp
+++ b/framework/device/gpu/build_topology.cpp
@@ -55,7 +55,7 @@ Topology build_topology()
 
 void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_per_slice)
 {
-    std::vector plan = { DeviceRange{ 0, thread_count() } };
+    SlicePlans::Slices plan = { SlicePlans::Slice{ DeviceRange{ 0, thread_count() }, {} } };
     plans[SlicePlans::IsolateSockets] = plan;
 
     auto& isolate_numa = plans[SlicePlans::IsolateNuma];
@@ -77,12 +77,12 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
             }
 
             // end of contiguous range
-            isolate_numa.push_back(DeviceRange{ range_start, prev_gpu - range_start + 1 });
+            isolate_numa.push_back(SlicePlans::Slice{ DeviceRange{ range_start, prev_gpu - range_start + 1 }, {} });
             range_start = prev_gpu = gpu;
         }
 
         // include open tailing range
-        isolate_numa.push_back(DeviceRange{ range_start, prev_gpu - range_start + 1 });
+        isolate_numa.push_back(SlicePlans::Slice{ DeviceRange{ range_start, prev_gpu - range_start + 1 }, {} });
     }
 
     if (isolate_numa.empty()) [[unlikely]] {
@@ -147,7 +147,7 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
 
             if (!contiguous || range_count + g.count > max_devices_per_slice) {
                 // commit the slice
-                heuristic.push_back({ range_start, range_count });
+                heuristic.push_back(SlicePlans::Slice{ DeviceRange{ range_start, range_count }, {} });
                 range_start = g.start;
                 range_count = g.count;
             } else {
@@ -156,7 +156,7 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
             }
         }
         // end of devices for this NUMA node, close the slice
-        heuristic.push_back({ range_start, range_count });
+        heuristic.push_back(SlicePlans::Slice{ DeviceRange{ range_start, range_count }, {} });
     }
 
     if (heuristic.empty()) [[unlikely]] {

--- a/framework/device/gpu/build_topology.cpp
+++ b/framework/device/gpu/build_topology.cpp
@@ -163,3 +163,11 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
         heuristic = plan;
     }
 }
+
+void slice_plan_init_for_threads(SlicePlans::SlicesArray& plans)
+{
+    for (auto &plan : plans) {
+        for (auto &slice : plan)
+            slice.thread_range = { slice.device_range.starting_device, slice.device_range.device_count }; // 1:1 for now...
+    }
+}

--- a/framework/device/gpu/unit-tests/topology_tests.cpp
+++ b/framework/device/gpu/unit-tests/topology_tests.cpp
@@ -214,12 +214,11 @@ TEST(Topology, SlicePlansCreation)
     device_info = gpu_info.data();
     topo_global = build_topology();
 
-    auto expect_plan = [](const auto& actual, const std::vector<std::pair<int, int>>& expected) {
+    auto expect_plan = [](const auto& actual, const std::vector<DeviceRange>& expected) {
         ASSERT_EQ(actual.size(), expected.size());
-        auto expected_it = expected.begin();
-        for (size_t i = 0; i < actual.size(); ++i, ++expected_it) {
-            EXPECT_EQ(actual[i].starting_device, expected_it->first);
-            EXPECT_EQ(actual[i].device_count, expected_it->second);
+        for (size_t i = 0; i < actual.size(); ++i) {
+            EXPECT_EQ(actual[i].device_range.starting_device, expected[i].starting_device);
+            EXPECT_EQ(actual[i].device_range.device_count, expected[i].device_count);
         }
     };
 

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2280,22 +2280,22 @@ void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, 
     }
 
 #if SANDSTONE_DEVICE_CPU
-    auto make_plan_string = [](const std::vector<DeviceRange> &plan) {
+    auto make_plan_string = [](const SlicePlans::Slices &plan) {
         std::string result;
-        for (DeviceRange r : plan) {
+        for (SlicePlans::Slice s : plan) {
             if (result.size())
                 result += ", ";
             result += "{ starting_cpu: ";
-            result += std::to_string(r.starting_device);
+            result += std::to_string(s.device_range.starting_device);
             result += ", count: ";
-            result += std::to_string(r.device_count);
+            result += std::to_string(s.device_range.device_count);
             result += " }";
         }
         return result;
     };
-    const std::vector<DeviceRange> &fullsocket = sApp->slice_plans.plans[SlicePlans::IsolateSockets];
-    const std::vector<DeviceRange> &isolatenuma = sApp->slice_plans.plans[SlicePlans::IsolateNuma];
-    const std::vector<DeviceRange> &heuristic = sApp->slice_plans.plans[SlicePlans::Heuristic];
+    const SlicePlans::Slices &fullsocket = sApp->slice_plans.plans[SlicePlans::IsolateSockets];
+    const SlicePlans::Slices &isolatenuma = sApp->slice_plans.plans[SlicePlans::IsolateNuma];
+    const SlicePlans::Slices &heuristic = sApp->slice_plans.plans[SlicePlans::Heuristic];
     logging_printf(LOG_LEVEL_VERBOSE(1), "test-plans:\n");
     logging_printf(LOG_LEVEL_VERBOSE(1), "  fullsocket: [ %s ]\n",
                    make_plan_string(fullsocket).c_str());

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2289,6 +2289,8 @@ void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, 
             result += std::to_string(s.device_range.starting_device);
             result += ", count: ";
             result += std::to_string(s.device_range.device_count);
+            result += ", threads: ";
+            result += std::to_string(s.thread_range.thread_count);
             result += " }";
         }
         return result;

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1662,7 +1662,7 @@ inline AbstractLogger::AbstractLogger(const struct test *test, std::span<const C
 
     case TestResult::TimedOut:
         // find stuck threads and insert error message
-        for_each_test_thread([](PerThreadData::Test *data, int i) {
+        for_each_test_thread([](PerThreadData::Test *data, int thread, int device=-1) {
             ThreadState thr_state = data->thread_state.load(std::memory_order_relaxed);
             if (thr_state != thread_running)
                 return;
@@ -1670,10 +1670,10 @@ inline AbstractLogger::AbstractLogger(const struct test *test, std::span<const C
             // if the thread hasn't failed prior to getting stuck an, mark
             // the failure as the original processor where it was run.
             bool had_failed = data->has_failed();
-            log_message(i, SANDSTONE_LOG_ERROR "Thread is stuck");
+            log_message(thread, SANDSTONE_LOG_ERROR "Thread is stuck");
             if (!had_failed)
-                data->failing_cpu = LogicalProcessor(device_info[i].cpu_number);
-        });
+                data->failing_cpu = LogicalProcessor(device_info[device].cpu_number);
+        }, slices.size());
         return;
 
     case TestResult::CoreDumped:
@@ -1687,12 +1687,12 @@ inline AbstractLogger::AbstractLogger(const struct test *test, std::span<const C
 
     // scan the threads for their state
     int sc = 0;
-    auto message_checker = [&](PerThreadData::Common *data, int i) {
+    auto message_checker = [&](PerThreadData::Common *data, int thread) {
         ThreadState thr_state = data->thread_state.load(std::memory_order_relaxed);
         if (data->has_failed()) {
             earliest_fail = std::min(earliest_fail, data->fail_time);
             testResult = TestResult::Failed;
-        } else if (i >= 0) {
+        } else if (thread >= 0) {
             // thread passed test. Don't count main thread results.
             ++pc;
             if (thr_state == thread_skipped) ++sc;
@@ -1831,16 +1831,16 @@ void YamlLogger::maybe_print_messages_header(int fd)
     }
 }
 
-void YamlLogger::print_thread_header(int fd, PerThreadData::Common *data, int device, LogLevelVerbosity verbosity)
+void YamlLogger::print_thread_header(int fd, PerThreadData::Common *data, int thread, int device, LogLevelVerbosity verbosity)
 {
     maybe_print_messages_header(fd);
-    if (device < 0) {
-        device = ~device;
-        if (device == 0)
+    if (thread < 0) {
+        int slice = ~thread;
+        if (slice == 0)
             writeln(fd, indent_spaces(), "  - thread: main");
         else
-            writeln(fd, indent_spaces(), "  - thread: main ", std::to_string(device));
-        maybe_print_slice_resource_usage(fd, device);
+            writeln(fd, indent_spaces(), "  - thread: main ", std::to_string(slice));
+        maybe_print_slice_resource_usage(fd, slice);
         return;
     }
 
@@ -1861,7 +1861,8 @@ void YamlLogger::print_thread_header(int fd, PerThreadData::Common *data, int de
 #  endif
     };
 #endif
-    dprintf(fd, "%s  - thread: %d\n", indent_spaces().data(), device);
+    assert(device >= 0); // All worker threads should have a valid device index
+    dprintf(fd, "%s  - thread: %d\n", indent_spaces().data(), thread);
 
     auto thr = static_cast<PerThreadData::Test *>(data);
     bool has_failed = thr->has_failed();
@@ -2191,7 +2192,7 @@ void YamlLogger::print_fixed()
 void YamlLogger::print_thread_messages()
 {
     // print the thread messages
-    auto doprint = [this](PerThreadData::Common *data, int s_tid) {
+    auto doprint = [this](PerThreadData::Common *data, int s_tid, int device=-1) {
         LogMessagesFile r = maybe_mmap_log(data);
         bool want_print = data->has_failed() || sApp->shmem->cfg.verbosity >= 3;
         ssize_t min_size = 0;
@@ -2208,7 +2209,7 @@ void YamlLogger::print_thread_messages()
             return;             /* nothing to be printed, on any level */
         }
 
-        print_thread_header(file_log_fd, data, s_tid, LogLevelVerbosity::Max);
+        print_thread_header(file_log_fd, data, s_tid, device, LogLevelVerbosity::Max);
         LogLevelVerbosity lowest_level =
                 print_one_thread_messages(file_log_fd, r, LogLevelVerbosity::Max);
 
@@ -2216,7 +2217,7 @@ void YamlLogger::print_thread_messages()
             // print to stdout
             bool has_messages = lowest_level <= sApp->shmem->cfg.verbosity;
             if (want_print || has_messages)
-                print_thread_header(real_stdout_fd, data, s_tid, sApp->shmem->cfg.verbosity);
+                print_thread_header(real_stdout_fd, data, s_tid, device, sApp->shmem->cfg.verbosity);
             if (has_messages)
                 print_one_thread_messages(real_stdout_fd, r, sApp->shmem->cfg.verbosity);
         }
@@ -2224,7 +2225,7 @@ void YamlLogger::print_thread_messages()
         munmap_and_truncate_log(data, r);
     };
     for_each_main_thread(doprint, slices.size());
-    for_each_test_thread(doprint);
+    for_each_test_thread(doprint, slices.size());
 }
 
 void YamlLogger::print()

--- a/framework/logging.h
+++ b/framework/logging.h
@@ -132,7 +132,7 @@ public:
     static void print_fixed_for_device();
 
 #ifdef SANDSTONE_DEVICE_CPU
-    static std::string thread_id_header_for_cpu(LogicalProcessor lp, int thread, LogLevelVerbosity verbosity);
+    static std::string thread_id_header_for_cpu(LogicalProcessor lp, int device, LogLevelVerbosity verbosity);
 #endif
 
     const struct test *test;
@@ -182,7 +182,7 @@ private:
     inline void maybe_print_messages_header(int fd);
     void print_fixed();
     void print_thread_messages();
-    void print_thread_header(int fd, PerThreadData::Common *data, int device, LogLevelVerbosity verbosity);
+    void print_thread_header(int fd, PerThreadData::Common *data, int thread, int device, LogLevelVerbosity verbosity);
     inline bool want_slice_resource_usage(int slice);
     void maybe_print_slice_resource_usage(int fd, int slice);
     inline int print_test_knobs(int fd, const LogMessagesFile &msgs);

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -958,6 +958,12 @@ static void slice_plan_init(int max_cores_per_slice)
     slice_plan_init_for_device(sApp->slice_plans.plans, max_cores_per_slice);
 }
 
+static void thread_plan_init()
+{
+    sApp->thread_count = device_count();
+    slice_plan_init_for_threads(sApp->slice_plans.plans);
+}
+
 int main(int argc, char **argv)
 {
     // initialize the main application
@@ -1052,8 +1058,9 @@ int main(int argc, char **argv)
 
     if (unsigned(opts.device_count) < unsigned(sApp->device_count))
         restrict_topology({ 0, opts.device_count });
-    sApp->thread_count = sApp->device_count; // TODO: Temporary 1:1
+
     slice_plan_init(opts.max_cores_per_slice);
+    thread_plan_init();
     commit_shmem();
 
     if (std::to_underlying(sApp->shmem->cfg.reschedule_mode) > std::to_underlying(RescheduleMode::none) && device_count() < 2) {

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -353,7 +353,7 @@ static void init_shmem()
 static void commit_shmem()
 {
     // the most detailed plan is the last
-    const std::vector<DeviceRange> &plan = sApp->slice_plans.plans.end()[-1];
+    const SlicePlans::Slices &plan = sApp->slice_plans.plans.end()[-1];
     size_t main_thread_count = plan.size();
     sApp->shmem->main_thread_count = main_thread_count;
     sApp->shmem->total_thread_count = thread_count();
@@ -944,13 +944,13 @@ skip_wait:
 
 static void slice_plan_init(int max_cores_per_slice)
 {
-    for (std::vector<DeviceRange> &plan : sApp->slice_plans.plans) {
+    for (SlicePlans::Slices &plan : sApp->slice_plans.plans) {
         plan.clear();
     }
 
     if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::no_fork || max_cores_per_slice < 0) {
         // set to full system
-        std::vector plan = { DeviceRange{ 0, thread_count() } };
+        SlicePlans::Slices plan = { SlicePlans::Slice{ DeviceRange{ 0, device_count() }, {} } };
         sApp->slice_plans.plans.fill(plan);
         return;
     }

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -459,7 +459,7 @@ inline void SandstoneApplication::select_main_thread(int slice)
 {
     assert(current_fork_mode() != ForkMode::no_fork || slice == 0);
     main_thread_data_ptr += slice;
-    test_thread_data_ptr += main_thread_data_ptr->device_range.starting_device;
+    test_thread_data_ptr += main_thread_data_ptr->thread_range.starting_thread;
 }
 
 template <typename Lambda> static void for_each_main_thread(Lambda &&l, int max_slices = INT_MAX)
@@ -469,10 +469,22 @@ template <typename Lambda> static void for_each_main_thread(Lambda &&l, int max_
         l(sApp->main_thread_data(i), -1 - i);
 }
 
-template <typename Lambda> static void for_each_test_thread(Lambda &&l)
+template <typename Lambda> static void for_each_test_thread(Lambda &&l, int max_slices = INT_MAX)
 {
-    for (int i = 0; i < thread_count(); i++)
-        l(sApp->test_thread_data(i), i);
+    if constexpr (requires { l(sApp->test_thread_data(0), 0, 0); }) {
+        int slices = sApp->is_main_process() ? std::min(sApp->shmem->main_thread_count, max_slices) : 1;
+        for (int s = 0; s < slices; s++) {
+            auto main_thread = sApp->main_thread_data(s);
+            for (int i = 0; i < main_thread->thread_range.thread_count; i++) {
+                int thread = main_thread->thread_range.starting_thread + i;
+                int device = main_thread->device_range.starting_device + i;
+                l(sApp->test_thread_data(thread), thread, device);
+            }
+        }
+    } else {
+        for (int i = 0; i < thread_count(); i++)
+            l(sApp->test_thread_data(i), i);
+    }
 }
 
 struct Pipe

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1220,7 +1220,7 @@ TestResult child_run(/*nonconst*/ struct test *test, int child_number)
         sApp->select_main_thread(child_number);
         pin_to_logical_processors(sApp->main_thread_data()->device_range, "control");
         restrict_topology(sApp->main_thread_data()->device_range);
-        sApp->thread_count = sApp->device_count; // TODO: Update when thread_count and device_count are decoupled
+        sApp->thread_count = sApp->main_thread_data()->thread_range.thread_count;
         signals_init_child();
         debug_init_child();
     }
@@ -1420,12 +1420,15 @@ static int slices_for_test(const struct test *test)
     }();
     if (type == SlicePlans::FullSystem) {
         sApp->main_thread_data()->device_range = { 0, sApp->device_count };
+        sApp->main_thread_data()->thread_range = { 0, sApp->thread_count };
         return 1;
     }
 
     const SlicePlans::Slices &plan = sApp->slice_plans.plans[type];
-    for (size_t i = 0; i < plan.size(); ++i)
+    for (size_t i = 0; i < plan.size(); ++i) {
         sApp->main_thread_data(i)->device_range = plan[i].device_range;
+        sApp->main_thread_data(i)->thread_range = plan[i].thread_range;
+    }
 
     return plan.size();
 }
@@ -1472,6 +1475,10 @@ static void run_one_test_children(ChildrenList &children, const struct test *tes
 
 static void run_one_test_init_in_parent(ChildrenList &children, const struct test *test)
 {
+    // Set up device/thread ranges so logging can iterate over them
+    sApp->main_thread_data()->device_range = { 0, sApp->device_count };
+    sApp->main_thread_data()->thread_range = { 0, sApp->thread_count };
+
     TestResult res;
     init_per_thread_data();
     int ret = test->test_init(const_cast<struct test *>(test));
@@ -1501,6 +1508,9 @@ static void run_one_test_init_in_parent(ChildrenList &children, const struct tes
 
 static void run_one_test_in_parent(ChildrenList &children, const struct test *test)
 {
+    // Set up device/thread ranges so logging can iterate over them
+    sApp->main_thread_data()->device_range = { 0, sApp->device_count };
+    sApp->main_thread_data()->thread_range = { 0, sApp->thread_count };
     auto state = run_one_test_inner(const_cast<struct test*>(test));
     children.results.emplace_back(ChildExitStatus{ state });
 }

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1423,9 +1423,9 @@ static int slices_for_test(const struct test *test)
         return 1;
     }
 
-    const std::vector<DeviceRange> &plan = sApp->slice_plans.plans[type];
+    const SlicePlans::Slices &plan = sApp->slice_plans.plans[type];
     for (size_t i = 0; i < plan.size(); ++i)
-        sApp->main_thread_data(i)->device_range = plan[i];
+        sApp->main_thread_data(i)->device_range = plan[i].device_range;
 
     return plan.size();
 }

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -283,7 +283,7 @@ void CrashContext::send(int sockfd, siginfo_t *si, void *ucontext)
     CrashContext::Fixed fixed = {
         .crash_address = si->si_addr,
         .rip = si->si_addr,
-        .thread_num = ::thread_num + sApp->main_thread_data()->device_range.starting_device,
+        .thread_num = ::thread_num + sApp->main_thread_data()->thread_range.starting_thread,
         .signum = si->si_signo,
         .signal_code = si->si_code,
     };

--- a/framework/sysdeps/windows/child_debug.cpp
+++ b/framework/sysdeps/windows/child_debug.cpp
@@ -161,7 +161,7 @@ static LONG WINAPI handler(EXCEPTION_POINTERS *info)
 
     // copy the context's fixed portions
     CrashContext *ctx = preallocatedContext;
-    ctx->header.thread_num = thread_num + sApp->main_thread_data()->device_range.starting_device;
+    ctx->header.thread_num = thread_num + sApp->main_thread_data()->thread_range.starting_thread;
     ctx->exceptionRecord = *info->ExceptionRecord;
     ptrdiff_t context_size = sizeof(*ctx);
     if (CopyContext(&ctx->fixedContext, CrashContext::DesiredContextFlags, info->ContextRecord))

--- a/framework/test_data.h
+++ b/framework/test_data.h
@@ -19,6 +19,13 @@ struct DeviceRange
     int device_count;
 };
 
+struct ThreadRange
+{
+    // a contiguous range
+    int starting_thread;
+    int thread_count;
+};
+
 enum class LogicalProcessor : int { None = -1 };
 
 enum ThreadState : int {
@@ -83,6 +90,7 @@ struct Common
 struct alignas(64) Main : Common
 {
     DeviceRange device_range;
+    ThreadRange thread_range;
 };
 
 struct alignas(64) TestCommon : Common

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -217,6 +217,7 @@ struct SlicePlans
 };
 
 void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_per_slice);
+void slice_plan_init_for_threads(SlicePlans::SlicesArray& plans);
 
 template <typename EnabledDevices>
 EnabledDevices detect_devices();

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -207,7 +207,11 @@ struct SlicePlans
         IsolateNuma,
         Heuristic,
     };
-    using Slices = std::vector<DeviceRange>;
+    struct Slice {
+        DeviceRange device_range;
+        ThreadRange thread_range;
+    };
+    using Slices = std::vector<Slice>;
     using SlicesArray = std::array<Slices, 3>;
     SlicesArray plans;
 };


### PR DESCRIPTION
Introduce per-slice ThreadRange alongside the existing DeviceRange so that each slice independently tracks how many threads it runs, separate from how many devices (CPUs) it covers. Currently the ratio is 1:1, but this decoupling prepares for future changes where threads != devices.
