### PR TITLE
FW/Random: add --random-control option

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -796,11 +796,11 @@ function selftest_log_yaml_common() {
 
 @test "selftest_logs_random_init" {
     declare -A yamldump
-    sandstone_selftest -e selftest_logs_random_init -s Constant:1234
+    sandstone_selftest -e selftest_logs_random_init -e selftest_preinit_random -s Constant:1234
     [[ "$status" -eq 0 ]]
     test_yaml_regexp "/tests/0/threads/0/messages/0/text" "I> 1234 1234 1234 1234"
 
-    sandstone_selftest -e selftest_logs_random_init -s LCG:1348219713
+    sandstone_selftest -e selftest_logs_random_init -e selftest_preinit_random -s LCG:1348219713
     [[ "$status" -eq 0 ]]
     test_yaml_expr "/tests/0/state/seed" = "LCG:1348219713"
     test_yaml_regexp "/tests/0/threads/0/messages/0/text" "I> 421843888 386376794 2046232626 184745881"
@@ -818,7 +818,8 @@ function selftest_log_yaml_common() {
     [[ "$output" = *'  Constant'* ]]
     [[ "$output" = *'  LCG'* ]]
     if [[ "$output" = *'  AES'* ]]; then
-        sandstone_selftest -e selftest_logs_random_init -s AES:87608d752b11fb972c8f0b4c19cdecf7789f728ad4ee0468d370f4b3e6321308
+        sandstone_selftest -e selftest_logs_random_init \
+            -s AES:87608d752b11fb972c8f0b4c19cdecf7789f728ad4ee0468d370f4b3e6321308
         [[ "$status" -eq 0 ]]
         test_yaml_regexp "/tests/0/state/seed" "AES:87608d752b11fb972c8f0b4c19cdecf7789f728ad4ee0468d370f4b3e6321308"
         test_yaml_regexp "/tests/0/threads/0/messages/0/text" "I> 1242137224 1378217084 1525375882 474233533"

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -833,6 +833,24 @@ function selftest_log_yaml_common() {
     fi
 }
 
+@test "selftest_logs_random --random-control=uniform-thread-seed" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_logs_random --random-control=uniform-thread-seed
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+
+    # All threads must produce the same random output
+    local first="${yamldump[/tests/0/threads/0/messages/0/text]}"
+    [[ -n "$first" ]]
+    for ((i = 1; i < yamldump[/tests/0/threads@len]; ++i)); do
+        local other="${yamldump[/tests/0/threads/$i/messages/0/text]}"
+        if [[ "$first" != "$other" ]]; then
+            echo "Thread $i output ($other) differs from thread 0 ($first)" >&2
+            false
+        fi
+    done
+}
+
 test_random() {
     if ! $is_debug; then
         skip "Test only works with Debug builds (to mock the topology)"

--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -833,6 +833,65 @@ function selftest_log_yaml_common() {
     fi
 }
 
+@test "selftest_logs_random seed advances between tests" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_logs_random_init -e selftest_logs_random
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+
+    # By default, seeds must differ between tests
+    local seed0="${yamldump[/tests/0/state/seed]}"
+    local seed1="${yamldump[/tests/1/state/seed]}"
+    [[ -n "$seed0" ]]
+    if [[ "$seed0" == "$seed1" ]]; then
+        echo "Seeds are identical ('$seed0') but should differ" >&2
+        false
+    fi
+}
+
+@test "selftest_logs_random --random-control=fixed-seed" {
+    declare -A yamldump
+    sandstone_selftest -e selftest_logs_random_init -e selftest_logs_random \
+        --random-control=fixed-seed
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+
+    # Both tests must have started with the same seed
+    local seed0="${yamldump[/tests/0/state/seed]}"
+    local seed1="${yamldump[/tests/1/state/seed]}"
+    [[ -n "$seed0" ]]
+    if [[ "$seed0" != "$seed1" ]]; then
+        echo "Seeds differ: test 0 had '$seed0', test 1 had '$seed1'" >&2
+        false
+    fi
+}
+
+@test "selftest_timedpass --random-control=fixed-seed does not advance seed between fractures" {
+    declare -A yamldump
+    # Use a duration long enough to force at least two fractures (auto-fracture runs 40 inner
+    # loops of 10 ms each = ~400 ms per fracture; 900 ms gives at least two fractures)
+    sandstone_selftest -e selftest_timedpass -t 900 --random-control=fixed-seed
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+
+    # We need at least 2 fractures to verify the behavior
+    if [[ "${yamldump[/tests@len]}" -lt 2 ]]; then
+        skip "Only one fracture produced; cannot verify fixed-seed behavior across fractures"
+    fi
+
+    # All fractures of selftest_timedpass must have started with the same seed
+    local ref_seed="${yamldump[/tests/0/state/seed]}"
+    [[ -n "$ref_seed" ]]
+    for ((i = 1; i < yamldump[/tests@len]; ++i)); do
+        [[ "${yamldump[/tests/$i/test]}" == "selftest_timedpass" ]] || break
+        local this_seed="${yamldump[/tests/$i/state/seed]}"
+        if [[ "$this_seed" != "$ref_seed" ]]; then
+            echo "Fracture $i seed ('$this_seed') differs from fracture 0 ('$ref_seed')" >&2
+            false
+        fi
+    done
+}
+
 @test "selftest_logs_random --random-control=uniform-thread-seed" {
     declare -A yamldump
     sandstone_selftest -e selftest_logs_random --random-control=uniform-thread-seed
@@ -844,6 +903,30 @@ function selftest_log_yaml_common() {
     [[ -n "$first" ]]
     for ((i = 1; i < yamldump[/tests/0/threads@len]; ++i)); do
         local other="${yamldump[/tests/0/threads/$i/messages/0/text]}"
+        if [[ "$first" != "$other" ]]; then
+            echo "Thread $i output ($other) differs from thread 0 ($first)" >&2
+            false
+        fi
+    done
+}
+
+@test "selftest_logs_random --random-control=uniform-thread-seed,fixed-seed" {
+    local -r SEED=LCG:1348219713
+    declare -A yamldump
+    sandstone_selftest -e selftest_logs_random_init -e selftest_logs_random \
+        -s $SEED --random-control=uniform-thread-seed,fixed-seed
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+
+    # Both tests must report the exact seed we passed with -s
+    test_yaml_expr "/tests/0/state/seed" = "$SEED"
+    test_yaml_expr "/tests/1/state/seed" = "$SEED"
+
+    # All threads in the second test must produce the same random output
+    local first="${yamldump[/tests/1/threads/0/messages/0/text]}"
+    [[ -n "$first" ]]
+    for ((i = 1; i < yamldump[/tests/1/threads@len]; ++i)); do
+        local other="${yamldump[/tests/1/threads/$i/messages/0/text]}"
         if [[ "$first" != "$other" ]]; then
             echo "Thread $i output ($other) differs from thread 0 ($first)" >&2
             false

--- a/framework/random.cpp
+++ b/framework/random.cpp
@@ -551,7 +551,8 @@ std::string random_format_seed()
 
 void random_advance_seed()
 {
-    rand();
+    if (!(sApp->shmem->cfg.random_control_flags & uint32_t(TestConfig::RandomControl::fixed_seed)))
+        rand();
 }
 
 uint32_t random_seed_low32()

--- a/framework/random.cpp
+++ b/framework/random.cpp
@@ -87,7 +87,7 @@ struct RandomEngineWrapper
     EngineType engine_type;
 
     RandomEngineWrapper(EngineType type)
-        : per_thread(thread_count() + 1), engine_type(type)
+        : per_thread(thread_count() + 2), engine_type(type)
     {}
 
     virtual ~RandomEngineWrapper();
@@ -101,6 +101,15 @@ struct RandomEngineWrapper
     virtual uint64_t generate64(thread_rng *thread_buffer) = 0;
     virtual long int generateInt(thread_rng *thread_buffer) = 0;
     virtual __uint128_t generate128(thread_rng *thread_buffer) = 0;
+
+    /*virtual*/ void saveEngineState()
+    {
+        per_thread[per_thread.size() - 1] = per_thread[0];
+    }
+    /*virtual*/ void restoreEngineState()
+    {
+        per_thread[0] = per_thread[per_thread.size() - 1];
+    }
 };
 RandomEngineWrapper::~RandomEngineWrapper() {}
 
@@ -539,6 +548,9 @@ void random_init_global(const char *seed_from_user)
         read_from_seed(sseq);
         sApp->random_engine->seedGlobalEngine(sseq);
     }
+
+    // save the engine state
+    sApp->random_engine->saveEngineState();
 }
 
 std::string random_format_seed()
@@ -549,10 +561,15 @@ std::string random_format_seed()
     return result;
 }
 
