### PR TITLE
FW/logging: Fix thread header entries missing from stdout for TAP and Key-value

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -342,7 +342,7 @@ selftest_pass() {
     test_yaml_regexp "/tests/1/result" skip
 }
 
-@test "selftest_pass has main thread and loop-count at -vvv" {
+@test "selftest_pass YAML has main thread and loop-count at -vvv" {
     # Verify that at least 1 main thread exists with runtime
     # and resource-usage when running at -vvv verbosity.
     # Also confirm loop-count is printed for silent threads.
@@ -356,6 +356,38 @@ selftest_pass() {
     fi
     for ((i = 1; i <= MAX_PROC; ++i)); do
         test_yaml_numeric "/tests/0/threads/$i/loop-count" 'value >= 0'
+    done
+}
+
+@test "selftest_pass TAP has main thread and loop-count at -vvv" {
+    # Verify that at least 1 main thread exists with runtime
+    # and resource-usage when running at -vvv verbosity.
+    # Also confirm loop-count is printed for silent threads.
+    run $SANDSTONE --selftests --retest-on-failure=0 --on-crash=kill -o /dev/null \
+        -e selftest_pass --output-format=tap -vvv
+    [[ "$status" -eq 0 ]]
+
+    tap_output=$(echo "$output" | sed 's/\r$//')
+    [[ "$tap_output" = *"Main thread:"* ]]
+
+    for ((i = 0; i < MAX_PROC; ++i)); do
+        [[ "$tap_output" = *"Thread $i on CPU"* ]]
+        echo "$tap_output" | grep -A1 "Thread $i on CPU" | grep -q "loop-count:"
+    done
+}
+
+@test "selftest_pass Key-value has main thread and loop-count at -vvv" {
+    # Verify that at least 1 main thread exists with runtime
+    # and resource-usage when running at -vvv verbosity.
+    # Also confirm loop-count is printed for silent threads.
+    run $SANDSTONE --selftests --retest-on-failure=0 --on-crash=kill -o /dev/null \
+        -e selftest_pass --output-format=key-value -vvv
+    [[ "$status" -eq 0 ]]
+    key_val_output=$(echo "$output" | sed 's/\r$//')
+
+    for ((i = 0; i < MAX_PROC; ++i)); do
+        [[ "$key_val_output" = *"selftest_pass_messages_thread_${i}_cpu = $i"* ]]
+        [[ "$key_val_output" = *"selftest_pass_thread_${i}_loop_count = "* ]]
     done
 }
 

--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -122,6 +122,7 @@ void KeyValuePairLogger::print_thread_messages()
 {
     auto doprint = [this](PerThreadData::Common *data, int thread, int device=-1) {
         LogMessagesFile r = maybe_mmap_log(data);
+        bool want_print = data->has_failed() || sApp->shmem->cfg.verbosity >= 3;
 
         if (r.empty() && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
             return;           /* nothing to be printed, on any level */
@@ -130,9 +131,13 @@ void KeyValuePairLogger::print_thread_messages()
         LogLevelVerbosity lowest_level =
                 print_one_thread_messages_tdata(file_log_fd, data, r, LogLevelVerbosity::Max);
 
-        if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
-            print_thread_header(real_stdout_fd, thread, device, test->id);
-            print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->cfg.verbosity);
+        if (file_log_fd != real_stdout_fd) {
+            // print to stdout
+            bool has_messages = lowest_level <= sApp->shmem->cfg.verbosity;
+            if (want_print || has_messages)
+                print_thread_header(real_stdout_fd, thread, device, test->id);
+            if (has_messages)
+                print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->cfg.verbosity);
         }
 
         munmap_and_truncate_log(data, r);
@@ -280,7 +285,7 @@ void TapFormatLogger::print_thread_header(int fd, int thread, int device, LogLev
         if (slice == 0)
             writeln(fd, "  Main thread:");
         else
-            dprintf(fd, "  Main thread %d:", slice);
+            dprintf(fd, "  Main thread %d:\n", slice);
         return;
     }
 
@@ -323,6 +328,7 @@ void TapFormatLogger::print_thread_messages()
 {
     auto doprint = [this](PerThreadData::Common *data, int thread, int device=-1) {
         LogMessagesFile r = maybe_mmap_log(data);
+        bool want_print = data->has_failed() || sApp->shmem->cfg.verbosity >= 3;
 
         if (r.empty() && !data->has_failed() && sApp->shmem->cfg.verbosity < 3)
             return;             /* nothing to be printed, on any level */
@@ -331,9 +337,13 @@ void TapFormatLogger::print_thread_messages()
         LogLevelVerbosity lowest_level =
                 print_one_thread_messages_tdata(file_log_fd, data, r, LogLevelVerbosity::Max);
 
-        if (lowest_level <= sApp->shmem->cfg.verbosity && file_log_fd != real_stdout_fd) {
-            print_thread_header(real_stdout_fd, thread, device, sApp->shmem->cfg.verbosity);
-            print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->cfg.verbosity);
+        if (file_log_fd != real_stdout_fd) {
+            // print to stdout
+            bool has_messages = lowest_level <= sApp->shmem->cfg.verbosity;
+            if (want_print || has_messages)
+                print_thread_header(real_stdout_fd, thread, device, sApp->shmem->cfg.verbosity);
+            if (has_messages)
+                print_one_thread_messages_tdata(real_stdout_fd, data, r, sApp->shmem->cfg.verbosity);
         }
 
         munmap_and_truncate_log(data, r);


### PR DESCRIPTION
Thread entries with no messages were not printed to stdout. The `doprint` lambda gated both header and message output behind lowest_level <= verbosity, but threads with no messages have lowest_level = Max (127), so the condition always failed and the stdout output was silently skipped.

Decouple header printing from message printing for the stdout path: print the thread header when want_print or has_messages is true, and print messages only when has_messages is true. This ensures main thread entries (runtime, resource-usage) appear on stdout at -vvv verbosity even when the thread has no messages.

Also add a selftest for each output format that verifies at least one main thread entry exists and that all test threads are present.

A similar issue was previously fixed for the YAML format #1099. In this case, it affected not only the main threads but also test threads, due to changes introduced in another patch  #1100 