### PR TITLE
FW: fix build with no-test-names and a built-in test list

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -153,24 +153,23 @@ typedef enum TestQuality {
 #define EXIT_SKIP               -255
 
 /// force the alignment so the compiler won't try to (un)helpfully overalign it.
-#define DECLARE_TEST_INNER2(test_id, test_short_id, test_description)   \
+#define DECLARE_TEST_INNER2(test_id, test_id_str, test_short_id, test_description)  \
     __attribute__((alias("_test_" SANDSTONE_STRINGIFY(test_id)))) extern struct test _testid_ ## test_short_id; \
     __attribute__((aligned(alignof(struct test)), used, section(SANDSTONE_SECTION_PREFIX "tests"))) \
     struct test _test_ ## test_id = {                                   \
         .compiler_minimum_device = device_compiler_features,            \
         .shortid = 0x ## test_short_id,                                 \
-        .id = SANDSTONE_STRINGIFY(test_id),                             \
+        .id = SANDSTONE_STRINGIFY(test_id_str),                         \
         .description = test_description,
-#define DECLARE_TEST_INNER(test_id, test_short_id, test_description)    \
-    DECLARE_TEST_INNER2(test_id, test_short_id, test_description)
-
 #if SANDSTONE_NO_TEST_NAMES
-#  define DECLARE_TEST(test_id, test_description)                       \
-    DECLARE_TEST_INNER(TEST_ID_ ## test_id, TEST_ID_ ## test_id, NULL)
+#  define DECLARE_TEST_INNER(test_id, test_short_id, test_description)  \
+    DECLARE_TEST_INNER2(test_id, test_short_id, test_short_id, NULL)
 #else
-#  define DECLARE_TEST(test_id, test_description)                       \
-    DECLARE_TEST_INNER(test_id, TEST_ID_ ## test_id, test_description)
+#  define DECLARE_TEST_INNER(test_id, test_short_id, test_description)  \
+    DECLARE_TEST_INNER2(test_id, test_id, test_short_id, test_description)
 #endif
+#define DECLARE_TEST(test_id, test_description)                         \
+    DECLARE_TEST_INNER(test_id, TEST_ID_ ## test_id, test_description)
 
 #define DECLARE_TEST_GROUPS(...)                                      \
     __extension__ (const struct test_group* const[]){ __VA_ARGS__, NULL }

--- a/framework/unit-tests/tests_dummy.cpp
+++ b/framework/unit-tests/tests_dummy.cpp
@@ -8,6 +8,6 @@
 // This defines a dummy test just so the __start_tests and __stop_tests
 // symbols get defined by the linker.
 
-DECLARE_TEST_INNER2(dummy, 1, nullptr)
+DECLARE_TEST_INNER(dummy, 1, nullptr)
 END_DECLARE_TEST
 


### PR DESCRIPTION
The sandstone_test_lists.cpp file refers to the test variables by name, which we broke in commit aba09c034226c0931f82486cb6833b63bd9746d3.

```
ld: opendcdiag/framework/libframework.a.p/meson-generated_.._sandstone_test_lists.cpp.o:(.data.rel.ro+0x2e70): undefined reference to `_test_eigen_svd_double'
ld: opendcdiag/framework/libframework.a.p/meson-generated_.._sandstone_test_lists.cpp.o:(.data.rel.ro+0x2c58): undefined reference to `_test_eigen_gemm_cdouble_dynamic_square'
ld: opendcdiag/framework/libframework.a.p/meson-generated_.._sandstone_test_lists.cpp.o:(.data.rel.ro+0x2c60): undefined reference to `_test_eigen_svd_cdouble'
ld: opendcdiag/framework/libframework.a.p/meson-generated_.._sandstone_test_lists.cpp.o:(.data.rel.ro+0x2c68): undefined reference to `_test_eigen_svd'
ld: opendcdiag/framework/libframework.a.p/meson-generated_.._sandstone_test_lists.cpp.o:(.data.rel.ro+0x2c70): undefined reference to `_test_zlib'
```

The variable names can be left behind, because they disappear when the executable is stripped of debugging information.

This isn't tested in the GitHub Actions CI, so it wasn't caught.