### PR TITLE
FW: do not print anything in `test_formatter`

### DIFF
--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -236,18 +236,14 @@ bool _memcmp_or_fail_check_fmt(const char *fmt, ...)
 
 bool SandstoneMemcmpOrFail::test_formatter(std::function<std::string ()> cb, size_t)
 {
-    log_yaml(SANDSTONE_LOG_DEBUG, ("memcmp_or_fail: " + cb()).c_str());
+    IGNORE_RETVAL(cb());
     return true;
 }
 
 bool SandstoneMemcmpOrFail::test_formatter(std::function<std::string (ptrdiff_t)> cb, size_t max)
 {
     auto doit = [&](ptrdiff_t idx) {
-        auto payload = cb(idx);
-        if (!payload.empty()) {
-            std::string yaml = stdprintf("memcmp_or_fail %td: ", idx) + payload;
-            log_yaml(SANDSTONE_LOG_DEBUG, yaml.c_str());
-        }
+        IGNORE_RETVAL(cb(idx));
     };
     doit(-1);
     doit(max - 1);


### PR DESCRIPTION
From what I understand, its main purpose is to see if the callback behaves correctly for corner case indices (possible OOB faults). For that we do not need to print anything. It was confusing to see quite a lot of messages polluting the log even though there was no error, during tests development.

_I might be missing the point, so this PR is rather a proposal, than a strong statement._