### PR TITLE
FW/GPU: rework L0 API errors propagation

### DIFF
--- a/framework/device/gpu/topology.cpp
+++ b/framework/device/gpu/topology.cpp
@@ -308,19 +308,25 @@ GpusSet detect_devices<GpusSet>()
         enabled_devices.emplace(indices, ZeDeviceCtx{ .driver = driver, .ze_handle = device_handle });
         return EXIT_SUCCESS;
     });
-    ret += for_each_zes_device([&](zes_device_handle_t device_handle, ze_driver_handle_t, const MultiSliceGpu& indices) {
+    if (ret != EXIT_SUCCESS) [[unlikely]] {
+        fprintf(stderr, "%s: internal error: gpu enumeration failed!\n",
+                program_invocation_name);
+        return enabled_devices;
+    }
+
+    ret = for_each_zes_device([&](zes_device_handle_t device_handle, ze_driver_handle_t, const MultiSliceGpu& indices) {
         if (!enabled_devices.count(indices)) {
             return EXIT_FAILURE;
         }
         enabled_devices.at(indices).zes_handle = device_handle; // matching indices must mean the exact same device
         return EXIT_SUCCESS;
     });
-
     if (ret != EXIT_SUCCESS) [[unlikely]] {
         fprintf(stderr, "%s: internal error: gpu enumeration failed!\n",
                 program_invocation_name);
         return enabled_devices;
     }
+
     if (enabled_devices.empty()) [[unlikely]] {
         fprintf(stderr, "%s: internal error: gpu devices set appears to be empty!\n",
                 program_invocation_name);

--- a/framework/device/gpu/ze_check.h
+++ b/framework/device/gpu/ze_check.h
@@ -9,21 +9,33 @@
 #include "sandstone_p.h"
 #include "ze_utils.h"
 
-#include "level_zero/ze_api.h"
+#include <level_zero/ze_api.h>
+
+#include <stdio.h>
 
 extern bool logging_in_test;
 
-/// Check return value of an L0 API call. Log the return status and return EXIT_FAILURE if check against "success" status fails.
+/// Log a runtime skip reason during test execution; outside tests, print a quiet message instead.
+#define LOG_RUNTIME_SKIP_OR_PRINT(fmt, ...) \
+    do { \
+        if (!sApp->shmem) { \
+            fprintf(stderr, fmt "\n", ##__VA_ARGS__); \
+        } else if (logging_in_test) { \
+            log_skip(RuntimeSkipCategory, fmt, ##__VA_ARGS__); \
+        } else { \
+            logging_printf(LOG_LEVEL_QUIET, fmt "\n", ##__VA_ARGS__); \
+        } \
+    } while (0)
+
+/// Check return value of an L0 API call.
+/// In test context it returns EXIT_SKIP; outside tests it returns EXIT_FAILURE.
 #define ZE_CHECK(...) \
     do { \
         auto result = (__VA_ARGS__); \
         if (result != ZE_RESULT_SUCCESS) { \
-            if (!sApp->shmem) { \
-                fprintf(stderr, "L0 API call failed with status %s\n", to_string(result)); \
-            } else if (logging_in_test) { \
-                log_error("L0 API call failed with status %s", to_string(result)); \
-            } else { \
-                logging_printf(LOG_LEVEL_QUIET, "L0 API call failed with status %s\n", to_string(result)); \
+            LOG_RUNTIME_SKIP_OR_PRINT("L0 API call failed with status %s", to_string(result)); \
+            if (logging_in_test) { \
+                return EXIT_SKIP; \
             } \
             return EXIT_FAILURE; \
         } \

--- a/framework/device/gpu/ze_enumeration.cpp
+++ b/framework/device/gpu/ze_enumeration.cpp
@@ -8,8 +8,12 @@
 #include "multi_slice_gpu.h"
 #include "topology_gpu.h"
 
-#include "level_zero/ze_api.h"
-#include "level_zero/zes_api.h"
+#include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
+
+#include <functional>
+#include <unordered_map>
+#include <vector>
 
 /// ZE API allows for nested enumeration of devices and their subdevices,
 /// depending on the ZE_FLAT_DEVICE_HIERARCHY env var value.
@@ -26,6 +30,10 @@ int for_each_ze_device(const std::function<int(ze_device_handle_t, ze_driver_han
 
     // Always pick the last ("newest") one.
     auto ze_driver = drivers.back();
+    if (!ze_driver) {
+        LOG_RUNTIME_SKIP_OR_PRINT("Could not initialize driver handle");
+        return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+    }
     int gpu_number = 0;
     uint32_t n_devices = 0;
     ZE_CHECK(zeDeviceGet(ze_driver, &n_devices, nullptr));
@@ -33,6 +41,10 @@ int for_each_ze_device(const std::function<int(ze_device_handle_t, ze_driver_han
     ZE_CHECK(zeDeviceGet(ze_driver, &n_devices, devices.data()));
 
     for (int i = 0; i < (int)devices.size(); i++) {
+        if (!devices[i]) {
+            LOG_RUNTIME_SKIP_OR_PRINT("Could not initialize device handle");
+            return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+        }
         ze_device_properties_t device_properties = { .stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES };
         ZE_CHECK(zeDeviceGetProperties(devices[i], &device_properties));
         if (device_properties.type == ZE_DEVICE_TYPE_GPU) {
@@ -65,12 +77,20 @@ int for_each_zes_device(const std::function<int(zes_device_handle_t, ze_driver_h
 
     int gpu_number = 0;
     for (auto zes_driver: zes_drivers) {
+        if (!zes_driver) {
+            LOG_RUNTIME_SKIP_OR_PRINT("Could not initialize driver handle");
+            return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+        }
         uint32_t n_zes_devices = 0;
         ZE_CHECK(zesDeviceGet(zes_driver, &n_zes_devices, nullptr));
         std::vector<zes_device_handle_t> zes_devices(n_zes_devices);
         ZE_CHECK(zesDeviceGet(zes_driver, &n_zes_devices, zes_devices.data()));
 
         for (int i = 0; i < (int)zes_devices.size(); i++) {
+            if (!zes_devices[i]) {
+                LOG_RUNTIME_SKIP_OR_PRINT("Could not initialize device handle");
+                return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+            }
             zes_device_properties_t device_prop = { .stype = ZES_STRUCTURE_TYPE_DEVICE_PROPERTIES };
             ZE_CHECK(zesDeviceGetProperties(zes_devices[i], &device_prop));
             if (device_prop.core.type == ZE_DEVICE_TYPE_GPU) {
@@ -103,7 +123,8 @@ int find_and_call_func(
     if (it != map.cend()) {
         return func(it->second, ze_driver, indices);
     }
-    return EXIT_FAILURE;
+    LOG_RUNTIME_SKIP_OR_PRINT("Could not find func for device");
+    return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
 }
 
 // XXX depending on API version, ze_device_handle_t and zes_device_handle_t can be the exact same type,
@@ -112,7 +133,7 @@ template <typename DeviceType, bool IsSysmanAPI = false>
 int for_each_device_within_topo_internal(const std::function<int(DeviceType, ze_driver_handle_t, const MultiSliceGpu&)>& func)
 {
     // Collect all handles for easier lookup.
-    ze_driver_handle_t ze_driver;
+    ze_driver_handle_t ze_driver{};
     std::unordered_map<MultiSliceGpu, DeviceType> dev_handles;
     auto emplace_map = [&](DeviceType dev_handle, ze_driver_handle_t driver, const MultiSliceGpu& indices) {
         ze_driver = driver;
@@ -126,15 +147,15 @@ int for_each_device_within_topo_internal(const std::function<int(DeviceType, ze_
     } else {
         ret = for_each_ze_device(emplace_map);
     }
-    if (ze_driver == nullptr || ret != EXIT_SUCCESS) {
-        return EXIT_FAILURE;
+    if (ret != EXIT_SUCCESS) {
+        return ret;
     }
 
     ret = for_each_topo_device([&](const gpu_info_t& info) {
         return find_and_call_func(info, ze_driver, dev_handles, func);
     });
     if (ret != EXIT_SUCCESS) {
-        return EXIT_FAILURE;
+        return ret;
     }
 
     return EXIT_SUCCESS;

--- a/framework/device/gpu/ze_enumeration.h
+++ b/framework/device/gpu/ze_enumeration.h
@@ -9,14 +9,19 @@
 #include "multi_slice_gpu.h"
 #include "ze_check.h"
 
-#include "level_zero/ze_api.h"
-#include "level_zero/zes_api.h"
+#include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
 
 #include <functional>
+#include <vector>
 
 #define CHECK_SANDSTONE(...) \
-    if ((__VA_ARGS__) != EXIT_SUCCESS) \
-        return EXIT_FAILURE;
+    do { \
+        int ret = (__VA_ARGS__); \
+        if (ret != EXIT_SUCCESS) { \
+            return ret; \
+        } \
+    } while (0)
 
 /// Functions containing boilerplate code for drivers, devices and subdevices enumeration. Contains level-zero drivers
 /// initialization, so can be called as a standalone function anytime. Calls passed function for each found Intel device.

--- a/framework/device/gpu/ze_kernel.h
+++ b/framework/device/gpu/ze_kernel.h
@@ -9,8 +9,9 @@
 #include "ze_check.h"
 #include "ze_utils.h"
 
-#include "level_zero/ze_api.h"
+#include <level_zero/ze_api.h>
 
+#include <cassert>
 #include <memory>
 
 struct ZeKernelDeleter
@@ -51,21 +52,28 @@ inline ZeKernelPtr get_ze_kernel(ze_context_handle_t context, ze_device_handle_t
     auto ret = zeModuleCreate(context, device, &desc, &ze_module, &build_log);
     if (ret != ZE_RESULT_SUCCESS) {
         auto create_ret = ret;
+        // Gather the build log first, then emit a single log_skip message.
+        const char *build_log_str = nullptr;
+        std::unique_ptr<char[]> owned_log;
+        if (build_log) {
+            size_t log_size = 0;
+            ret = zeModuleBuildLogGetString(build_log, &log_size, nullptr);
+            if (ret == ZE_RESULT_SUCCESS && log_size > 0) {
+                owned_log.reset(new char[log_size + 1]);
+                size_t buffer_size = log_size;
+                ret = zeModuleBuildLogGetString(build_log, &buffer_size, owned_log.get());
+                if (ret == ZE_RESULT_SUCCESS) {
+                    owned_log[log_size] = '\0';
+                    build_log_str = owned_log.get();
+                }
+            }
+        }
 
-        // try to print log
-        size_t log_size = 0;
-        ret = zeModuleBuildLogGetString(build_log, &log_size, nullptr);
-        if (ret != ZE_RESULT_SUCCESS) {
-            destroy_log();
-            return nullptr; // give up
+        if (build_log_str) {
+            log_skip(RuntimeSkipCategory, "L0 API call zeModuleCreate failed with %s; build log: %s", to_string(create_ret), build_log_str);
+        } else {
+            log_skip(RuntimeSkipCategory, "L0 API call zeModuleCreate failed with %s", to_string(create_ret));
         }
-        std::unique_ptr<char[]> string_log(new char[log_size]);
-        ret = zeModuleBuildLogGetString(build_log, &log_size, string_log.get());
-        if (ret != ZE_RESULT_SUCCESS) {
-            destroy_log();
-            return nullptr;
-        }
-        log_debug("zeModuleCreate ret: %s (0x%x) zeModuleCreate log: %s", to_string(create_ret), create_ret, string_log.get());
         destroy_log();
         return nullptr;
     }
@@ -77,7 +85,7 @@ inline ZeKernelPtr get_ze_kernel(ze_context_handle_t context, ze_device_handle_t
     ret = zeKernelCreate(ze_module, &kernelDesc, &ze_kernel);
     if (ret != ZE_RESULT_SUCCESS) {
         IGNORE_RETVAL(zeModuleDestroy(ze_module));
-        log_debug("L0 API call zeKernelCreate failed with %s (0x%x)", to_string(ret), ret);
+        log_skip(RuntimeSkipCategory, "L0 API call zeKernelCreate failed with %s", to_string(ret));
         return nullptr; // isn't ze_kernel a nullptr anyway?
     }
 

--- a/framework/device/gpu/ze_utils.cpp
+++ b/framework/device/gpu/ze_utils.cpp
@@ -5,8 +5,8 @@
 
 #include "ze_utils.h"
 
-#include "level_zero/ze_api.h"
-#include "level_zero/zes_api.h"
+#include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
 
 const char* to_string(ze_result_t value)
 {

--- a/framework/device/gpu/ze_utils.h
+++ b/framework/device/gpu/ze_utils.h
@@ -6,8 +6,8 @@
 #ifndef INC_ZE_UTILS_H
 #define INC_ZE_UTILS_H
 
-#include "level_zero/ze_api.h"
-#include "level_zero/zes_api.h"
+#include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
 
 /// Functions converting resource type to a human readable string.
 const char* to_string(ze_result_t value);

--- a/framework/device/gpu/ze_wrappers.h
+++ b/framework/device/gpu/ze_wrappers.h
@@ -7,16 +7,17 @@
 #define INC_ZE_WRAPPERS_H
 
 #include "sandstone.h"
-
-#include "level_zero/ze_api.h"
 #include "ze_utils.h"
 
+#include <level_zero/ze_api.h>
+
+#include <cassert>
 #include <memory>
 #include <utility>
 
 extern bool logging_in_test;
 
-/// Use for non-critical paths (like cleanup): log the failure but do not mark test failed.
+/// Use for non-critical paths (like cleanup): log the failure but do not mark test as skipped.
 #define ZE_CHECK_AND_LOG(...) \
     do { \
         assert(logging_in_test); \
@@ -26,23 +27,23 @@ extern bool logging_in_test;
         } \
     } while (0)
 
-/// Use for critical setup paths (like constructors/factories): log_error marks thread failed,
-/// but the macro still continues. Caller must validate the handle and return on failure.
-#define ZE_CHECK_AND_FAIL(...) \
+/// Use for critical setup paths (like constructors/factories): log_skip marks thread as skipped,
+/// but the macro still continues. Caller must validate the handle and return on null (see CHECK_NULL below).
+#define ZE_CHECK_AND_SKIP(...) \
     do { \
         assert(logging_in_test); \
         auto result = (__VA_ARGS__); \
         if (result != ZE_RESULT_SUCCESS) { \
-            log_error("L0 API call failed with status %s", to_string(result)); \
+            log_skip(RuntimeSkipCategory, "L0 API call failed with status %s", to_string(result)); \
         } \
     } while (0)
 
-/// Macro for call sites. Returns failure if constructed handle is null. Error should've
-/// already been printed by ZE_CHECK_AND_LOG/FAIL macros, so here we just return.
+/// Macro for call sites. Returns skip if constructed handle is null. Error should've
+/// already been printed by ZE_CHECK_AND_LOG/SKIP macros, so here we just return.
 #define CHECK_NULL(handle) \
     do { \
         if (!(handle)) { \
-            return EXIT_FAILURE; \
+            return EXIT_SKIP; \
         } \
     } while (0)
 
@@ -69,7 +70,7 @@ public:
     ) :
         context{context}
     {
-        ZE_CHECK_AND_FAIL(zeMemAllocDevice(context, &desc, size, alignment, device, &data));
+        ZE_CHECK_AND_SKIP(zeMemAllocDevice(context, &desc, size, alignment, device, &data));
     }
 
     ZeDeviceDataPtr(ZeDeviceDataPtr&& other) noexcept :
@@ -110,7 +111,7 @@ class ZeCmdListPtr : public NonCopyable
 {
 public:
     ZeCmdListPtr(ze_context_handle_t context, ze_device_handle_t device, const ze_command_list_desc_t& desc) {
-        ZE_CHECK_AND_FAIL(zeCommandListCreate(context, device, &desc, &cmd_list));
+        ZE_CHECK_AND_SKIP(zeCommandListCreate(context, device, &desc, &cmd_list));
     }
 
     ZeCmdListPtr(ZeCmdListPtr&& other) noexcept:
@@ -184,7 +185,7 @@ inline ZeHostDataPtr ze_alloc_host(ze_context_handle_t context, size_t size,
 {
     ZeHostDataPtrDeleter deleter{context};
     void* data = nullptr;
-    ZE_CHECK_AND_FAIL(zeMemAllocHost(context, &desc, size, alignment, &data));
+    ZE_CHECK_AND_SKIP(zeMemAllocHost(context, &desc, size, alignment, &data));
     return {data, deleter};
 }
 
@@ -204,7 +205,7 @@ inline ZeCmdQueuePtr ze_create_cmd_queue(ze_context_handle_t context, ze_device_
 {
     ZeCmdQueueDeleter deleter{};
     ze_command_queue_handle_t cmd_queue{};
-    ZE_CHECK_AND_FAIL(zeCommandQueueCreate(context, device, &desc, &cmd_queue));
+    ZE_CHECK_AND_SKIP(zeCommandQueueCreate(context, device, &desc, &cmd_queue));
     return {cmd_queue, deleter};
 }
 
@@ -212,7 +213,7 @@ inline ZeFencePtr ze_create_fence(ze_command_queue_handle_t cmd_queue, const ze_
 {
     ZeFenceDeleter deleter{};
     ze_fence_handle_t fence{};
-    ZE_CHECK_AND_FAIL(zeFenceCreate(cmd_queue, &desc, &fence));
+    ZE_CHECK_AND_SKIP(zeFenceCreate(cmd_queue, &desc, &fence));
     return {fence, deleter};
 }
 
@@ -220,7 +221,7 @@ inline ZeContextPtr ze_create_context(ze_driver_handle_t driver, const ze_contex
 {
     ZeContextDeleter deleter{};
     ze_context_handle_t context{};
-    ZE_CHECK_AND_FAIL(zeContextCreate(driver, &desc, &context));
+    ZE_CHECK_AND_SKIP(zeContextCreate(driver, &desc, &context));
     return {context, deleter};
 }
 

--- a/tests/gpu/ze_matmul/ze_matmul.cpp
+++ b/tests/gpu/ze_matmul/ze_matmul.cpp
@@ -54,16 +54,13 @@ int ze_matmul_init(struct test* test)
 
     // TODO: to be put in the common part for each L0 test
     int ret = for_each_ze_device_within_topo([&](ze_device_handle_t device_handle, ze_driver_handle_t driver, const MultiSliceGpu&) {
-        if (!device_handle || !driver)
-            return EXIT_FAILURE;
         data->ze_handles.emplace_back(device_handle);
         data->ze_driver = driver;
         return EXIT_SUCCESS;
     });
     if (ret != EXIT_SUCCESS) {
-        log_error("Devices enumeration failure");
         delete data;
-        return EXIT_FAILURE;
+        return ret;
     }
 
     // We assume homogenous topology
@@ -91,21 +88,21 @@ int ze_matmul_init(struct test* test)
     assert(data->group_count > 0 && data->group_count <= std::numeric_limits<uint32_t>::max());
 
     data->context = ze_create_context(data->ze_driver);
-    if (!data->context) {
+    if (!data->context) { // can't call CHECK_NULL, because we have to also delete data.
         delete data;
-        return EXIT_FAILURE;
+        return EXIT_SKIP;
     }
 
     data->a = ze_alloc_host(data->context.get(), data->size_bytes);
     if (!data->a) {
         delete data;
-        return EXIT_FAILURE;
+        return EXIT_SKIP;
     }
 
     data->b = ze_alloc_host(data->context.get(), data->size_bytes);
     if (!data->b) {
         delete data;
-        return EXIT_FAILURE;
+        return EXIT_SKIP;
     }
     memset_random(data->a.get(), data->size_bytes);
     memset_random(data->b.get(), data->size_bytes);
@@ -130,10 +127,7 @@ int ze_matmul_run(struct test* test, int thread)
     CHECK_NULL(cmd_list);
 
     auto ze_kernel = get_ze_kernel(data->context.get(), device, matmul::kernel_source, matmul::kernel_size, "mxm");
-    if (!ze_kernel) {
-        log_skip(RuntimeSkipCategory, "Kernel instantiation failure");
-        return EXIT_SKIP;
-    }
+    CHECK_NULL(ze_kernel);
 
     // Kernel thread-dispatch
     ze_group_count_t dispatch;

--- a/tests/gpu/ze_matmul/ze_matmul.cpp
+++ b/tests/gpu/ze_matmul/ze_matmul.cpp
@@ -23,6 +23,7 @@
 #include "matmul_source.h" // auto generated file
 
 #include <algorithm>
+#include <memory>
 #include <limits>
 #include <vector>
 
@@ -50,7 +51,7 @@ struct ze_matmul_data
 
 int ze_matmul_init(struct test* test)
 {
-    auto data = new ze_matmul_data;
+    auto data = std::make_unique<ze_matmul_data>();
 
     // TODO: to be put in the common part for each L0 test
     int ret = for_each_ze_device_within_topo([&](ze_device_handle_t device_handle, ze_driver_handle_t driver, const MultiSliceGpu&) {
@@ -59,7 +60,6 @@ int ze_matmul_init(struct test* test)
         return EXIT_SUCCESS;
     });
     if (ret != EXIT_SUCCESS) {
-        delete data;
         return ret;
     }
 
@@ -69,7 +69,6 @@ int ze_matmul_init(struct test* test)
     data->max_group_size = info.compute_properties.maxTotalGroupSize;
     if (data->max_group_size % 16 != 0) {
         log_skip(RuntimeSkipCategory, "Cannot construct matrix");
-        delete data;
         return EXIT_SKIP;
     }
 
@@ -88,26 +87,16 @@ int ze_matmul_init(struct test* test)
     assert(data->group_count > 0 && data->group_count <= std::numeric_limits<uint32_t>::max());
 
     data->context = ze_create_context(data->ze_driver);
-    if (!data->context) { // can't call CHECK_NULL, because we have to also delete data.
-        delete data;
-        return EXIT_SKIP;
-    }
-
+    CHECK_NULL(data->context);
     data->a = ze_alloc_host(data->context.get(), data->size_bytes);
-    if (!data->a) {
-        delete data;
-        return EXIT_SKIP;
-    }
-
+    CHECK_NULL(data->a);
     data->b = ze_alloc_host(data->context.get(), data->size_bytes);
-    if (!data->b) {
-        delete data;
-        return EXIT_SKIP;
-    }
+    CHECK_NULL(data->b);
+
     memset_random(data->a.get(), data->size_bytes);
     memset_random(data->b.get(), data->size_bytes);
 
-    test->data = data;
+    test->data = data.release();
     return EXIT_SUCCESS;
 }
 

--- a/tests/gpu/ze_memcpy/ze_memcpy.cpp
+++ b/tests/gpu/ze_memcpy/ze_memcpy.cpp
@@ -18,6 +18,7 @@
 #include <ze_enumeration.h>
 #include <ze_wrappers.h>
 
+#include <memory>
 #include <limits>
 #include <vector>
 
@@ -35,7 +36,7 @@ struct ze_memcpy_data {
 
 int ze_memcpy_init(struct test* test)
 {
-    auto data = new ze_memcpy_data;
+    auto data = std::make_unique<ze_memcpy_data>();
 
     // TODO: to be put in the common part for each L0 test
     int ret = for_each_ze_device_within_topo([&](ze_device_handle_t device_handle, ze_driver_handle_t driver, const MultiSliceGpu&) {
@@ -44,23 +45,16 @@ int ze_memcpy_init(struct test* test)
         return EXIT_SUCCESS;
     });
     if (ret != EXIT_SUCCESS) {
-        delete data;
         return ret;
     }
 
     data->context = ze_create_context(data->ze_driver);
-    if (!data->context) {
-        delete data;
-        return EXIT_SKIP;
-    }
+    CHECK_NULL(data->context);
     data->golden = ze_alloc_host(data->context.get(), SIZE_BYTES);
-    if (!data->golden) {
-        delete data;
-        return EXIT_SKIP;
-    }
+    CHECK_NULL(data->golden);
     memset_random(data->golden.get(), SIZE_BYTES);
 
-    test->data = data;
+    test->data = data.release();
     return EXIT_SUCCESS;
 }
 

--- a/tests/gpu/ze_memcpy/ze_memcpy.cpp
+++ b/tests/gpu/ze_memcpy/ze_memcpy.cpp
@@ -39,27 +39,24 @@ int ze_memcpy_init(struct test* test)
 
     // TODO: to be put in the common part for each L0 test
     int ret = for_each_ze_device_within_topo([&](ze_device_handle_t device_handle, ze_driver_handle_t driver, const MultiSliceGpu&) {
-        if (!device_handle || !driver)
-            return EXIT_FAILURE;
         data->ze_handles.emplace_back(device_handle);
         data->ze_driver = driver;
         return EXIT_SUCCESS;
     });
     if (ret != EXIT_SUCCESS) {
-        log_error("Devices enumeration failure");
         delete data;
-        return EXIT_FAILURE;
+        return ret;
     }
 
     data->context = ze_create_context(data->ze_driver);
     if (!data->context) {
         delete data;
-        return EXIT_FAILURE;
+        return EXIT_SKIP;
     }
     data->golden = ze_alloc_host(data->context.get(), SIZE_BYTES);
     if (!data->golden) {
         delete data;
-        return EXIT_FAILURE;
+        return EXIT_SKIP;
     }
     memset_random(data->golden.get(), SIZE_BYTES);
 


### PR DESCRIPTION
Previously we treated them as errors, now as skips. The skip reason should propagade down to the caller and do not duplicate on its way. The user's lambdas must provide skip reason only for conditions not handled by framework functions. In non-test scenarios we return `EXIT_FAILURE` as we did before.