### PR TITLE
FW: add `memset_random` overload taking `std::span` and `std::array`

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -32,6 +32,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <span>
 using std::atomic_int;
 extern "C" {
 #else
@@ -603,6 +604,21 @@ int num_packages() __attribute__((pure));
 extern int8_t sandstone_verbosity_level() __attribute__((pure));
 
 #ifdef __cplusplus
+}
+
+template <typename T, size_t E> inline void memset_random(std::span<T, E> span)
+{
+    memset_random(span.data(), span.size_bytes());
+}
+
+template <typename T, size_t N> inline void memset_random(std::array<T, N> &arr)
+{
+    memset_random(std::span(arr));
+}
+
+template <typename T> inline void memset_random(std::vector<T> &vec)
+{
+    memset_random(std::span(vec));
 }
 
 extern void log_thread_context(std::string_view msg);

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -775,7 +775,7 @@ static int selftest_datacomparefailrare_run(struct test *, int)
         for (T &value : expected)
             value = frandom_scale(1);
     } else {
-        memset_random(expected.data(), sizeof(expected));
+        memset_random(expected);
     }
 
     std::array actual = expected;


### PR DESCRIPTION
Simplifies writing code like in the changed selftest:
```c++
    std::array<T, Count> expected;
    memset_random(expected);
```