### PR TITLE
FW/Unix: improve stack protection on Unix, and with fewer blocks on Linux

### DIFF
--- a/framework/sandstone_thread.cpp
+++ b/framework/sandstone_thread.cpp
@@ -38,7 +38,7 @@ struct SandstoneTestThreadAttributes
 #ifndef _WIN32
 unsigned char *SandstoneTestThreadAttributes::allocate_stack_block()
 {
-    size_t size = thread_count() * (THREAD_STACK_SIZE + GuardSize);
+    size_t size = thread_count() * (THREAD_STACK_SIZE + GuardSize) + GuardSize;
     void *map = mmap(nullptr, size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     if (map == MAP_FAILED)
         return nullptr;

--- a/framework/sandstone_thread.cpp
+++ b/framework/sandstone_thread.cpp
@@ -10,6 +10,10 @@
 
 #include <sys/mman.h>
 
+#if defined(__linux__) && !defined(MADV_GUARD_INSTALL)
+#  define MADV_GUARD_INSTALL    102     /* since 6.13 */
+#endif
+
 namespace {
 struct SandstoneTestThreadAttributes
 {
@@ -44,6 +48,25 @@ unsigned char *SandstoneTestThreadAttributes::allocate_stack_block()
         return nullptr;
 
     auto ptr = static_cast<unsigned char *>(map);
+
+#ifdef MADV_GUARD_INSTALL
+    // check if MADV_GUARD_INSTALL works
+    if (madvise(map, GuardSize, MADV_GUARD_INSTALL) == 0) {
+        // yes, let's use it
+        // we mark the entire region we've allocated as read-writable, then
+        // mark specific regions as guards
+        IGNORE_RETVAL(mprotect(map, size, PROT_READ | PROT_WRITE));
+
+        for (int i = 0; i < thread_count(); ++i) {
+            ptr += GuardSize + THREAD_STACK_SIZE;
+            // and mark the above this thread's stack (below the next's) as a guard
+            IGNORE_RETVAL(madvise(ptr, GuardSize, MADV_GUARD_INSTALL));
+        }
+
+        return ptr;
+    }
+#endif
+
     for (int i = 0; i < thread_count(); ++i) {
         ptr += GuardSize;
         IGNORE_RETVAL(mprotect(ptr, THREAD_STACK_SIZE, PROT_READ | PROT_WRITE));


### PR DESCRIPTION
This PR uses the Linux 6.13 `madvise` command `MADV_INSTALL_GUARD` where available, which avoids creating new mapping blocks. The timing difference is negligible and I have not done strict performance checks, other than to verify it's still in the same ballpark as the old code.

Additionally, we now allocate one extra guard block. This is to catch a buffer overflow going upwards in the stack. Before this change, there was a non-zero chance that the next VM block above the thread was writable.

Prior to this PR, I see `stacks_block = 0x7fffec000000` in gdb on my laptop (note that is the *top* of the last stack), and it prints the mapping:
```
0x00007fffeaffc000 0x00007fffeaffe000 0x2000             0x0                ---p
0x00007fffeaffe000 0x00007fffeb7fe000 0x800000           0x0                rw-p
0x00007fffeb7fe000 0x00007fffeb800000 0x2000             0x0                ---p
0x00007fffeb800000 0x00007fffec021000 0x821000           0x0                rw-p
0x00007fffec021000 0x00007ffff0000000 0x3fdf000          0x0                ---p
```

Note memory at 0x7fffec000000 is writable for another 0x21000 bytes and it does not belong to us. This area is the `malloc()` arena for the first auxilary thread, which we have created at this point in the execution.

After the first change in the PR, `stacks_block = 0x7fffefffe000` and the mapping is:
```
0x00007fffeeffa000 0x00007fffeeffc000 0x2000             0x0                ---p
0x00007fffeeffc000 0x00007fffef7fc000 0x800000           0x0                rw-p
0x00007fffef7fc000 0x00007fffef7fe000 0x2000             0x0                ---p
0x00007fffef7fe000 0x00007fffefffe000 0x800000           0x0                rw-p
0x00007fffefffe000 0x00007ffff0000000 0x2000             0x0                ---p
0x00007ffff0000000 0x00007ffff0021000 0x21000            0x0                rw-p
0x00007ffff0021000 0x00007ffff4000000 0x3fdf000          0x0                ---p
```
After both, it is:
```
0x00007fffebfee000 0x00007ffff0000000 0x4012000          0x0                rw-p   
0x00007ffff0000000 0x00007ffff0021000 0x21000            0x0                rw-p   
0x00007ffff0021000 0x00007ffff4000000 0x3fdf000          0x0                ---p   
```