### PR TITLE
FW/Logging: move print of "Registers:" into CPU-specific build

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -476,7 +476,10 @@ void AbstractLogger::print_fixed_for_device()
 
 #endif // !SANDSTONE_NO_LOGGING
 
-void dump_device_state(std::string&, int)
+void dump_device_state(std::string& out, int)
 {
-    // CPU crash dumps already include register and XSAVE state.
+    // prepend only if there is anything to print
+    if (out.size()) {
+        out.insert(0, "Registers:\n");
+    }
 }

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -989,7 +989,6 @@ static void print_crash_info(int slice, const char *pidstr, CrashContext &ctx)
         dump_device_state(log, thread);
 
         if (log.size()) {
-            log.insert(0, "Registers:\n");
             log_message_preformatted(thread, LOG_LEVEL_VERBOSE(2), log);
         }
     }


### PR DESCRIPTION
For other device types it was polluting the log.