### PR TITLE
Doc: update the schema file

### DIFF
--- a/docs/opendcdiag-cpu.schema.json
+++ b/docs/opendcdiag-cpu.schema.json
@@ -78,6 +78,9 @@
         "fullsocket": {
           "$ref": "#/$defs/test-plan-entry"
         },
+        "isolate_numa": {
+          "$ref": "#/$defs/test-plan-entry"
+        },
         "heuristic": {
           "$ref": "#/$defs/test-plan-entry"
         }

--- a/docs/opendcdiag-cpu.schema.json
+++ b/docs/opendcdiag-cpu.schema.json
@@ -227,12 +227,16 @@
           },
           "count": {
             "type": "integer"
+          },
+          "threads": {
+            "type": "integer"
           }
         },
         "minItems": 1,
         "required": [
           "count",
-          "starting_cpu"
+          "starting_cpu",
+          "threads"
         ]
       }
     },
@@ -321,6 +325,9 @@
                 ]
               },
               "id": {
+                "$ref": "#/$defs/cpu-info"
+              },
+              "previous-cpu": {
                 "$ref": "#/$defs/cpu-info"
               },
               "context": {

--- a/docs/opendcdiag-cpu.schema.json
+++ b/docs/opendcdiag-cpu.schema.json
@@ -540,6 +540,12 @@
               },
               "remark": {
                 "type": "string"
+              },
+              "details": {
+                "type": [
+                  "object",
+                  "array"
+                ]
               }
             },
             "required": [
@@ -550,6 +556,12 @@
               "mask",
               "offset",
               "type"
+            ]
+          },
+          "details": {
+            "type": [
+              "map",
+              "array"
             ]
           }
         },

--- a/docs/opendcdiag-cpu.schema.yaml
+++ b/docs/opendcdiag-cpu.schema.yaml
@@ -54,6 +54,8 @@ properties:
     properties:
       fullsocket:
         $ref: '#/$defs/test-plan-entry'
+      isolate_numa:
+        $ref: '#/$defs/test-plan-entry'
       heuristic:
         $ref: '#/$defs/test-plan-entry'
     required:

--- a/docs/opendcdiag-cpu.schema.yaml
+++ b/docs/opendcdiag-cpu.schema.yaml
@@ -370,6 +370,10 @@ $defs:
                 - string
             remark:
               type: string
+            details:
+              type:
+                - object
+                - array
           required:
             - actual
             - address
@@ -378,6 +382,10 @@ $defs:
             - mask
             - offset
             - type
+        details:
+          type:
+            - map
+            - array
       required:
         - level
 

--- a/docs/opendcdiag-cpu.schema.yaml
+++ b/docs/opendcdiag-cpu.schema.yaml
@@ -159,10 +159,13 @@ $defs:
           type: integer
         count:
           type: integer
+        threads:
+          type: integer
       minItems: 1
       required:
         - count
         - starting_cpu
+        - threads
 
   test-entry:
     type: object


### PR DESCRIPTION
This updates with a few recent-ish changes to the output. It adds:
- the `isolate_numa` entry to the `plans` section
- the `threads` count to each `plans` entry
- `details` to the thread messages and `memcmp_or_fail` output. This is functionality added by the `log_yaml()` function (added in commit 11a6f207b68fcec26014b2e6cf471652b23edd7d). 