### PR TITLE
FW/bats: Fix thread-to-CPU checks for non-contiguous logical CPUs

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -386,7 +386,7 @@ selftest_pass() {
     key_val_output=$(echo "$output" | sed 's/\r$//')
 
     for ((i = 0; i < MAX_PROC; ++i)); do
-        [[ "$key_val_output" = *"selftest_pass_messages_thread_${i}_cpu = $i"* ]]
+        [[ "$key_val_output" = *"selftest_pass_messages_thread_${i}_cpu = "* ]]
         [[ "$key_val_output" = *"selftest_pass_thread_${i}_loop_count = "* ]]
     done
 }
@@ -2202,16 +2202,28 @@ check_thread_ratio_plans() {
         test_yaml_numeric "/test-plans/heuristic/$i/threads" "value == $expected"
     done
 
-    # Verify each test thread is pinned to a logical CPU within its slice's range
+    # Verify each test thread is pinned to the expected logical CPU.
+    # Thread t within a slice must be on the t-th device's logical CPU.
+    # We look up logical CPUs from cpu-info because they are not necessarily
+    # contiguous (e.g. device 1 could be logical CPU 120).
     local thread_idx=$slice_count
     for ((i = 0; i < slice_count; i++)); do
         local start=${yamldump[/test-plans/heuristic/$i/starting_cpu]}
-        local count=${yamldump[/test-plans/heuristic/$i/count]}
         local threads=${yamldump[/test-plans/heuristic/$i/threads]}
 
+        # Build array of logical CPUs for this slice's devices
+        local -a valid_cpus=()
+        local count=${yamldump[/test-plans/heuristic/$i/count]}
+        for ((d = start; d < start + count; d++)); do
+            valid_cpus+=("${yamldump[/cpu-info/$d/logical]}")
+        done
+
         for ((t = 0; t < threads; t++)); do
-            test_yaml_numeric "/tests/0/threads/$thread_idx/id/logical" \
-                "value >= $start && value < $(( start + count ))"
+            local logical=${yamldump[/tests/0/threads/$thread_idx/id/logical]}
+            if (( logical != valid_cpus[t] )); then
+                echo "Thread $thread_idx: expected logical CPU ${valid_cpus[$t]}, got $logical" >&2
+                return 1
+            fi
             thread_idx=$(( thread_idx + 1 ))
         done
     done


### PR DESCRIPTION
On high-core-count systems, logical CPU numbers are not contiguous (e.g. device index 1 maps to logical CPU 120). The thread_ratio placement checks and the key-value output test assumed contiguous numbering, causing false negatives.

Fix the thread_ratio check in check_thread_ratio_plans() to build an array of valid logical CPUs from cpu-info for each slice, then verify that thread t is pinned to a valid cpu.

Also relax the key-value selftest_pass check to not assume thread i runs on CPU i.

```
#   cpu-info:
#   - { logical:   0, package: 0, numa_node: 0, module: 0, core: 0, thread: 0, core_type: p, family: 6, model: 0xad, stepping: 1, microcode: 0x1000434, ppin: "43e401ca0c95824d" }   # 0
#   - { logical: 120, package: 0, numa_node: 0, module: 0, core: 0, thread: 1, core_type: p, family: 6, model: 0xad, stepping: 1, microcode: 0x1000434, ppin: "43e401ca0c95824d" }   # 1
#   - { logical:   1, package: 0, numa_node: 0, module: 1, core: 1, thread: 0, core_type: p, family: 6, model: 0xad, stepping: 1, microcode: 0x1000434, ppin: "43e401ca0c95824d" }   # 2
#   - { logical: 121, package: 0, numa_node: 0, module: 1, core: 1, thread: 1, core_type: p, family: 6, model: 0xad, stepping: 1, microcode: 0x1000434, ppin: "43e401ca0c95824d" }   # 3
```