### PR TITLE
FW: change alignment of `tests` section

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -150,8 +150,9 @@ typedef enum TestQuality {
 /// used in a test's test_init function to indicate that a test should be skipped.
 #define EXIT_SKIP               -255
 
+/// force the alignment so the compiler won't try to (un)helpfully overalign it.
 #define DECLARE_TEST_INNER2(test_id, test_description) \
-    __attribute__((aligned(alignof(void*)), used, section(SANDSTONE_SECTION_PREFIX "tests"))) \
+    __attribute__((aligned(alignof(struct test)), used, section(SANDSTONE_SECTION_PREFIX "tests"))) \
     struct test _test_ ## test_id = {                   \
         .compiler_minimum_device = device_compiler_features,   \
         .id = SANDSTONE_STRINGIFY(test_id),             \


### PR DESCRIPTION
`DECLARE_TEST_INNER2` places each `struct test` in section `tests` with alignment `alignof(void*)` (8 bytes on x86_64).
    `struct test` contains `device_features_t` fields (`compiler_minimum_device` and `minimum_cpu`), which is 128-bit in CPU/GPU builds.
    In GPU debug builds builds with clang segfaults were observed, when accessing `test->compiler_minimum_device/minimum_cpu`
    due to misalignment of entries inside `tests` section (8-byte aligned instead of 16-byte aligned). Most probably GCC
    does not emmit aligned SIMD load instructions, since we did not observe crashes before.
    This commit changes the alignment to be `alignof(struct test)`. We do not remove it, as we do not want compiler to overalign.