### PR TITLE
FW/Logging: cast `lp` before printing

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -391,7 +391,7 @@ static std::string full_cpu_info(LogicalProcessor lp, LogLevelVerbosity verbosit
                      // see win32/cpu_affinity.cpp
                      unsigned(lp) / 64u, unsigned(lp) % 64u);
 #else
-    line = stdprintf("{ logical: %*d", thread_core_spacing().logical, int(lp));
+    line = stdprintf("{ logical: %*d", thread_core_spacing().logical, std::to_underlying(lp));
 #endif
 
     if (info) {

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -1857,7 +1857,7 @@ void YamlLogger::print_thread_header(int fd, PerThreadData::Common *data, int de
                          // see win32/cpu_affinity.cpp
                          unsigned(lp) / 64u, unsigned(lp) % 64u);
 #  else
-        return stdprintf("{ logical: %d }", lp);
+        return stdprintf("{ logical: %d }", std::to_underlying(lp));
 #  endif
     };
 #endif


### PR DESCRIPTION
Suspends this warning:
```
../framework/logging.cpp:1860:39: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘LogicalProcessor’ [-Wformat=]
 1860 |         return stdprintf("{ logical: %d }", lp);
      |                                      ~^     ~~
      |                                       |     |
      |                                       int   LogicalProcessor
```