-void random_advance_seed()
+void random_advance_seed() noexcept
 {
     if (!(sApp->shmem->cfg.random_control_flags & uint32_t(TestConfig::RandomControl::fixed_seed)))
         rand();
+}
+
+void random_restore_seed() noexcept
+{
+    sApp->random_engine->restoreEngineState();
 }
 
 uint32_t random_seed_low32()

--- a/framework/random.cpp
+++ b/framework/random.cpp
@@ -562,7 +562,9 @@ uint32_t random_seed_low32()
 void random_init_thread(int thread_num)
 {
     // nothing should be modifying the global engine now
-    sApp->random_engine->seedThread(rng_for_thread(thread_num), mixin_from_device_info(thread_num));
+    bool skip_mixin = sApp->shmem->cfg.random_control_flags & uint32_t(TestConfig::RandomControl::uniform_thread_seed);
+    uint32_t mixin = skip_mixin ? 0 : mixin_from_device_info(thread_num);
+    sApp->random_engine->seedThread(rng_for_thread(thread_num), mixin);
 }
 
 template <typename FP> static inline FP random_template(FP scale)

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1210,6 +1210,7 @@ int main(int argc, char **argv)
     TestResult lastTestResult = TestResult::Skipped;
 
     preinit_tests();
+    random_restore_seed();
     for (auto it = get_first_test(); it != test_set->end(); it = get_next_test(it)) {
         if (lastTestResult != TestResult::Skipped) {
             if (sApp->service_background_scan) {

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -300,6 +300,8 @@ Common command-line options are:
      Comma-separated list of controls that modify RNG behavior. Available controls:
        uniform-thread-seed  Uniformly initialize the random generator in each thread
                             to the same state.
+       fixed-seed           Do not advance the global seed between tests. Every test
+                            will start from the same seed.
  -v, -q, --verbose, --quiet
      Set logging output verbosity level. Default is quiet.
  --version
@@ -963,6 +965,14 @@ struct ProgramOptionsParser {
                 if (token == "uniform-thread-seed") {
                     opts.shmem_cfg.random_control_flags |=
                         uint32_t(TestConfig::RandomControl::uniform_thread_seed);
+                } else if (token == "fixed-seed") {
+                    opts.shmem_cfg.random_control_flags |=
+                        uint32_t(TestConfig::RandomControl::fixed_seed);
+                } else if (token == "fixed-uniform-seed" || token == "uniform-fixed-seed") {
+                    // shorthand forms
+                    opts.shmem_cfg.random_control_flags |=
+                            uint32_t(TestConfig::RandomControl::fixed_seed) |
+                            uint32_t(TestConfig::RandomControl::uniform_thread_seed);
                 } else {
                     fprintf(ERR_STREAM, "%s: unknown --random-control value: '%.*s'\n",
                             argv[0], int(token.size()), token.data());

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -68,6 +68,7 @@ enum {
     output_format_option,
     quality_option,
     quick_run_option,
+    random_control_option,
     raw_list_test_ids,
     raw_list_tests,
     raw_list_group_members,
@@ -161,6 +162,7 @@ static struct option long_options[]  = {
     { "quality", required_argument, nullptr, quality_option },
     { "quick", no_argument, nullptr, quick_run_option },
     { "quiet", no_argument, nullptr, 'q' },
+    { "random-control", required_argument, nullptr, random_control_option },
     { "retest-on-failure", required_argument, nullptr, retest_on_failure_option },
     { "reschedule", required_argument, nullptr, reschedule_option },
     { "rng-state", required_argument, nullptr, 's' },
@@ -294,6 +296,10 @@ Common command-line options are:
  -s <STATE>, --rng-state=<STATE>
      Specify the random generator state to reload. The seed is in the form:
      Engine:engine-specific-data
+ --random-control=<CONTROLS>
+     Comma-separated list of controls that modify RNG behavior. Available controls:
+       uniform-thread-seed  Uniformly initialize the random generator in each thread
+                            to the same state.
  -v, -q, --verbose, --quiet
      Set logging output verbosity level. Default is quiet.
  --version
@@ -510,6 +516,7 @@ struct ProgramOptionsParser {
             case max_logdata_option:
             case max_messages_option:
             case reschedule_option:
+            case random_control_option:
             case thread_ratio_option:
                 opts_map.insert_or_assign(opt, optarg);
                 break;
@@ -945,6 +952,25 @@ struct ProgramOptionsParser {
             } else {
                 fprintf(ERR_STREAM, "%s: unknown reschedule mode: %s\n", argv[0], value);
                 return EX_USAGE;
+            }
+        }
+
+        if (auto value = string_opt_for(random_control_option)) {
+            std::string_view sv(value);
+            while (!sv.empty()) {
+                auto comma = sv.find(',');
+                auto token = sv.substr(0, comma);
+                if (token == "uniform-thread-seed") {
+                    opts.shmem_cfg.random_control_flags |=
+                        uint32_t(TestConfig::RandomControl::uniform_thread_seed);
+                } else {
+                    fprintf(ERR_STREAM, "%s: unknown --random-control value: '%.*s'\n",
+                            argv[0], int(token.size()), token.data());
+                    return EX_USAGE;
+                }
+                if (comma == std::string_view::npos)
+                    break;
+                sv = sv.substr(comma + 1);
             }
         }
 

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -247,6 +247,7 @@ struct TestConfig
 
     enum class RandomControl : uint32_t {
         uniform_thread_seed     = 1u << 0,  // all threads seeded uniformly
+        fixed_seed              = 1u << 1,  // do not advance seed between tests
     };
 
     // test execution

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -245,11 +245,16 @@ struct TestConfig
     };
     static constexpr auto DefaultOutputFormat = SANDSTONE_DEFAULT_LOGGING;
 
+    enum class RandomControl : uint32_t {
+        uniform_thread_seed     = 1u << 0,  // all threads seeded uniformly
+    };
+
     // test execution
     bool selftest = false;
     bool ud_on_failure = false;
     bool use_strict_runtime = false;
     RescheduleMode reschedule_mode = RescheduleMode::unset;
+    uint32_t random_control_flags = 0;
 
     // logging parameters
     LogLevelVerbosity verbosity = LogLevelVerbosity::Error;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -661,7 +661,8 @@ int log_skip_or_print(SkipCategory cat, const char *fmt, ...) ATTRIBUTE_PRINTF(2
 
 /* random.cpp */
 void random_init_global(const char *argument);
-void random_advance_seed();
+void random_advance_seed() noexcept;
+void random_restore_seed() noexcept;
 std::string random_format_seed();
 void random_init_thread(int thread_num);
 uint32_t random_seed_low32();

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -322,6 +322,17 @@ static int selftest_logs_reschedule_cleanup(struct test *test)
     free (reschedule_sem);
     return EXIT_SUCCESS;
 }
+
+static int selftest_random_preinit(struct test *test)
+{
+    // use (but not print) 4 ints
+    int r1 = random();
+    int r2 = random();
+    int r3 = random();
+    int r4 = random();
+    return (r1 + r2 + r3 + r4) ? EXIT_SUCCESS : EXIT_SUCCESS;
+}
+
 static int selftest_logs_random_init(struct test *test)
 {
     // print 4 ints
@@ -1472,6 +1483,15 @@ static struct test selftests_array[] = {
     .test_init = selftest_preinit_init,
     .test_run = selftest_pass_run,
     .desired_duration = INT_MAX,        // we change to -1 in the preinit
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_preinit_random",
+    .description = "Uses the random generator in the preinit function",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_preinit = selftest_random_preinit,
+    .test_run = selftest_pass_run,
+    .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },
 {


### PR DESCRIPTION
Add a new `--random-control=<CONTROLS>` command-line option that modifies RNG behavior. Controls are specified as a comma-separated list, allowing multiple to be combined and more to be added in the future without interface changes.

Two controls are introduced:

**`no-thread-mixin`** — By default, each thread's RNG is seeded by XOR-ing a per-device topology value into the global seed, giving every thread a unique random sequence. With `no-thread-mixin`, this mixin is skipped and all threads start from the same RNG state.

**`fixed-seed`** — By default, the global RNG seed is advanced after each test, so consecutive tests produce different random sequences. With `fixed-seed`, the seed is not advanced, so every test starts from the same seed. Combined with `-s ENGINE:SEED`, this makes runs fully reproducible regardless of how many tests run.

The two controls are independent and can be combined:
```
--random-control=no-thread-mixin,fixed-seed
```

BATS selftests are added for each control individually and for the combined case.
