### PR TITLE
FW/CPU: fix thread offset accumulation in slice_plan_init_for_threads

### DIFF
--- a/framework/device/cpu/slicing.cpp
+++ b/framework/device/cpu/slicing.cpp
@@ -132,8 +132,9 @@ int slice_plan_init_for_threads(SlicePlans::SlicesArray& plans, ThreadRatio rati
             } else {
                 thread_count = static_cast<int>(n * std::get<float>(ratio_type));
             }
-            slice.thread_range = { thread_offset, thread_count > 0 ? thread_count : 1 };
-            thread_offset += thread_count;
+            thread_count = std::max(thread_count, 1);
+            slice.thread_range = { thread_offset, thread_count};
+            thread_offset += slice.thread_range.thread_count;
         }
         if (thread_offset > max_thread_count)
             max_thread_count = thread_offset;


### PR DESCRIPTION
The thread_offset was accumulated using the raw thread_count before clamping to a minimum of 1, while the slice's thread_range stored the clamped value. This meant that when thread_count was <= 0, the slice would get 1 thread assigned but thread_offset would advance by 0 or a negative value, causing subsequent slices to have overlapping or incorrect thread ranges.