### PR TITLE
FW: add `--ulog` option to log test state to mapped memory

### DIFF
--- a/bats/sanity-check/28-ulog.bats
+++ b/bats/sanity-check/28-ulog.bats
@@ -1,0 +1,215 @@
+#!/usr/bin/bats
+# -*- mode: sh -*-
+# Copyright 2026 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+load ../testenv
+load helpers
+
+function setup_file() {
+    setup_sandstone
+
+    # Probe whether --ulog is supported: if recognized, a bad arg produces
+    # "FILE=OFFSET"; if not recognized, it produces an unknown-option error.
+    run $SANDSTONE --ulog noequal --ulog noequal --ulog noequal
+    if [[ "$output" != *"FILE=OFFSET"* ]]; then
+        export ulog_skip_reason="--ulog not supported in this build"
+        return
+    fi
+
+    # MAP_SHARED_VALIDATE|MAP_SYNC requires a DAX-capable filesystem; tmpfs also
+    # works. Check by inspecting the filesystem type of the temp directory.
+    local probe_file fstype
+    probe_file=$(mktempfile ulog-probe-XXXXXX)
+    fstype=$(stat -f -c %T "$probe_file" 2>/dev/null)
+    rm -f "$probe_file"
+    if [[ -n "$fstype" && "$fstype" != "tmpfs" ]]; then
+        export ulog_skip_reason="--ulog mmap requires a DAX-capable or tmpfs filesystem (got: $fstype)"
+    fi
+}
+
+function ulog_skip_if_unsupported() {
+    if [[ -n "${ulog_skip_reason-}" ]]; then
+        skip "$ulog_skip_reason"
+    fi
+}
+
+# Create a zero-filled (sparse) temp file of the given size in bytes (default: 4096).
+function ulog_make_file() {
+    ulog_skip_if_unsupported
+    local size=${1:-4096}
+    local f
+    f=$(mktempfile ulog-XXXXXX)
+    truncate -s "$size" "$f"
+    echo "$f"
+}
+
+# Verify the three ulog slots at the given file+offset pairs.
+# Usage: ulog_check_slots test_name file0 offset0 file1 offset1 file2 offset2
+# Requires yamldump to be pre-declared and populated by sandstone_selftest.
+function ulog_check_slots() {
+    local test_name=$1
+    local v0 v1 v2
+    v0=$(od -A n -t x4 -N 4 -j "$3" "$2"); v0="${v0// /}"
+    v1=$(od -A n -t u4 -N 4 -j "$5" "$4")
+    v2=$(od -A n -t u4 -N 4 -j "$7" "$6")
+
+    # slot 0: first 6 hex digits must match the test's shortid from --list-test-ids;
+    # last 2 hex digits must be "00" (not a retest)
+    local shortid
+    shortid=$($SANDSTONE --selftests --list-test-ids | awk -v t="$test_name" '$1==t{print $2}')
+    [[ "${v0:0:6}" == "$shortid" ]]
+    [[ "${v0:6:2}" == "00" ]]
+
+    # slot 1: must equal the seed value from the YAML
+    local seed_value
+    extract_from_yaml "/tests/0/state/seed"
+    seed_value="${value#*:}"
+    (( v1 == seed_value ))
+
+    # slot 2: reserved, must be zero
+    (( v2 == 0 ))
+}
+
+@test "--ulog wrong argument count (1)" {
+    ulog_skip_if_unsupported
+    run $SANDSTONE --ulog file=0
+    [[ $status -eq 64 ]]
+    [[ "$output" == *"--ulog requires exactly 3"* ]]
+}
+
+@test "--ulog wrong argument count (2)" {
+    ulog_skip_if_unsupported
+    run $SANDSTONE --ulog file=0 --ulog file=1
+    [[ $status -eq 64 ]]
+    [[ "$output" == *"--ulog requires exactly 3"* ]]
+}
+
+@test "--ulog missing equal sign" {
+    ulog_skip_if_unsupported
+    run $SANDSTONE --ulog noequal --ulog noequal --ulog noequal
+    [[ $status -eq 64 ]]
+    [[ "$output" == *"FILE=OFFSET"* ]]
+}
+
+@test "--ulog invalid offset" {
+    ulog_skip_if_unsupported
+    run $SANDSTONE --ulog file=abc --ulog file=abc --ulog file=abc
+    [[ $status -eq 64 ]]
+    [[ "$output" == *"invalid offset"* ]]
+}
+
+@test "--ulog nonexistent file" {
+    ulog_skip_if_unsupported
+    local f=/nonexistent/path/to/file
+    run $SANDSTONE --ulog $f=0 --ulog $f=0 --ulog $f=0
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"cannot open"* ]]
+}
+
+@test "--ulog writes test info (three files)" {
+    declare -A yamldump
+    ulog_skip_if_unsupported
+
+    local f
+    f1=$(ulog_make_file)
+    f2=$(ulog_make_file)
+    f3=$(ulog_make_file)
+
+    # We need the LCG random number generator because its state fits into
+    # the 32 bits we have reserved to it.
+    sandstone_selftest -s LCG -e selftest_pass \
+        --ulog "$f1=0" --ulog "$f2=0" --ulog "$f3=0"
+
+    ulog_check_slots selftest_pass "$f1" 0 "$f2" 0 "$f3" 0
+}
+
+function ulog_same_file_common() {
+    declare -A yamldump
+    ulog_skip_if_unsupported
+
+    local o1=$1
+    local o2=$2
+    local o3=$3
+    local f
+    f=$(ulog_make_file $((o3 + 4096)))
+
+    # We need the LCG random number generator because its state fits into
+    # the 32 bits we have reserved to it.
+    sandstone_selftest -s LCG -e selftest_pass \
+        --ulog "$f=$o1" --ulog "$f=$o2" --ulog "$f=$o3"
+
+    ulog_check_slots selftest_pass "$f" $o1 "$f" $o2 "$f" $o3
+}
+
+@test "--ulog same file same page" {
+    ulog_same_file_common 0 4 8
+}
+
+@test "--ulog same file different pages" {
+    ulog_same_file_common 0 4096 8192
+}
+
+@test "--ulog same file different pages, non-zero offsets" {
+    ulog_same_file_common 256 4100 10240
+}
+
+@test "--ulog same file far pages" {
+    # On Windows, our mmap() allocates to 64kB granularity
+    ulog_same_file_common 0 65536 131072
+}
+
+@test "--ulog same file different large pages" {
+    ulog_same_file_common 0 $((4*1024*1024)) $((8*1024*1024))
+}
+
+@test "--ulog verify short ID" {
+    declare -A yamldump
+    ulog_skip_if_unsupported
+    ulimit -Sc 0 || :   # disable core dumps, we don't need them here
+
+    local f
+    f=$(ulog_make_file)
+
+    # Build a map of test name → shortid
+    local -A testids
+    while read -r name hexid; do
+        testids[$name]=$hexid
+    done < <($SANDSTONE --selftests --list-test-ids | sed 's/\r$//')
+
+    # Run a selection of simple, fast tests
+    local tests=(
+        selftest_pass selftest_timedpass selftest_logs selftest_skip
+        selftest_failinit selftest_fail selftest_logerror
+        selftest_abortinit selftest_abort selftest_sigsegv selftest_oserror
+        selftest_freeze
+    )
+    local name
+    for name in $tests; do
+        sandstone_selftest -e "$name" --quick --retest-on-failure=0 --timeout=2s \
+            --on-hang=kill --on-crash=kill --ulog "$f=0" --ulog "$f=4" --ulog "$f=8"
+        local v0
+        v0=$(od -A n -t x4 -N 4 -j 0 "$f"); v0="${v0// /}"
+        [[ "${v0:0:6}" == "${testids[$name]}" ]]
+        [[ "${v0:6:2}" == "00" ]]
+    done
+}
+
+@test "--ulog retest count" {
+    declare -A yamldump
+    ulog_skip_if_unsupported
+
+    local f
+    f=$(ulog_make_file)
+
+    sandstone_selftest -e selftest_failinit --retest-on-failure=1 \
+        --ulog "$f=0" --ulog "$f=4" --ulog "$f=8"
+    [[ $status -eq 1 ]]
+
+    local v0 shortid
+    v0=$(od -A n -t x4 -N 4 -j 0 "$f"); v0="${v0// /}"
+    shortid=$($SANDSTONE --selftests --list-test-ids | awk -v t=selftest_failinit '$1==t{print $2}')
+
+    # The last written value reflects the retest: shortid in upper bits, count=1 in low byte
+    [[ "${v0:0:6}" == "$shortid" ]]
+    [[ "${v0:6:2}" == "01" ]]
+}

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -175,6 +175,11 @@ else
     )
 endif
 
