### PR TITLE
FW: allow spaces after `DECLARE_TEST` macro in source files

### DIFF
--- a/scripts/generate-short-ids.pl
+++ b/scripts/generate-short-ids.pl
@@ -29,7 +29,7 @@ sub find_dirs($@) {
     return @result;
 }
 
-my $declare_test_rx = qr/^DECLARE_TEST\((\w+)/;
+my $declare_test_rx = qr/^DECLARE_TEST\s*\((\w+)/;
 my $me = $0;
 unless (scalar @ARGV) {
 print "$0 <output> [secret] <test-dir...>


### PR DESCRIPTION
We had one test in the internal repository that did that:
```c
DECLARE_TEST (testname, "Test description")
```

That's the GNU-style spacing, adopted by Glib and GNOME world too.

We also had one test with a space *before* the macro, not as indentation. That's just sloppy coding, so I'm not allowing it.