### PR TITLE
Bats: do not search for `Registers:` in GPU builds

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1897,9 +1897,14 @@ selftest_crash_common() {
     # Ensure we can use this option even if gdb isn't found
     # (can't use run_sandstone_yaml here because we empty $PATH)
     if ! $is_windows; then
+        local marker="Registers:"
+        if [[ "$SANDSTONE_DEVICE_TYPE" = "GPU" ]]; then
+            marker="gpu_runtime_state:"
+        fi
+
         run env PATH=/ $SANDSTONE -Y --selftests -e selftest_sigsegv --retest-on-failure=0 --on-crash=context -o -
         [[ $status -eq 1 ]]     # instead of 64 (EX_USAGE)
-        [[ "$output" = *"level: info"*"Registers:"* ]]
+        [[ "$output" = *"level: info"*"$marker"* ]]
         ! [[ "$output" = *Backtrace:* ]]
 
         # And that we get a context even without the option
@@ -1907,7 +1912,7 @@ selftest_crash_common() {
         opts=(${opts/--on-crash=*})     # remove --on-crash
         SANDSTONE="${opts[@]}"          # rejoin with spaces
         run env PATH=/ $SANDSTONE -Y --selftests -e selftest_sigsegv --retest-on-failure=0 -o -
-        [[ "$output" = *"level: info"*"Registers:"* ]]
+        [[ "$output" = *"level: info"*"$marker"* ]]
         ! [[ "$output" = *Backtrace:* ]]
     fi
 }

--- a/bats/sanity-check/helpers.bash
+++ b/bats/sanity-check/helpers.bash
@@ -123,7 +123,7 @@ selftest_crash_context_common() {
         test_yaml_regexp "/tests/0/threads/$threadidx/messages/0/text" ".*Received signal $signum \((Segmentation fault|Access violation)\) code=[0-9]+.* RIP = 0x.*"
     fi
 
-    if [[ `uname -m` = x86_64 ]]; then
+    if [[ `uname -m` = x86_64 ]] && [[ "$SANDSTONE_DEVICE_TYPE" != "GPU" ]]; then
         # OpenDCDiag's built-in register dumper is only implemented for x86-64.
         # Scan messages to find the one containing "Registers:".
         local msgcount=$((yamldump[/tests/0/threads/$threadidx/messages@len]))


### PR DESCRIPTION
This change should've been a part of 087b461