### PR TITLE
FW: Fix bug in `log_error()` not marking failure in no-logging mode

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -70,7 +70,14 @@ jobs:
           for t; do
             builddir/opendcdiag --quick --selftests -e "$t" -o -
           done
-          builddir/opendcdiag --quick --selftests -e selftest_failinit && exit 1 || [[ $? = 1 ]]
+          set selftest_failinit selftest_logerror
+          for t; do
+            if builddir/opendcdiag --quick --retest-on-failure=0 --selftests -e "$t" -o -; then
+              exit 1
+            else
+              [[ $? = 1 ]]
+            fi
+          done
       - name: run selftests
         if: ${{ matrix.selftests }}
         shell: bash

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -682,7 +682,7 @@ static void log_message_preformatted(int thread_num, std::string_view msg)
     LogLevelVerbosity level = status_level(msg[0]);
     bool is_error = msg[0] == 'E';
     if (is_error)
-        logging_mark_thread_failed(thread_num);
+        assert(sApp->thread_data(thread_num)->has_failed());
 
     log_message_preformatted(thread_num, level, msg);
     if (is_error)
@@ -1018,24 +1018,27 @@ void logging_finish()
 {
 }
 
-static inline void assert_log_message(const char *fmt)
+// returns true if we are done and no logging is required
+static inline bool message_common_check(int thread_num, const char *fmt)
 {
     assert(fmt);
     assert(fmt[0] == 'd' || fmt[0] == 'I' || fmt[0] == 'W' || fmt[0] == 'E');
     assert(fmt[1] == '>');
     assert(fmt[2] == ' ');
-    (void)fmt;  // for release builds
+
+    if (!SandstoneConfig::Debug && *fmt == 'd')
+        return true;       /* no Debug in non-debug build */
+    if (*fmt == 'E')
+        logging_mark_thread_failed(thread_num);
+    return current_output_format() == SandstoneApplication::OutputFormat::no_output;
 }
 
 #undef log_platform_message
 void log_platform_message(const char *fmt, ...)
 {
-    if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
+    if (message_common_check(thread_num, fmt))
         return;
 
-    assert_log_message(fmt);
-    if (!SandstoneConfig::Debug && *fmt == 'd')
-        return;         /* no Debug in non-debug build */
     va_list va;
     va_start(va, fmt);
     std::string msg = create_filtered_message_string(fmt, va);
@@ -1070,12 +1073,9 @@ void log_message_skip(int thread_num, SkipCategory category, const char *fmt, ..
 #undef log_message
 void log_message(int thread_num, const char *fmt, ...)
 {
-    if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
+    if (message_common_check(thread_num, fmt))
         return;
 
-    assert_log_message(fmt);
-    if (!SandstoneConfig::Debug && *fmt == 'd')
-        return;         /* no Debug in non-debug build */
     va_list va;
     va_start(va, fmt);
     std::string msg = create_filtered_message_string(fmt, va);


### PR DESCRIPTION
I'm not sure how long this has been broken. Possibly forever. In no- logging mode, `log_message()` performed an early return and never marked the thread as failed. If the test did not do `return EXIT_FAILURE`, the framework would conclude the test had passed.

This can be seen with the `selftest_logerror` selftest. In YAML mode
```yaml
tests:
- test: selftest_logerror
  details: { quality: production, description: "Fails by calling log_error()" }
  state: { seed: 'AES:02911b9aed7ac2c6c5991e77805f259dfd6ee46512853d393a66e1887fa0da62', iteration: 0, retry: false }
  time-at-start: { elapsed:      0.000, now: !!timestamp '2026-06-26T21:25:05Z' }
  result: fail
  fail: { cpu-mask: 'X', time-to-fail: 1.705, seed: 'AES:02911b9aed7ac2c6c5991e77805f259dfd6ee46512853d393a66e1887fa0da62'}
  time-at-end:   { elapsed:      2.000, now: !!timestamp '2026-06-26T21:25:05Z' }
  test-runtime: 1.988
  threads:
  - thread: 0
    id: { logical: 0, package: 0, numa_node: 0, module: 0, core: 0, thread: 0, family: 6, model: 0x8c, stepping: 1, microcode: 0xbe, ppin: null }
    state: failed
    time-to-fail: 1.705
    loop-count: 0
    messages:
    - { level: error, text: 'E> This is an error message from CPU 0' }
    - { level: error, text: 'E> This is an another error message' }
exit: fail
```

But in no-logging mode:
```
$ ./opendcdiag --selftests --retest-on-failure=0 -e selftest_logerror -o - -n1 --output-format=none
exit: pass
```

Now:
```
$ ./opendcdiag --selftests --retest-on-failure=0 -e selftest_logerror -o - -n1 --output-format=none
exit: fail
```