### PR TITLE
FW/Random: un-ban `srand` for GPU builds

### DIFF
--- a/framework/random.cpp
+++ b/framework/random.cpp
@@ -685,10 +685,13 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Wunreachable-code-return"
 #endif
 
+// allow for GPU builds - oneAPI can call it internally
+#if !SANDSTONE_DEVICE_GPU
 void srand(unsigned)
 {
     abort();
 }
+#endif
 void srandom(unsigned)
 {
     abort();


### PR DESCRIPTION
Some oneAPI APIs call it internally, causing the app to crash.