### PR TITLE
Add --thread-ratio flag to control thread-to-device ratio per slice

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -2132,3 +2132,69 @@ selftest_interrupt_common() {
     test_yaml_regexp "/tests/2/test" selftest_test_optional_include_optional
     test_yaml_regexp "/tests/3/test" selftest_test_optional_beta_include_optional
 }
+
+thread_ratio_expected_threads() {
+    local count=$1
+    local ratio=$2
+    local threads
+    if [[ "$ratio" == -* ]]; then
+        threads=$(( count + ratio ))
+    else
+        threads=$(awk "BEGIN { printf \"%d\", int($count * $ratio) }")
+    fi
+    (( threads = threads > 0 ? threads : 1 ))
+    echo "$threads"
+}
+
+check_thread_ratio_plans() {
+    local ratio=$1
+
+    # fullsocket
+    local fs_count=${yamldump[/test-plans/fullsocket/0/count]}
+    local expected=$(thread_ratio_expected_threads "$fs_count" "$ratio")
+    test_yaml_numeric "/test-plans/fullsocket/0/threads" "value == $expected"
+
+    # isolate_numa slices
+    local slice_count=${yamldump[/test-plans/isolate_numa@len]}
+    for ((i = 0; i < slice_count; i++)); do
+        local count=${yamldump[/test-plans/isolate_numa/$i/count]}
+        expected=$(thread_ratio_expected_threads "$count" "$ratio")
+        test_yaml_numeric "/test-plans/isolate_numa/$i/threads" "value == $expected"
+    done
+
+    # heuristic slices
+    slice_count=${yamldump[/test-plans/heuristic@len]}
+    for ((i = 0; i < slice_count; i++)); do
+        local count=${yamldump[/test-plans/heuristic/$i/count]}
+        expected=$(thread_ratio_expected_threads "$count" "$ratio")
+        test_yaml_numeric "/test-plans/heuristic/$i/threads" "value == $expected"
+    done
+
+    # Verify each test thread is pinned to a logical CPU within its slice's range
+    local thread_idx=$slice_count
+    for ((i = 0; i < slice_count; i++)); do
+        local start=${yamldump[/test-plans/heuristic/$i/starting_cpu]}
+        local count=${yamldump[/test-plans/heuristic/$i/count]}
+        local threads=${yamldump[/test-plans/heuristic/$i/threads]}
+
+        for ((t = 0; t < threads; t++)); do
+            test_yaml_numeric "/tests/0/threads/$thread_idx/id/logical" \
+                "value >= $start && value < $(( start + count ))"
+            thread_idx=$(( thread_idx + 1 ))
+        done
+    done
+}
+
+@test "thread_ratio delta YAML pass output" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_pass -vvv --max-cores-per-slice=2 --thread-ratio=-1
+    test_yaml_regexp "/exit" pass
+    check_thread_ratio_plans -1
+}
+
+@test "thread_ratio 70% YAML pass output" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_pass -vvv --max-cores-per-slice=2 --thread-ratio=70%
+    test_yaml_regexp "/exit" pass
+    check_thread_ratio_plans 0.70
+}

--- a/framework/device/cpu/slicing.cpp
+++ b/framework/device/cpu/slicing.cpp
@@ -118,10 +118,26 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
     }
 }
 
-void slice_plan_init_for_threads(SlicePlans::SlicesArray& plans)
+int slice_plan_init_for_threads(SlicePlans::SlicesArray& plans, ThreadRatio ratio_type)
 {
+    int max_thread_count = 1;
+
     for (auto &plan : plans) {
-        for (auto &slice : plan)
-            slice.thread_range = { slice.device_range.starting_device, slice.device_range.device_count }; // 1:1 for now...
+        int thread_offset = 0;
+        for (auto &slice : plan) {
+            int n = slice.device_range.device_count;
+            int thread_count;
+            if (auto *delta = std::get_if<int>(&ratio_type)) {
+                thread_count = n + *delta;
+            } else {
+                thread_count = static_cast<int>(n * std::get<float>(ratio_type));
+            }
+            slice.thread_range = { thread_offset, thread_count > 0 ? thread_count : 1 };
+            thread_offset += thread_count;
+        }
+        if (thread_offset > max_thread_count)
+            max_thread_count = thread_offset;
     }
+
+    return max_thread_count;
 }

--- a/framework/device/gpu/build_topology.cpp
+++ b/framework/device/gpu/build_topology.cpp
@@ -164,10 +164,11 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
     }
 }
 
-void slice_plan_init_for_threads(SlicePlans::SlicesArray& plans)
+int slice_plan_init_for_threads(SlicePlans::SlicesArray& plans, ThreadRatio ratio_type)
 {
     for (auto &plan : plans) {
         for (auto &slice : plan)
             slice.thread_range = { slice.device_range.starting_device, slice.device_range.device_count }; // 1:1 for now...
     }
+    return device_count();
 }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -965,10 +965,9 @@ static void slice_plan_init(int max_cores_per_slice)
     slice_plan_init_for_device(sApp->slice_plans.plans, max_cores_per_slice);
 }
 
