### PR TITLE
simd.conf: add support for detecting ACEv1

### DIFF
--- a/framework/device/cpu/cpuid_internal.h
+++ b/framework/device/cpu/cpuid_internal.h
@@ -153,6 +153,7 @@ static device_features_t detect_cpu()
         if (eax) {
             __cpuid_count(7, 1, eax, ebx, ecx, edx);
             features |= parse_register(Leaf07_01EAX, eax);
+            features |= parse_register(Leaf07_01ECX, ecx);
             features |= parse_register(Leaf07_01EDX, edx);
         }
     }
@@ -170,6 +171,25 @@ static device_features_t detect_cpu()
     __cpuid(0x80000001, eax, ebx, ecx, edx);
     features |= parse_register(Leaf80000001ECX, ecx);
 
+    if (max_level >= 0x1d && features & cpu_feature_ace) {
+        // extract the version number from CPUID
+        __cpuid_count(0x1d, 2, eax, ebx, ecx, edx);
+
+        int acever = ecx & 0xff;
+#ifdef cpu_feature_ace1
+        if (acever >= 1)
+            features |= cpu_feature_ace1;
+#endif
+#ifdef cpu_feature_ace2
+        if (acever >= 2)
+            features |= cpu_feature_ace2;
+#endif
+#ifdef cpu_feature_ace3
+        if (acever >= 3)
+            features |= cpu_feature_ace3;
+#endif
+        assert(acever < 4 && "Internal error: update code above!");
+    }
     if (max_level >= 0x24 && features & cpu_feature_avx10_1) {
         // extract the version number from CPUID
         __cpuid_count(0x24, 0, eax, ebx, ecx, edx);

--- a/framework/device/cpu/scripts/x86simd_generate.pl
+++ b/framework/device/cpu/scripts/x86simd_generate.pl
@@ -13,6 +13,7 @@ my %leaves = (
     Leaf07_00ECX        => "CPUID Leaf 7, Sub-leaf 0, ECX",
     Leaf07_00EDX        => "CPUID Leaf 7, Sub-leaf 0, EDX",
     Leaf07_01EAX        => "CPUID Leaf 7, Sub-leaf 1, EAX",
+    Leaf07_01ECX        => "CPUID Leaf 7, Sub-leaf 1, ECX",
     Leaf07_01EDX        => "CPUID Leaf 7, Sub-leaf 1, EDX",
     Leaf0D_01EAX        => "CPUID Leaf 0Dh, Sub-leaf 1, EAX",
     Leaf1E_01EAX        => "CPUID Leaf 1Eh, Sub-leaf 1, EAX",

--- a/framework/device/cpu/simd.conf
+++ b/framework/device/cpu/simd.conf
@@ -99,6 +99,7 @@ lam			Leaf07_01EAX	    26		# Linear Address Masking
 #msrlist		Leaf07_01EAX	    27		# RDMSRLIST, WRMSRLIST, IA32_BARRIER_MSR
 movrs			Leaf07_01EAX	    31		# MOV instructions with Read-Shared hint
 #pbndkb			Leaf07_01EBX	    1		# Total Storage Encryption (TSE) instruction PBNDKB
+ace			Leaf07_01ECX	    11		# AI Compute Extensions (ACE)
 avxvnniint8		Leaf07_01EDX	    4	avxvnni	# AVX Vector Neural Network Instructions, Int8
 avxneconvert		Leaf07_01EDX	    5	avx	# AVX Non-Exception BF16/FP16/FP32 Conversion instructions
 amx-complex		Leaf07_01EDX	    8	amx-tile	# AMX Tile multiplication for complex matrices
@@ -114,6 +115,7 @@ apx-f			Leaf07_01EDX	    21		# Advanced Performance Extensions
 #xgetbv1		Leaf0D_01EAX	    2		# XGETBV with ECX=1
 #xsaves			Leaf0D_01EAX	    3		# XSAVE Supervisor mode
 #xfd			Leaf0D_01EAX	    4		# eXtended Feature Disable MSR
+#ace1			Leaf1D_02ECX	    0_7==1	# AI Compute Extensions version 1
 #amx-int8		Leaf1E_01EAX	    0	amx-tile	# (repeated) AMX Tile multiplication for Int8
 #amx-bf16		Leaf1E_01EAX	    1	amx-tile	# (repeated) AMX Tile multiplication in BFloat16
 #amx-complex		Leaf1E_01EDX	    2	amx-tile	# (repeated) AMX Tile multiplication for complex matrices
@@ -126,6 +128,8 @@ avx10.2			Leaf24_00EBX	    0_7==2	avx10.1	# AVX10.2
 #avx10_128		Leaf24_00ECX	    16		# 128-bit AVX10
 #avx10_256		Leaf24_00ECX	    17		# 256-bit AVX10
 #avx10_512		Leaf24_00ECX	    18		# 512-bit AVX10
+#avx10_v1_aux		Leaf24_01ECX	    2		# AVX10.1 auxiliary instructions
+#avx10_v2_aux		Leaf24_01ECX	    3		# AVX10.2 auxiliary instructions
 lzcnt			Leaf80000001ECX	    5		# Leading Zero Count
 
 # XSAVE states
@@ -152,10 +156,12 @@ xsave=HwpState		0x10000				# Hardware P-State
 xsave=Xtilecfg		0x20000				# AMX: XTILECFG register
 xsave=Xtiledata		0x40000				# AMX: data in the tiles
 xsave=ApxState		0x80000			apx-f	# APX Extended GPRs
+xsave=BsrState		0x100000			# Block Scale Register
 xsave=AvxState		SseState|Ymm_Hi128	avx,avx512f
 xsave=MPXState		Bndregs|Bndcsr		mpx
 xsave=Avx512State	AvxState|OpMask|Zmm_Hi256|Hi16_Zmm	avx512f
 xsave=AmxState		Xtilecfg|Xtiledata	amx-tile
+xsave=AceState		Avx512State|AmxState|BsrState		ace
 
 # Processor/arch listing below this line
 # Source: Intel Instruction Set Extension manual, section 1.2


### PR DESCRIPTION
From https://x86ecosystem.org/wp-content/uploads/2026/06/ACE_v1_Specification_public_1_15.pdf

That document does not describe whether Linux will require a different arch_prl(ARCH_REQ_XCOMP_PERM) to enable the BSR state. This patch assumes the kernel will enable it when we request XTILEDATA and XTILECFG. If that ends up not being the case, we'll need to update this.