### PR TITLE
FW: port `logging_in_test` to common part of the framework

### DIFF
--- a/framework/device/gpu/gpu_device.cpp
+++ b/framework/device/gpu/gpu_device.cpp
@@ -10,8 +10,6 @@
 #include <string>
 #include <print>
 
-bool logging_in_test = false;
-
 std::string device_features_to_string(device_features_t f)
 {
     std::string result;
@@ -52,13 +50,11 @@ void dump_device_info()
 
 TestResult prepare_test_for_device(struct test *test)
 {
-    logging_in_test = true;
     return TestResult::Passed;
 }
 
 void finish_test_for_device(struct test *test)
 {
-    logging_in_test = false;
 }
 
 std::vector<struct test*> special_tests_for_device()

--- a/framework/device/gpu/ze_check.h
+++ b/framework/device/gpu/ze_check.h
@@ -11,33 +11,13 @@
 
 #include <level_zero/ze_api.h>
 
-#include <stdio.h>
-
-extern bool logging_in_test;
-
-/// Log a runtime skip reason during test execution; outside tests, print a quiet message instead.
-#define LOG_RUNTIME_SKIP_OR_PRINT(fmt, ...) \
-    do { \
-        if (!sApp->shmem) { \
-            fprintf(stderr, fmt "\n", ##__VA_ARGS__); \
-        } else if (logging_in_test) { \
-            log_skip(RuntimeSkipCategory, fmt, ##__VA_ARGS__); \
-        } else { \
-            logging_printf(LOG_LEVEL_QUIET, fmt "\n", ##__VA_ARGS__); \
-        } \
-    } while (0)
-
 /// Check return value of an L0 API call.
 /// In test context it returns EXIT_SKIP; outside tests it returns EXIT_FAILURE.
 #define ZE_CHECK(...) \
     do { \
         auto result = (__VA_ARGS__); \
         if (result != ZE_RESULT_SUCCESS) { \
-            LOG_RUNTIME_SKIP_OR_PRINT("L0 API call failed with status %s", to_string(result)); \
-            if (logging_in_test) { \
-                return EXIT_SKIP; \
-            } \
-            return EXIT_FAILURE; \
+            return log_skip_or_print(RuntimeSkipCategory, "L0 API call failed with status %s", to_string(result)); \
         } \
     } while (0)
 

--- a/framework/device/gpu/ze_enumeration.cpp
+++ b/framework/device/gpu/ze_enumeration.cpp
@@ -31,8 +31,7 @@ int for_each_ze_device(const std::function<int(ze_device_handle_t, ze_driver_han
     // Always pick the last ("newest") one.
     auto ze_driver = drivers.back();
     if (!ze_driver) {
-        LOG_RUNTIME_SKIP_OR_PRINT("Could not initialize driver handle");
-        return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+        return log_skip_or_print(RuntimeSkipCategory, "Could not initialize driver handle");
     }
     int gpu_number = 0;
     uint32_t n_devices = 0;
@@ -42,8 +41,7 @@ int for_each_ze_device(const std::function<int(ze_device_handle_t, ze_driver_han
 
     for (int i = 0; i < (int)devices.size(); i++) {
         if (!devices[i]) {
-            LOG_RUNTIME_SKIP_OR_PRINT("Could not initialize device handle");
-            return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+            return log_skip_or_print(RuntimeSkipCategory, "Could not initialize device handle");
         }
         ze_device_properties_t device_properties = { .stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES };
         ZE_CHECK(zeDeviceGetProperties(devices[i], &device_properties));
@@ -78,8 +76,7 @@ int for_each_zes_device(const std::function<int(zes_device_handle_t, ze_driver_h
     int gpu_number = 0;
     for (auto zes_driver: zes_drivers) {
         if (!zes_driver) {
-            LOG_RUNTIME_SKIP_OR_PRINT("Could not initialize driver handle");
-            return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+            return log_skip_or_print(RuntimeSkipCategory, "Could not initialize driver handle");
         }
         uint32_t n_zes_devices = 0;
         ZE_CHECK(zesDeviceGet(zes_driver, &n_zes_devices, nullptr));
@@ -88,8 +85,7 @@ int for_each_zes_device(const std::function<int(zes_device_handle_t, ze_driver_h
 
         for (int i = 0; i < (int)zes_devices.size(); i++) {
             if (!zes_devices[i]) {
-                LOG_RUNTIME_SKIP_OR_PRINT("Could not initialize device handle");
-                return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+                return log_skip_or_print(RuntimeSkipCategory, "Could not initialize device handle");
             }
             zes_device_properties_t device_prop = { .stype = ZES_STRUCTURE_TYPE_DEVICE_PROPERTIES };
             ZE_CHECK(zesDeviceGetProperties(zes_devices[i], &device_prop));
@@ -123,8 +119,7 @@ int find_and_call_func(
     if (it != map.cend()) {
         return func(it->second, ze_driver, indices);
     }
-    LOG_RUNTIME_SKIP_OR_PRINT("Could not find func for device");
-    return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+    return log_skip_or_print(RuntimeSkipCategory, "Could not find func for device");
 }
 
 // XXX depending on API version, ze_device_handle_t and zes_device_handle_t can be the exact same type,

--- a/framework/device/gpu/ze_kernel.h
+++ b/framework/device/gpu/ze_kernel.h
@@ -60,6 +60,8 @@ inline void maybe_destroy_log(ze_module_build_log_handle_t build_log)
     }
 }
 
+extern bool logging_in_test;
+
 /// Function returning an RAII wrapper owning a level-zero kernel (and its module) created from compiled binary source.
 inline ZeKernelPtr get_ze_kernel(ze_context_handle_t context, ze_device_handle_t device, const uint8_t* source, const size_t source_size, const char* name)
 {

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2373,3 +2373,23 @@ TestResult logging_print_results(std::span<const ChildExitStatus> status, const 
 
     return AbstractLogger(test, status).testResult;
 }
+
+/// Logs a skip reason during test execution; outside tests, prints a quiet message instead.
+/// Returns either EXIT_SKIP when logging_in_test, EXIT_FAILURE otherwise.
+int log_skip_or_print(SkipCategory cat, const char *fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    std::string msg = create_filtered_message_string(fmt, va);
+    va_end(va);
+
+    if (!sApp->shmem) {
+        fprintf(stderr, "%s\n", msg.c_str());
+    } else if (logging_in_test) {
+        log_skip(cat, "%s", msg.c_str());
+    } else {
+        logging_printf(LOG_LEVEL_QUIET, "%s\n", msg.c_str());
+    }
+
+    return logging_in_test ? EXIT_SKIP : EXIT_FAILURE;
+}

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -186,6 +186,8 @@ ShortDuration test_timeout(ShortDuration regular_duration)
     return result;
 }
 
+bool logging_in_test = false;
+
 static void preinit_tests()
 {
     struct GroupReplacementEntry {
@@ -215,7 +217,9 @@ static void preinit_tests()
 
         if (test->test_preinit) {
             sApp->main_thread_data()->init();
+            logging_in_test = true;
             preinit_ret = test->test_preinit(test);
+            logging_in_test = false;
             assert(preinit_ret <= EXIT_SUCCESS && "preinit functions cannot fail");
             test->test_preinit = nullptr;   // don't rerun in case the test is re-added
             truncate_log = true;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -617,6 +617,8 @@ extern "C" initfunc group_kvm_init(void) noexcept;
 #endif
 
 /* logging.cpp */
+extern bool logging_in_test;
+
 void log_message_yaml(int thread_num, char levelchar, const char *yaml);
 void log_message_preformatted(int thread_num, LogLevelVerbosity level, std::string_view msg);
 int logging_stdout_fd(void);
@@ -644,6 +646,7 @@ void logging_init(const struct test *test);
 void logging_init_child_preexec();
 void logging_finish();
 TestResult logging_print_results(std::span<const ChildExitStatus> status, const struct test *test);
+int log_skip_or_print(SkipCategory cat, const char *fmt, ...) ATTRIBUTE_PRINTF(2, 3);
 
 /* random.cpp */
 void random_init_global(const char *argument);

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1123,6 +1123,20 @@ static void wait_for_children(ChildrenList &children, const struct test *test)
     }
 }
 
+extern bool logging_in_test;
+
+static TestResult prepare_test_common(struct test *test)
+{
+    logging_in_test = true;
+    return prepare_test_for_device(test);
+}
+
+static void finish_test_common(struct test *test)
+{
+    finish_test_for_device(test);
+    logging_in_test = false;
+}
+
 static TestResult run_one_test_inner(struct test *test, bool init_in_aux_thread = false)
 {
     TestResult state = [&] {
@@ -1131,7 +1145,8 @@ static TestResult run_one_test_inner(struct test *test, bool init_in_aux_thread 
         std::fill_n(test->per_thread, sApp->thread_count, test_data_per_thread{});
         init_per_thread_data();
 
-        TestResult state = prepare_test_for_device(test);
+        TestResult state = prepare_test_common(test);
+        auto finish_test = scopeExit([&] { finish_test_common(test); }); // we can return early
         if (state != TestResult::Passed) {
             return state;
         }
@@ -1199,7 +1214,6 @@ static TestResult run_one_test_inner(struct test *test, bool init_in_aux_thread 
             }
         }
 
-        finish_test_for_device(test);
         sApp->test_tests_finish(test);
         return state;
     }();


### PR DESCRIPTION
This commit also fixes `finish_test_for_device` not being called in case of a fail.
