### PR TITLE
FW: Improve exception handling if a test throws

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -1589,14 +1589,37 @@ function selftest_logerror_common() {
     fail_callback_common
 }
 
+function selftest_cxxthrow_common() {
+    if $is_asan; then
+        skip "Crashing tests skipped with ASAN"
+    fi
+    sandstone_selftest --on-crash=kill -e "$BATS_TEST_DESCRIPTION"
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+    test_yaml_regexp "/tests/0/result" "crash"
+    local seenmessage=false
+    for ((i = 0; i < ${yamldump[/tests/0/threads@len]}; ++i)); do
+        local cpu=${yamldump[/tests/0/threads/$i/thread]}
+        [[ "$cpu" = [0-9]* ]] || continue   # skip main thread
+        # All threads attempt to throw, but not all of them may have done so
+        if [[ -n "${yamldump[/tests/0/threads/$i/messages@len]}" ]]; then
+            test_yaml_regexp "/tests/0/threads/$i/messages/0/level" error
+            test_yaml_regexp "/tests/0/threads/$i/messages/0/text" 'E> Caught C\+\+ exception of type.*'
+            seenmessage=true
+        fi
+    done
+    $seenmessage
+}
 @test "selftest_cxxthrow" {
     declare -A yamldump
-    selftest_logerror_common selftest_cxxthrow 'Caught C\+\+ exception: .*'
+    selftest_cxxthrow_common
 }
-
 @test "selftest_cxxthrow_with_cb" {
     declare -A yamldump
-    selftest_logerror_common selftest_cxxthrow_with_cb 'Caught C\+\+ exception: .*'
+    # Because this is a crash, we could race between one thread doing abort() and
+    # another running the callbacks. Therefore, we run just one.
+    MAX_PROC=1
+    selftest_cxxthrow_common
     fail_callback_common
 }
 

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -21,9 +21,11 @@
 #include "logging.h"
 #include "device/logging_device.h"
 
+#include <exception>
 #include <limits>
 #include <string>
 #include <string_view>
+#include <typeinfo>
 #include <unordered_set>
 
 #include <assert.h>
@@ -116,6 +118,7 @@ enum class AbstractLogger::LogTypes : uint8_t
 };
 using LogTypes = AbstractLogger::LogTypes;
 
+static void terminate_handler() noexcept;
 static SandstoneApplication::OutputFormat current_output_format()
 {
     if (SandstoneConfig::NoLogging)
@@ -405,6 +408,7 @@ void logging_init_global_child()
     logging_printf(LOG_LEVEL_QUIET, "# stdout is expected to be connected to " _PATH_DEVNULL
                    " so you should never see this message\n");
 #endif
+    std::set_terminate(terminate_handler);
 }
 
 static bool should_log_to_file()
@@ -550,6 +554,7 @@ void logging_init_global(void)
 #ifdef __GLIBC__
     setenv("LIBC_FATAL_STDERR_", "1", true);
 #endif
+    std::set_terminate(terminate_handler);
 }
 
 int logging_close_global(int exitcode)
@@ -783,6 +788,39 @@ void logging_printf(LogLevelVerbosity level, const char *fmt, ...)
         log_message_to_syslog(msg.c_str());
 }
 #endif /* SANDSTONE_NO_LOGGING */
+
+static void terminate_handler() noexcept
+{
+    if (sApp->shmem->cfg.ud_on_failure)
+        ud2();
+    logging_mark_thread_failed(thread_num);
+    // the rest of the setting up the error state is done by log_message below
+
+    std::string msg;
+    if (current_output_format() == SandstoneApplication::OutputFormat::no_output) {
+        msg = SANDSTONE_LOG_ERROR;
+    } else if (std::exception_ptr ex = std::current_exception()) {
+        // get some information about the current exception
+        msg = SANDSTONE_LOG_ERROR "Caught C++ exception of type ";
+
+        try {
+            throw;  // rethrow
+        } catch (std::exception &e) {
+            msg += typeid(e).name();
+            if (std::string_view what = e.what(); what.size()) {
+                msg += ": ";
+                msg += what;
+            }
+        } catch (...) {
+            msg += "<unknown>";
+        }
+    }
+    if (msg.empty())
+        msg = SANDSTONE_LOG_ERROR "std::terminate() called without an exception";
+
+    log_message_preformatted(thread_num, msg);
+    abort();
+}
 
 static std::string kernel_info()
 {

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -27,6 +27,9 @@
 #include <string_view>
 #include <typeinfo>
 #include <unordered_set>
+#if __has_include(<cxxabi.h>)
+#  include <cxxabi.h>
+#endif
 
 #include <assert.h>
 #include <errno.h>
@@ -802,17 +805,30 @@ static void terminate_handler() noexcept
     } else if (std::exception_ptr ex = std::current_exception()) {
         // get some information about the current exception
         msg = SANDSTONE_LOG_ERROR "Caught C++ exception of type ";
+        bool appended_name = [&] {
+            int status = -1;
+#if __has_include(<cxxabi.h>)
+            const std::type_info *ti = ex.__cxa_exception_type();
+            char *demangled = abi::__cxa_demangle(ti->name(), nullptr, nullptr, &status);
+            if (status == 0)
+                msg += demangled;
+            free(demangled);
+#endif
+            return status == 0;
+        }();
 
         try {
             throw;  // rethrow
         } catch (std::exception &e) {
-            msg += typeid(e).name();
+            if (!appended_name)
+                msg += typeid(e).name();
             if (std::string_view what = e.what(); what.size()) {
                 msg += ": ";
                 msg += what;
             }
         } catch (...) {
-            msg += "<unknown>";
+            if (!appended_name)
+                msg += "<unknown>";
         }
     }
     if (msg.empty())

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -96,6 +96,11 @@ int open_memfd(enum MemfdCloexecFlag);
 */
 void dump_device_info();
 