+framework_config.set10(
+    'SANDSTONE_ULOG',
+    not get_option('framework_options').contains('no-ulog'),
+)
+
 framework_config.set10('SANDSTONE_SSL_BUILD', get_option('ssl_link_type') != 'none')
 framework_config.set10(
     'SANDSTONE_SSL_LINKED',
@@ -196,6 +201,7 @@ framework_files += files(
     'sandstone_test_groups.cpp',
     'sandstone_tests.cpp',
     'sandstone_thread.cpp',
+    'sandstone_ulog.cpp',
     'sandstone_utils.cpp',
     'static_vectors.c',
     'test_knobs.cpp',

--- a/framework/random.cpp
+++ b/framework/random.cpp
@@ -554,6 +554,11 @@ void random_advance_seed()
     rand();
 }
 
+uint32_t random_seed_low32()
+{
+    return rng_for_thread(-1)->u32[0];
+}
+
 void random_init_thread(int thread_num)
 {
     // nothing should be modifying the global engine now

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1086,6 +1086,7 @@ int main(int argc, char **argv)
     signals_init_global();
     resource_init_global();
     random_init_global(opts.seed);
+    ulog_init(opts.ulog_args);
     debug_init_global(opts.on_hang_arg, opts.on_crash_arg);
     background_scan_init();
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, nullptr);

--- a/framework/sandstone_config.h.in
+++ b/framework/sandstone_config.h.in
@@ -39,6 +39,7 @@
 #mesondefine SANDSTONE_DEVICE_GPU
 
 #mesondefine SANDSTONE_FREQUENCY_MANAGER
+#mesondefine SANDSTONE_ULOG
 
 #define SANDSTONE_CHILD_DEBUG (SANDSTONE_CHILD_DEBUG_CRASHES || SANDSTONE_CHILD_DEBUG_HANGS)
 
@@ -55,6 +56,7 @@ static constexpr bool ChildDebug = SANDSTONE_CHILD_DEBUG;
 static constexpr bool ChildDebugCrashes = SANDSTONE_CHILD_DEBUG_CRASHES;
 static constexpr bool ChildDebugHangs = SANDSTONE_CHILD_DEBUG_HANGS;
 static constexpr bool HasBuiltinTestList = SANDSTONE_BUILTIN_TEST_LIST;
+static constexpr bool HasUlogSupport = SANDSTONE_ULOG;
 static constexpr bool NoLogging = SANDSTONE_NO_LOGGING;
 static constexpr bool RestrictedCommandLine = SANDSTONE_RESTRICTED_CMDLINE;
 } // namespace SandstoneConfig

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -92,6 +92,7 @@ enum {
     total_retest_on_failure,
     triage_option,
     ud_on_failure_option,
+    ulog_option,
     use_builtin_test_list_option,
 #if SANDSTONE_FREQUENCY_MANAGER
     vary_frequency,
@@ -184,6 +185,9 @@ static struct option long_options[]  = {
     { "total-retest-on-failure", required_argument, nullptr, total_retest_on_failure },
     { "total-time", required_argument, nullptr, 'T' },
     { "ud-on-failure", no_argument, nullptr, ud_on_failure_option },
+#if SANDSTONE_ULOG
+    { "ulog", required_argument, nullptr, ulog_option },
+#endif
     { "use-builtin-test-list", optional_argument, nullptr, use_builtin_test_list_option },
 #if SANDSTONE_FREQUENCY_MANAGER
     { "vary-frequency", no_argument, nullptr, vary_frequency},
@@ -451,6 +455,9 @@ struct ProgramOptionsParser {
             case disable_option:
             case 'e':
             case 'O':
+#if SANDSTONE_ULOG
+            case ulog_option:
+#endif
                 add_to_map_as_vec(opt, optarg);
                 break;
 
@@ -938,6 +945,10 @@ struct ProgramOptionsParser {
             }
         }
 
+#if SANDSTONE_ULOG
+        if (auto it = opts_map.find(ulog_option); it != opts_map.end())
+            opts.ulog_args = std::get<std::vector<const char*>>(it->second);
+#endif
         if (auto it = opts_map.find(_format_option); it != opts_map.end()) {
             switch (std::get<int>(it->second)) {
             case 'Y': {

--- a/framework/sandstone_opts.hpp
+++ b/framework/sandstone_opts.hpp
@@ -34,6 +34,7 @@ struct ProgramOptions {
     const char* on_hang_arg = nullptr;
     const char* on_crash_arg = nullptr;
     std::vector<const char*> deviceset;
+    std::vector<const char *> ulog_args;
 
     std::string list_group_name; // for list_group
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -642,6 +642,7 @@ void random_init_global(const char *argument);
 void random_advance_seed();
 std::string random_format_seed();
 void random_init_thread(int thread_num);
+uint32_t random_seed_low32();
 
 /* sandstone.cpp */
 TestResult run_one_test(int *tc, const struct test *test, PerThreadFailures &per_thread_fails);

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -319,6 +319,7 @@ struct SandstoneApplicationConfig {
 struct SandstoneApplication : SandstoneApplicationConfig, public test_the_test_data<SandstoneConfig::Debug>
 {
     static constexpr int MaxRetestCount = sizeof(PerThreadFailures::value_type) * 8;
+    static constexpr int UlogCount = 3;
     using OutputFormat = TestConfig::OutputFormat;
 
     struct SharedMemory;
@@ -345,6 +346,9 @@ struct SandstoneApplication : SandstoneApplicationConfig, public test_the_test_d
     } current_test_failure_callback = {};
 
     std::unique_ptr<RandomEngineWrapper, RandomEngineDeleter> random_engine;
+#if SANDSTONE_ULOG
+    std::array<volatile uint32_t *, UlogCount> ulog_addresses = {};
+#endif
 #if SANDSTONE_FREQUENCY_MANAGER
     std::unique_ptr<FrequencyManager> frequency_manager;
 #endif
@@ -656,6 +660,10 @@ ShortDuration test_timeout(ShortDuration regular_duration);
 TestResult child_run(/*nonconst*/ struct test *test, int child_number);
 struct test_cfg_info;
 TestResult run_one_test(const test_cfg_info &test_cfg, PerThreadFailures &per_thread_failures);
+
+/* sandstone_ulog.cpp */
+void ulog_init(std::span<const char * const> args);
+void ulog_update(const struct test *test);
 
 /* test_knobs.cpp */
 void load_test_knob_args(std::span<const char *const> args);

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -600,6 +600,7 @@ static void init_internal(const struct test *test)
     print_temperature_of_device();
 
     logging_init(test);
+    ulog_update(test);
 }
 
 static void init_per_thread_data()

--- a/framework/sandstone_ulog.cpp
+++ b/framework/sandstone_ulog.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "sandstone_p.h"
+#include "sandstone_utils.h"
+
+#include <span>
+#include <string>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sysexits.h>
+#include <unistd.h>
+
+#ifndef O_SYNC
+#  define O_SYNC        0
+#endif
+#ifndef MAP_SYNC
+#  define MAP_SYNC      0
+#endif
+#ifndef MAP_SHARED_VALIDATE
+#  ifdef __linux__
+#    define MAP_SHARED_VALIDATE   0x03
+#  else
+#    define MAP_SHARED_VALIDATE   MAP_SHARED
+#  endif
+#endif
+
+void ulog_init(std::span<const char * const> args)
+{
+#if SANDSTONE_ULOG
+    if (args.empty())
+        return;
+
+    if (args.size() != sApp->ulog_addresses.size()) {
+        fprintf(stderr, "%s: --ulog requires exactly %zu file=offset arguments, got %zu\n",
+                program_invocation_name, sApp->ulog_addresses.size(), args.size());
+        exit(EX_USAGE);
+    }
+
+    struct OpenFd {
+        std::string path;
+        auto_fd fd;
+    };
+    struct MappedPage {
+        int fd;
+        ptrdiff_t page_offset;
+        void *base;
+    };
+
+    std::vector<OpenFd> open_fds;
+    std::vector<MappedPage> mapped_pages;
+
+    for (size_t i = 0; i < sApp->ulog_addresses.size(); ++i) {
+        const char *arg = args[i];
+        const char *eq = strchr(arg, '=');
+        if (!eq) {
+            fprintf(stderr, "%s: --ulog: argument must be in the form FILE=OFFSET: '%s'\n",
+                    program_invocation_name, arg);
+            exit(EX_USAGE);
+        }
+
+        std::string filename(arg, eq - arg);
+        const char *offset_str = eq + 1;
+
+        char *endptr;
+        errno = 0;
+        ptrdiff_t offset = strtoll(offset_str, &endptr, 0);
+        if (errno || endptr == offset_str || *endptr != '\0' || offset < 0) {
+            fprintf(stderr, "%s: --ulog: invalid offset '%s'\n",
+                    program_invocation_name, offset_str);
+            exit(EX_USAGE);
+        }
+
+        // Open file (or reuse an already-opened fd for the same path)
+        int fd = -1;
+        for (auto &entry : open_fds) {
+            if (entry.path == filename) {
+                fd = entry.fd;
+                break;
+            }
+        }
+        if (fd == -1) {
+            fd = open(filename.c_str(), O_RDWR | O_SYNC);
+            if (fd == -1) {
+                fprintf(stderr, "%s: --ulog: cannot open '%s': %s\n",
+                        program_invocation_name, filename.c_str(), strerror(errno));
+                exit(EX_NOINPUT);
+            }
+            open_fds.push_back({ std::move(filename), auto_fd(fd) });
+        }
+
+        // Map the region containing the offset (or reuse an already-mapped region).
+        // Use 64 KB alignment: POSIX mmap accepts any multiple of the page size, and
+        // Windows MapViewOfFile requires the offset to be aligned to the allocation
+        // granularity (dwAllocationGranularity), which is 64 KB on all known systems.
+        static constexpr ptrdiff_t MmapGranularity = 65536;
+        ptrdiff_t page_offset = offset & ~(MmapGranularity - 1);
+        void *page = nullptr;
+        for (auto &entry : mapped_pages) {
+            if (entry.fd == fd && entry.page_offset == page_offset) {
+                page = entry.base;
+                break;
+            }
+        }
+        if (!page) {
+            page = mmap(nullptr, MmapGranularity, PROT_READ | PROT_WRITE, MAP_SHARED_VALIDATE | MAP_SYNC, fd, off_t(page_offset));
+            if (page == MAP_FAILED) {
+                fprintf(stderr, "%s: --ulog: mmap of '%s' at offset 0x%tx failed: %s\n",
+                        program_invocation_name, open_fds.back().path.c_str(),
+                        page_offset, strerror_for_mmap());
+                exit(EX_OSERR);
+            }
+            mapped_pages.push_back({ fd, page_offset, page });
+        }
+
+        size_t offset_in_page = size_t(offset - page_offset);
+        sApp->ulog_addresses[i] = reinterpret_cast<volatile uint32_t *>(static_cast<char *>(page) + offset_in_page);
+    }
+#endif  // SANDSTONE_ULOG
+}
+
+void ulog_update(const struct test *test)
+{
+#if SANDSTONE_ULOG
+    if constexpr (!SandstoneConfig::HasUlogSupport)
+        return;
+
+    if (!sApp->ulog_addresses[0])
+        return;
+
+    int iteration = sApp->current_iteration_count;
+    *sApp->ulog_addresses[0] = (test->shortid << 8) | (iteration < 0 ? uint8_t(-iteration) : 0);
+    *sApp->ulog_addresses[1] = random_seed_low32();
+    *sApp->ulog_addresses[2] = 0;
+#endif // SANDSTONE_ULOG
+}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,7 +8,7 @@ option('march_base', type : 'string', value : '',
 option('framework_options', type : 'array', value : [],
     description : 'Configuration options for the framework. ' +
     'Possible options: restricted-cmdline, no-child-debug{,-crashes,-hangs}, no-child-backtrace, ' +
-    'no-test-names, allow-stdout-from-tests')
+    'no-test-names, no-ulog, allow-stdout-from-tests')
 option('dependency_link', type : 'combo', choices : ['dynamic', 'static'], value : 'dynamic',
     description : 'Link preference for dependencies: dynamic (default) or static')
 option('docdir', type : 'string', value : 'doc/dcdiag',


### PR DESCRIPTION
The option takes three `FILE=OFFSET` arguments, each pointing to a byte offset in a file. The framework mmap()s the page containing the offset and writes to the three resulting pointers at the start of each test:

-  [0] `test->shortid << 8 | retest_count`
-  [1] low 32 bits of the current random seed
-  [2] 0 (reserved for future expansion)

The feature is enabled by default and can be disabled at build time with the `no-ulog` framework option.

[ChangeLog][Framework] Added `--ulog FILE=OFFSET` option (must be specified exactly three times) to write the current test short ID, random seed, and retest count to user-specified locations in memory-mapped files.

This is very much a prototype for now.