-static void thread_plan_init()
+static void thread_plan_init(ThreadRatio thread_ratio)
 {
-    sApp->thread_count = device_count();
-    slice_plan_init_for_threads(sApp->slice_plans.plans);
+    sApp->thread_count = slice_plan_init_for_threads(sApp->slice_plans.plans, thread_ratio);
 }
 
 int main(int argc, char **argv)
@@ -1067,7 +1066,7 @@ int main(int argc, char **argv)
         restrict_topology({ 0, opts.device_count });
 
     slice_plan_init(opts.max_cores_per_slice);
-    thread_plan_init();
+    thread_plan_init(opts.thread_ratio);
     commit_shmem();
 
     if (std::to_underlying(sApp->shmem->cfg.reschedule_mode) > std::to_underlying(RescheduleMode::none) && device_count() < 2) {

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -98,6 +98,7 @@ enum {
 #endif
     version_option,
     weighted_testrun_option,
+    thread_ratio_option,
     alpha_option,
     beta_option,
 
@@ -175,6 +176,7 @@ static struct option long_options[]  = {
     { "test-time", required_argument, nullptr, 't' },   // repeated below
     { "force-test-time", no_argument, nullptr, force_test_time_option },
     { "test-option", required_argument, nullptr, 'O'},
+    { "thread-ratio", required_argument, nullptr, thread_ratio_option },
     { "threads", required_argument, nullptr, 'n' },
     { "time", required_argument, nullptr, 't' },        // repeated above
     { "timeout", required_argument, nullptr, timeout_option },
@@ -499,6 +501,7 @@ struct ProgramOptionsParser {
             case max_logdata_option:
             case max_messages_option:
             case reschedule_option:
+            case thread_ratio_option:
                 opts_map.insert_or_assign(opt, optarg);
                 break;
 
@@ -902,6 +905,16 @@ struct ProgramOptionsParser {
             }
         }
 
+        if (auto value = string_opt_for(thread_ratio_option)) {
+            std::string str_value(value);
+            if (!validate_thread_ratio(str_value, opts.thread_ratio, app_cfg->device_count)) {
+                fprintf(ERR_STREAM, "%s: invalid value for --thread-ratio: %s\n"
+                        "Value must be a fraction (0.0-1.0 or 0%%-100%%) or a signed delta (-N threads).\n",
+                        argv[0], value);
+                return EX_USAGE;
+            }
+        }
+
         if (auto value = string_opt_for(reschedule_option)) {
             std::string_view str_value(value);
             if (str_value == "queue") {
@@ -1168,6 +1181,34 @@ struct ProgramOptionsParser {
         static_assert(!SandstoneConfig::RestrictedCommandLine || SandstoneConfig::HasBuiltinTestList,
                 "Restricted command-line build must have a built-in test list");
         return EXIT_SUCCESS;
+    }
+
+    bool validate_thread_ratio(std::string str_value, ThreadRatio& thread_ratio, const int device_count) {
+        bool isValid = false;
+        char *end = nullptr;
+        if (str_value.starts_with('-')) {
+            // delta mode: -N threads relative to device count
+            // Not using ParseIntArgument so we have a single error usage message
+            long val = strtol(str_value.c_str(), &end, 10);
+            if (*end != '\0') {
+                isValid = false;
+            } else if (val < 0 && val > -(device_count - 1)) {
+                thread_ratio = int(val);
+                isValid = true;
+            }
+        } else {
+            // parse as fraction (e.g. 0.5, 50%, .75)
+            float val = strtof(str_value.c_str(), &end);
+            if (*end == '%') {
+                val /= 100;
+                ++end;
+            }
+            if (*end == '\0' && val > 0 && val <= 1) {
+                thread_ratio = val;
+                isValid = true;
+            }
+        }
+        return isValid;
     }
 };
 } /* anonymous namespace */

--- a/framework/sandstone_opts.hpp
+++ b/framework/sandstone_opts.hpp
@@ -23,6 +23,7 @@ struct ProgramOptions {
     const char* seed = nullptr;
     int max_cores_per_slice = 0;
     int device_count = -1;
+    ThreadRatio thread_ratio = 1.0f;
     bool fatal_errors = false;
     enum class ListMode : uint8_t {
         // action must be list_tests for these

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -13,6 +13,7 @@
 #include <limits>
 #include <span>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <assert.h>
@@ -32,6 +33,8 @@ struct DeviceScheduler
     virtual void reschedule_to_next_device() = 0;
     virtual void finish_reschedule() = 0;
 };
+
+using ThreadRatio = std::variant<int, float>;
 
 void make_rescheduler(RescheduleMode mode);
 
@@ -217,7 +220,7 @@ struct SlicePlans
 };
 
 void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_per_slice);
-void slice_plan_init_for_threads(SlicePlans::SlicesArray& plans);
+int slice_plan_init_for_threads(SlicePlans::SlicesArray& plans, ThreadRatio thread_ratio);
 
 template <typename EnabledDevices>
 EnabledDevices detect_devices();


### PR DESCRIPTION
This PR introduces the `--thread-ratio` command-line option, which allows users to control how many threads are spawned per slice relative to the number of devices in that slice.

This becomes particularly useful when combined with reschedule, as it enables scenarios like running a subset of threads (e.g., 50%) across all available cores. This can leave part of the system temporarily idle during execution, allowing for more flexible scheduling and utilization patterns during tests.