+static inline __attribute__((always_inline, noreturn)) void ud2()
+{
+    __builtin_trap();
+    __builtin_unreachable();
+}
 #ifdef __cplusplus
 }
 

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -723,7 +723,7 @@ static uintptr_t thread_runner(int thread_number)
     random_init_thread(thread_number);
     int ret = EXIT_FAILURE;
 
-    auto cleanup = scopeExit([&] {
+    auto cleanup = [&] {
         // let SIGQUIT handler know we're done
         ThreadState new_state = thread_failed;
         if (!this_thread->has_failed()) {
@@ -747,25 +747,23 @@ static uintptr_t thread_runner(int thread_number)
         // If rescheduling, do cleanup
         if (device_scheduler)
             device_scheduler->finish_reschedule();
-    });
-
-    // indicate to SIGQUIT handler that we're running
-    this_thread->thread_state.store(thread_running, std::memory_order_relaxed);
+    };
 
 #if SANDSTONE_DEVICE_CPU
     CPUTimeFreqStamp before;
     before.Snapshot(thread_number);
 #endif
-    test_start();
 
-    try {
+    {
+        auto e = scopeExit(std::move(cleanup));
+        // indicate to SIGQUIT handler that we're running
+        this_thread->thread_state.store(thread_running, std::memory_order_relaxed);
+
+        test_start();
         ret = test_run_wrapper_function(current_test, thread_number);
-    } catch (std::exception &e) {
-        log_error("Caught C++ exception: \"%s\" (type '%s')", e.what(), typeid(e).name());
-        // no rethrow
-    }
 
-    cleanup.run_now();
+        // cleanup resets thread_state
+    }
 
 #if SANDSTONE_DEVICE_CPU
     CPUTimeFreqStamp after;

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -169,12 +169,6 @@ static void merge_test_result(ChildExitStatus &current, const ChildExitStatus& i
     current.endtime = MonotonicTimePoint::clock::now();
 }
 
-static inline __attribute__((always_inline, noreturn)) void ud2()
-{
-    __builtin_trap();
-    __builtin_unreachable();
-}
-
 static void __attribute__((noreturn)) report_fail_common()
 {
     logging_mark_thread_failed(thread_num);


### PR DESCRIPTION
The rule of thumb for C++ exceptions is that you should only catch them if you're going to continue normally; otherwise, it's often better to leave them uncaught so we get a backtrace of the throw point. This PR implements that by installing a `std::terminate()` handler and removing the `try`/`catch` block in `thread_runner()`.

That's what we get now. For example (trimmed):
```yaml
tests:
- test: selftest_cxxthrow
  details: { quality: production, description: "Throws C++ exception" }
  state: { seed: 'LCG:1177949238', iteration: 0, retry: false }
  time-at-start: { elapsed:      0.000, now: !!timestamp '2026-06-26T20:40:06Z' }
  result: crash
  result-details: { crashed: true, core-dump: true, code: 6, reason: 'Aborted' }
  fail: { cpu-mask: 'XXXX', time-to-fail: null, seed: 'LCG:1177949238'}
  time-at-end:   { elapsed:   1262.018, now: !!timestamp '2026-06-26T20:40:08Z' }
  test-runtime: 1261.631
  threads:
  - thread: main
    runtime: 1261.625
    resource-usage: { utime: 1.600, stime: 1.600, cpuavg: 0.3, maxrss: 4816, majflt: 0, minflt: 133, voluntary-cs: 58, involutary-cs: 7 }
    messages:
    - level: info
      text: |1
       Backtrace:
       Thread 9 (Thread 0x7fe18bffd6c0 (LWP 834316) "selftest_cxxthr"):
       #0  0x00007fe193ca4252 in __syscall_cancel_arch () from /lib64/libc.so.6
       #1  0x00007fe193c97dd8 in __internal_syscall_cancel () from /lib64/libc.so.6
       #2  0x00007fe193c97e31 in __syscall_cancel () from /lib64/libc.so.6
       #3  0x00007fe193d1192a in poll () from /lib64/libc.so.6
       #4  0x0000556ed80ce5ee in child_crash_handler (signum=6, si=0x7fe18bffbf30, ucontext=0x7fe18bffbe00) at framework/sysdeps/unix/child_debug.cpp:255
       #5  <signal handler called>
       #6  0x00007fe193c9d87c in __pthread_kill_implementation () from /lib64/libc.so.6
       #7  0x00007fe193c424c6 in raise () from /lib64/libc.so.6
       #8  0x00007fe193c293a0 in abort () from /lib64/libc.so.6
       #9  0x0000556ed8029b5b in terminate_handler () at framework/logging.cpp:828
               msg = "E> Caught C++ exception of type '17SelftestException': OpenDCDiag C++ selftest exception"
       #10 0x00007fe1940cad9c in ?? () from /lib64/libstdc++.so.6
       #11 0x00007fe1940b6cd9 in std::terminate() () from /lib64/libstdc++.so.6
       #12 0x00007fe1940cb048 in __cxa_throw () from /lib64/libstdc++.so.6
       #13 0x0000556ed80bd7b0 in selftest_cxxthrow_run () at framework/selftest.cpp:830
  - thread: 0
    id: { logical: 0, package: 0, numa_node: 0, module: 0, core: 0, thread: 0, family: 6, model: 0x8c, stepping: 1, microcode: 0xbe, ppin: null }
    state: failed
    time-to-fail: 1.905
    loop-count: 0
    freq_mhz: 0.0
    messages:
    - { level: error, text: 'E> Caught C++ exception of type ''SelftestException'': OpenDCDiag C++ selftest exception' }
```
