### PR TITLE
FW: Fix double-offset in for_each_test_thread

### DIFF
--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -544,7 +544,8 @@ void logging_init_global(void)
         data->log_fd = open_new_log();
     };
     for_each_main_thread(logopener);
-    for_each_test_thread(logopener);
+    for (int i = 0; i < thread_count(); i++)
+        logopener(sApp->test_thread_data(i), i);
 
 #ifdef __GLIBC__
     setenv("LIBC_FATAL_STDERR_", "1", true);
@@ -588,7 +589,8 @@ int logging_close_global(int exitcode)
         close(data->log_fd);
     };
     for_each_main_thread(logcloser);
-    for_each_test_thread(logcloser);
+    for (int i = 0; i < thread_count(); i++)
+        logcloser(sApp->test_thread_data(i), i);
 #endif
 
     /* leak all file descriptors without closing, the application
@@ -1699,7 +1701,7 @@ inline AbstractLogger::AbstractLogger(const struct test *test, std::span<const C
         }
     };
     for_each_main_thread(message_checker, slices.size());
-    for_each_test_thread(message_checker);
+    for_each_test_thread(message_checker, slices.size());
 
     if (testResult == TestResult::Passed && pc == sc)
         testResult = TestResult::Skipped;       // all threads skipped

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -478,7 +478,12 @@ template <typename Lambda> static void for_each_test_thread(Lambda &&l, int max_
             for (int i = 0; i < main_thread->thread_range.thread_count; i++) {
                 int thread = main_thread->thread_range.starting_thread + i;
                 int device = main_thread->device_range.starting_device + i;
-                l(sApp->test_thread_data(thread), thread, device);
+                int data_idx = sApp->is_main_process() ? thread : i;
+                int device_idx = sApp->is_main_process() ? device : i;
+
+                assert(data_idx < sApp->thread_count);
+                assert(device_idx < sApp->device_count);
+                l(sApp->test_thread_data(data_idx), thread, device);
             }
         }
     } else {

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -471,24 +471,24 @@ template <typename Lambda> static void for_each_main_thread(Lambda &&l, int max_
 
 template <typename Lambda> static void for_each_test_thread(Lambda &&l, int max_slices = INT_MAX)
 {
-    if constexpr (requires { l(sApp->test_thread_data(0), 0, 0); }) {
-        int slices = sApp->is_main_process() ? std::min(sApp->shmem->main_thread_count, max_slices) : 1;
-        for (int s = 0; s < slices; s++) {
-            auto main_thread = sApp->main_thread_data(s);
-            for (int i = 0; i < main_thread->thread_range.thread_count; i++) {
-                int thread = main_thread->thread_range.starting_thread + i;
-                int device = main_thread->device_range.starting_device + i;
-                int data_idx = sApp->is_main_process() ? thread : i;
-                int device_idx = sApp->is_main_process() ? device : i;
+    int slices = sApp->is_main_process() ? std::min(sApp->shmem->main_thread_count, max_slices) : 1;
+    for (int s = 0; s < slices; s++) {
+        auto main_thread = sApp->main_thread_data(s);
 
-                assert(data_idx < sApp->thread_count);
+        for (int i = 0; i < main_thread->thread_range.thread_count; i++) {
+            int thread = main_thread->thread_range.starting_thread + i;
+            int data_idx = sApp->is_main_process() ? thread : i;
+            assert(data_idx < sApp->thread_count);
+
+            if constexpr (requires { l(sApp->test_thread_data(0), 0, 0); }) {
+                int device = main_thread->device_range.starting_device + i;
+                int device_idx = sApp->is_main_process() ? device : i;
                 assert(device_idx < sApp->device_count);
-                l(sApp->test_thread_data(data_idx), thread, device);
-            }
+
+                l(sApp->test_thread_data(data_idx), thread, device_idx);
+            } else
+                l(sApp->test_thread_data(data_idx), thread);
         }
-    } else {
-        for (int i = 0; i < thread_count(); i++)
-            l(sApp->test_thread_data(i), i);
     }
 }
 


### PR DESCRIPTION
After `select_main_thread()` rebases `test_thread_data_ptr` by starting_thread, the 3-arg path in `for_each_test_thread()` must use the local loop index (i) to access `test_thread_data()`, not the absolute thread offset (starting_thread + i).

Using the absolute offset caused a double-offset: the rebased pointer plus the absolute index would overshoot the slice's data range, potentially accessing memory beyond the allocated array. This led to memory corruption that manifested as unexpected assertion failures in `has_failed()` due to reading uninitialized `PerThreadData`.

The thread and device absolute indices are still passed through to the lambda for logging and device_info lookups, where they are used correctly without pointer arithmetic.