### PR TITLE
FW/x86: modernise the `sandstone_context_dump()` code with `<format>`

### DIFF
--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -4,8 +4,6 @@
  */
 
 #include "sandstone_context_dump.h"
-#include "sandstone_utils.h"
-#include "sandstone.h"
 
 #ifdef __x86_64__
 #include "amx_common.h"
@@ -14,6 +12,7 @@
 
 #include <algorithm>
 #include <array>
+#include <format>
 #include <limits>
 
 #ifdef __unix__
@@ -172,34 +171,34 @@ static void print_flag_description(std::string &f, uint64_t value, T (&array)[N]
 
 static void print_gpr(std::string &f, const char *name, int64_t value)
 {
-    f += stdprintf(" %-5s = 0x%016" PRIx64, name, value);
+    f += std::format(" {:<5} = 0x{:016x}", name, uint64_t(value));
     if (value <= 4096 && value >= -4096)
-        f += stdprintf(" (%d)", int(value));
+        f += std::format(" ({})", int(value));
     f += '\n';
 }
 
 static void print_rip(std::string &f, uintptr_t rip)
 {
-    f += stdprintf(" %-5s = 0x%016tx", "rip", rip);
+    f += std::format(" {:<5} = 0x{:016x}", "rip", rip);
 #ifdef __unix__
     uint8_t *ptr = reinterpret_cast<uint8_t *>(rip);
     Dl_info dli;
     if (dladdr(ptr, &dli) && dli.dli_sname)
-        f += stdprintf(" <%s+%#tx>", dli.dli_sname, ptr - static_cast<uint8_t *>(dli.dli_saddr));
+        f += std::format(" <{}+{:#x}>", dli.dli_sname, ptr - static_cast<uint8_t *>(dli.dli_saddr));
 #endif
     f += '\n';
 }
 
 static void print_eflags(std::string &f, uint64_t value)
 {
-    f += stdprintf(" flags = 0x%08" PRIx64 " [ ", value);
+    f += std::format(" flags = 0x{:08x} [ ", value);
     print_flag_description(f, value, eflags);
     f += "]\n";
 }
 
 static void print_segment(std::string &f, const char *name, uint16_t value)
 {
-    f += stdprintf(" %-5s = 0x%x\n", name, value);
+    f += std::format(" {:<5} = 0x{:x}\n", name, value);
 }
 
 #if defined(__linux__)
@@ -361,9 +360,9 @@ static void print_egprs(std::string &f, const Fxsave *state)
 static void print_x87mmx_registers(std::string &f, const Fxsave *state)
 {
     int fptop = (state->fsw >> 11) & 7;
-    f += stdprintf(" fcw   = %#x\n fsw   = %#x [ ", state->fcw, state->fsw);
+    f += std::format(" fcw   = {:#x}\n fsw   = {:#x} [ ", state->fcw, state->fsw);
     print_flag_description(f, state->fsw, fsw);
-    f += stdprintf("top=%d ]\n ftw   = %#x\n", fptop, state->ftw);
+    f += std::format("top={} ]\n ftw   = {:#x}\n", fptop, state->ftw);
 
     if (state->ftw == 0)
         return;                 // no tags, nothing to display, so save space
@@ -374,7 +373,7 @@ static void print_x87mmx_registers(std::string &f, const Fxsave *state)
         effective = i;
 
         auto st = state->st + effective;
-        f += stdprintf(" st(%zu) = %04x%016" PRIx64 " (%La)\n",
+        f += std::format(" st({}) = {:04x}{:016x} ({:a})\n",
                 i, st->as_hex.high16, st->as_hex.low64, st->as_float);
     }
 }
@@ -383,15 +382,15 @@ static void print_xmm_register(std::string &f, const xmmreg &ptr)
 {
     uint64_t low = uint64_t(ptr.u);
     uint64_t high = uint64_t(ptr.u >> 8 * sizeof(low));
-    f += stdprintf("%016" PRIx64 ":%016" PRIx64 " ", high, low);
+    f += std::format("{:016x}:{:016x} ", high, low);
 }
 
 static void print_avx_registers(std::string &f, const Fxsave *state, XSave mask)
 {
     // start with the MXCSR
-    f += stdprintf(" mxcsr = 0x%08x [ ", state->mxcsr);
+    f += std::format(" mxcsr = 0x{:08x} [ ", state->mxcsr);
     print_flag_description(f, state->mxcsr, mxcsr);
-    f += stdprintf("RC=%s ]\n", rounding_modes[(state->mxcsr & _MM_ROUND_MASK) / _MM_ROUND_DOWN]);
+    f += std::format("RC={} ]\n", rounding_modes[(state->mxcsr & _MM_ROUND_MASK) / _MM_ROUND_DOWN]);
 
     char nameprefix = 'x';
     auto base = reinterpret_cast<const uint8_t *>(state);
@@ -420,7 +419,7 @@ static void print_avx_registers(std::string &f, const Fxsave *state, XSave mask)
     }
 
     for (int i = 0; i < int(std::size(state->xmm)); ++i) {
-        f += stdprintf(" %cmm%-2d = ", nameprefix, i);
+        f += std::format(" {}mm{:<2} = ", nameprefix, i);
         if (zmmhstate) {
             print_xmm_register(f, zmmhstate[i].xmm[1]);
             print_xmm_register(f, zmmhstate[i].xmm[0]);
@@ -432,13 +431,13 @@ static void print_avx_registers(std::string &f, const Fxsave *state, XSave mask)
     }
     for (int i = 0; hizmmstate && i < 16; ++i) {
         nameprefix = 'z';
-        f += stdprintf(" %cmm%-2d = ", nameprefix, i + 16);
+        f += std::format(" {}mm{:<2} = ", nameprefix, i + 16);
         for (int j = std::size(hizmmstate->xmm) - 1; j >= 0; --j)
             print_xmm_register(f, hizmmstate[i].xmm[j]);
         f += '\n';
     }
     for (int i = 0; opmaskstate && i < 8; ++i)
-        f += stdprintf("    k%d = 0x%016" PRIx64 "\n", i, uint64_t(opmaskstate[i]));
+        f += std::format("    k{} = 0x{:016x}\n", i, uint64_t(opmaskstate[i]));
 }
 
 static void print_amx_tiles_palette1(std::string &f, const Fxsave *state, const amx_tileconfig *tileconfig)
@@ -459,19 +458,19 @@ static void print_amx_tiles_palette1(std::string &f, const Fxsave *state, const 
 
     auto base = reinterpret_cast<const uint8_t *>(state) + offset;
     for (int reg = 0; reg < info.max_names; ++reg) {
-        f += stdprintf(" tmm%-2d =", reg);
+        f += std::format(" tmm{:<2} =", reg);
         if (tileconfig->rows[reg] == 0) {
-            f += stdprintf(" <0 rows>\n");
+            f += " <0 rows>\n";
             continue;
         }
 
         const uint8_t *tiledata = base + reg * info.bytes_per_tile;
         for (int row = 0; row < tileconfig->rows[reg]; ++row) {
             const uint8_t *rowdata = tiledata + row * info.bytes_per_row;
-            f += stdprintf(" %d: {", row);
+            f += std::format(" {}: {{", row);
             for (int i = 0; i < tileconfig->colsb[reg]; ++i)
-                f += stdprintf(" %02x", rowdata[i]);
-            f += stdprintf(" }\n");
+                f += std::format(" {:02x}", rowdata[i]);
+            f += " }\n";
         }
     }
 }
@@ -484,9 +483,9 @@ static void print_amx_state(std::string &f, const Fxsave *state, XSave mask)
 
     auto base = reinterpret_cast<const uint8_t *>(state);
     auto tileconfig = reinterpret_cast<const amx_tileconfig *>(base + offset);
-    f += stdprintf(" xtilecfg = palette: %u, start_row: %u\n", tileconfig->palette, tileconfig->start_row);
+    f += std::format(" xtilecfg = palette: {}, start_row: {}\n", tileconfig->palette, tileconfig->start_row);
     for (size_t i = 0; i < std::size(tileconfig->colsb); ++i)
-        f += stdprintf("            tile%-2zu { colsb: %u, rows: %u }\n",
+        f += std::format("            tile{:<2} {{ colsb: {}, rows: {} }}\n",
                 i, tileconfig->colsb[i], tileconfig->rows[i]);
 
     if (mask & XSave::Xtiledata) {

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -487,7 +487,10 @@ static void print_amx_tiles_palette1(std::string &f, const Fxsave *state, const 
         const uint8_t *tiledata = base + reg * info.bytes_per_tile;
         for (int row = 0; row < tileconfig->rows[reg]; ++row) {
             const uint8_t *rowdata = tiledata + row * info.bytes_per_row;
-            append_format(f, " {}: {{", row);
+            if (row == 0)
+                append_format(f, " {:2}: {{", row);
+            else
+                append_format(f, "         {:2}: {{", row);
             for (int i = 0; i < tileconfig->colsb[reg]; ++i)
                 append_format(f, " {:02x}", rowdata[i]);
             f += " }\n";

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -15,6 +15,7 @@
 #include <format>
 #include <iterator>
 #include <limits>
+#include <span>
 #include <string_view>
 #include <utility>
 
@@ -151,6 +152,33 @@ static constexpr char rounding_modes[][9] = {
     "nearest", "down", "up", "truncate"
 };
 
+struct FlagBits
+{
+    uint64_t value;
+    std::span<const char4> names;
+};
+
+template <>
+struct std::formatter<FlagBits>
+{
+    constexpr auto parse(std::format_parse_context &ctx) { return ctx.begin(); }
+    auto format(const FlagBits &fb, std::format_context &ctx) const
+    {
+        auto out = ctx.out();
+        bool any = false;
+        for (size_t i = 0; i < fb.names.size(); ++i) {
+            if ((fb.value >> i & 1) && fb.names[i][0]) {
+                if (!any) {
+                    *out++ = ' ';
+                    any = true;
+                }
+                out = std::format_to(out, "{} ", std::string_view(fb.names[i]));
+            }
+        }
+        return out;
+    }
+};
+
 static ptrdiff_t xsave_offset(XSave bit)
 {
     int n = __bsfd(bit);
@@ -163,19 +191,6 @@ template <typename... Args>
 static void append_format(std::string &f, std::format_string<Args...> fmt, Args &&... args)
 {
     std::format_to(std::back_inserter(f), fmt, std::forward<Args>(args)...);
-}
-
-template <int N, typename T>
-static void print_flag_description(std::string &f, uint64_t value, T (&array)[N])
-{
-    for (size_t i = 0; i < std::size(array); ++i) {
-        uint64_t bit = UINT64_C(1) << i;
-        const char *name = array[i];
-        if ((value & bit) && *name) {
-            f += name;
-            f += ' ';
-        }
-    }
 }
 
 static void print_gpr(std::string &f, const char *name, int64_t value)
@@ -200,9 +215,7 @@ static void print_rip(std::string &f, uintptr_t rip)
 
 static void print_eflags(std::string &f, uint64_t value)
 {
-    append_format(f, " flags = 0x{:08x} [ ", value);
-    print_flag_description(f, value, eflags);
-    f += "]\n";
+    append_format(f, " flags = 0x{:08x} [{}]\n", value, FlagBits{value, eflags});
 }
 
 static void print_segment(std::string &f, const char *name, uint16_t value)
@@ -369,9 +382,8 @@ static void print_egprs(std::string &f, const Fxsave *state)
 static void print_x87mmx_registers(std::string &f, const Fxsave *state)
 {
     int fptop = (state->fsw >> 11) & 7;
-    append_format(f, " fcw   = {:#x}\n fsw   = {:#x} [ ", state->fcw, state->fsw);
-    print_flag_description(f, state->fsw, fsw);
-    append_format(f, "top={} ]\n ftw   = {:#x}\n", fptop, state->ftw);
+    append_format(f, " fcw   = {:#x}\n fsw   = {:#x} [{}top={} ]\n ftw   = {:#x}\n",
+            state->fcw, state->fsw, FlagBits{state->fsw, fsw}, fptop, state->ftw);
 
     if (state->ftw == 0)
         return;                 // no tags, nothing to display, so save space
@@ -397,9 +409,8 @@ static void print_xmm_register(std::string &f, const xmmreg &ptr)
 static void print_avx_registers(std::string &f, const Fxsave *state, XSave mask)
 {
     // start with the MXCSR
-    append_format(f, " mxcsr = 0x{:08x} [ ", state->mxcsr);
-    print_flag_description(f, state->mxcsr, mxcsr);
-    append_format(f, "RC={} ]\n", rounding_modes[(state->mxcsr & _MM_ROUND_MASK) / _MM_ROUND_DOWN]);
+    append_format(f, " mxcsr = 0x{:08x} [{}RC={} ]\n", state->mxcsr,
+            FlagBits{state->mxcsr, mxcsr}, rounding_modes[(state->mxcsr & _MM_ROUND_MASK) / _MM_ROUND_DOWN]);
 
     char nameprefix = 'x';
     auto base = reinterpret_cast<const uint8_t *>(state);

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -13,7 +13,10 @@
 #include <algorithm>
 #include <array>
 #include <format>
+#include <iterator>
 #include <limits>
+#include <string_view>
+#include <utility>
 
 #ifdef __unix__
 #  include <dlfcn.h>
@@ -156,6 +159,12 @@ static ptrdiff_t xsave_offset(XSave bit)
     return ebx;
 };
 
+template <typename... Args>
+static void append_format(std::string &f, std::format_string<Args...> fmt, Args &&... args)
+{
+    std::format_to(std::back_inserter(f), fmt, std::forward<Args>(args)...);
+}
+
 template <int N, typename T>
 static void print_flag_description(std::string &f, uint64_t value, T (&array)[N])
 {
@@ -171,34 +180,34 @@ static void print_flag_description(std::string &f, uint64_t value, T (&array)[N]
 
 static void print_gpr(std::string &f, const char *name, int64_t value)
 {
-    f += std::format(" {:<5} = 0x{:016x}", name, uint64_t(value));
+    append_format(f, " {:<5} = 0x{:016x}", name, uint64_t(value));
     if (value <= 4096 && value >= -4096)
-        f += std::format(" ({})", int(value));
+        append_format(f, " ({})", int(value));
     f += '\n';
 }
 
 static void print_rip(std::string &f, uintptr_t rip)
 {
-    f += std::format(" {:<5} = 0x{:016x}", "rip", rip);
+    append_format(f, " {:<5} = 0x{:016x}", "rip", rip);
 #ifdef __unix__
     uint8_t *ptr = reinterpret_cast<uint8_t *>(rip);
     Dl_info dli;
     if (dladdr(ptr, &dli) && dli.dli_sname)
-        f += std::format(" <{}+{:#x}>", dli.dli_sname, ptr - static_cast<uint8_t *>(dli.dli_saddr));
+        append_format(f, " <{}+{:#x}>", dli.dli_sname, ptr - static_cast<uint8_t *>(dli.dli_saddr));
 #endif
     f += '\n';
 }
 
 static void print_eflags(std::string &f, uint64_t value)
 {
-    f += std::format(" flags = 0x{:08x} [ ", value);
+    append_format(f, " flags = 0x{:08x} [ ", value);
     print_flag_description(f, value, eflags);
     f += "]\n";
 }
 
 static void print_segment(std::string &f, const char *name, uint16_t value)
 {
-    f += std::format(" {:<5} = 0x{:x}\n", name, value);
+    append_format(f, " {:<5} = 0x{:x}\n", name, value);
 }
 
 #if defined(__linux__)
@@ -360,9 +369,9 @@ static void print_egprs(std::string &f, const Fxsave *state)
 static void print_x87mmx_registers(std::string &f, const Fxsave *state)
 {
     int fptop = (state->fsw >> 11) & 7;
-    f += std::format(" fcw   = {:#x}\n fsw   = {:#x} [ ", state->fcw, state->fsw);
+    append_format(f, " fcw   = {:#x}\n fsw   = {:#x} [ ", state->fcw, state->fsw);
     print_flag_description(f, state->fsw, fsw);
-    f += std::format("top={} ]\n ftw   = {:#x}\n", fptop, state->ftw);
+    append_format(f, "top={} ]\n ftw   = {:#x}\n", fptop, state->ftw);
 
     if (state->ftw == 0)
         return;                 // no tags, nothing to display, so save space
@@ -373,7 +382,7 @@ static void print_x87mmx_registers(std::string &f, const Fxsave *state)
         effective = i;
 
         auto st = state->st + effective;
-        f += std::format(" st({}) = {:04x}{:016x} ({:a})\n",
+        append_format(f, " st({}) = {:04x}{:016x} ({:a})\n",
                 i, st->as_hex.high16, st->as_hex.low64, st->as_float);
     }
 }
@@ -382,15 +391,15 @@ static void print_xmm_register(std::string &f, const xmmreg &ptr)
 {
     uint64_t low = uint64_t(ptr.u);
     uint64_t high = uint64_t(ptr.u >> 8 * sizeof(low));
-    f += std::format("{:016x}:{:016x} ", high, low);
+    append_format(f, "{:016x}:{:016x} ", high, low);
 }
 
 static void print_avx_registers(std::string &f, const Fxsave *state, XSave mask)
 {
     // start with the MXCSR
-    f += std::format(" mxcsr = 0x{:08x} [ ", state->mxcsr);
+    append_format(f, " mxcsr = 0x{:08x} [ ", state->mxcsr);
     print_flag_description(f, state->mxcsr, mxcsr);
-    f += std::format("RC={} ]\n", rounding_modes[(state->mxcsr & _MM_ROUND_MASK) / _MM_ROUND_DOWN]);
+    append_format(f, "RC={} ]\n", rounding_modes[(state->mxcsr & _MM_ROUND_MASK) / _MM_ROUND_DOWN]);
 
     char nameprefix = 'x';
     auto base = reinterpret_cast<const uint8_t *>(state);
@@ -419,7 +428,7 @@ static void print_avx_registers(std::string &f, const Fxsave *state, XSave mask)
     }
 
     for (int i = 0; i < int(std::size(state->xmm)); ++i) {
-        f += std::format(" {}mm{:<2} = ", nameprefix, i);
+        append_format(f, " {}mm{:<2} = ", nameprefix, i);
         if (zmmhstate) {
             print_xmm_register(f, zmmhstate[i].xmm[1]);
             print_xmm_register(f, zmmhstate[i].xmm[0]);
@@ -431,13 +440,13 @@ static void print_avx_registers(std::string &f, const Fxsave *state, XSave mask)
     }
     for (int i = 0; hizmmstate && i < 16; ++i) {
         nameprefix = 'z';
-        f += std::format(" {}mm{:<2} = ", nameprefix, i + 16);
+        append_format(f, " {}mm{:<2} = ", nameprefix, i + 16);
         for (int j = std::size(hizmmstate->xmm) - 1; j >= 0; --j)
             print_xmm_register(f, hizmmstate[i].xmm[j]);
         f += '\n';
     }
     for (int i = 0; opmaskstate && i < 8; ++i)
-        f += std::format("    k{} = 0x{:016x}\n", i, uint64_t(opmaskstate[i]));
+        append_format(f, "    k{} = 0x{:016x}\n", i, uint64_t(opmaskstate[i]));
 }
 
 static void print_amx_tiles_palette1(std::string &f, const Fxsave *state, const amx_tileconfig *tileconfig)
@@ -458,7 +467,7 @@ static void print_amx_tiles_palette1(std::string &f, const Fxsave *state, const 
 
     auto base = reinterpret_cast<const uint8_t *>(state) + offset;
     for (int reg = 0; reg < info.max_names; ++reg) {
-        f += std::format(" tmm{:<2} =", reg);
+        append_format(f, " tmm{:<2} =", reg);
         if (tileconfig->rows[reg] == 0) {
             f += " <0 rows>\n";
             continue;
@@ -467,9 +476,9 @@ static void print_amx_tiles_palette1(std::string &f, const Fxsave *state, const 
         const uint8_t *tiledata = base + reg * info.bytes_per_tile;
         for (int row = 0; row < tileconfig->rows[reg]; ++row) {
             const uint8_t *rowdata = tiledata + row * info.bytes_per_row;
-            f += std::format(" {}: {{", row);
+            append_format(f, " {}: {{", row);
             for (int i = 0; i < tileconfig->colsb[reg]; ++i)
-                f += std::format(" {:02x}", rowdata[i]);
+                append_format(f, " {:02x}", rowdata[i]);
             f += " }\n";
         }
     }
@@ -483,9 +492,9 @@ static void print_amx_state(std::string &f, const Fxsave *state, XSave mask)
 
     auto base = reinterpret_cast<const uint8_t *>(state);
     auto tileconfig = reinterpret_cast<const amx_tileconfig *>(base + offset);
-    f += std::format(" xtilecfg = palette: {}, start_row: {}\n", tileconfig->palette, tileconfig->start_row);
+    append_format(f, " xtilecfg = palette: {}, start_row: {}\n", tileconfig->palette, tileconfig->start_row);
     for (size_t i = 0; i < std::size(tileconfig->colsb); ++i)
-        f += std::format("            tile{:<2} {{ colsb: {}, rows: {} }}\n",
+        append_format(f, "            tile{:<2} {{ colsb: {}, rows: {} }}\n",
                 i, tileconfig->colsb[i], tileconfig->rows[i]);
 
     if (mask & XSave::Xtiledata) {


### PR DESCRIPTION
`stdprintf()` is a hack. While `snprintf()` produces less bloated code than `std::format_to()`, our `stdprintf()` solution formats to `std::string` each time, possibly allocating memory, then appends to the resulting string. `std::format_to()` will directly append to it. It could be better if there were a way for it to realise the output is a `std::string`, but the need for the `std::back_inserter()` middle-man hides that information.

Drive-by align the AMX rows in each tile, which is what got me to look at this code in the first place:
```
 tmm0  =  0: { 5b 26 9e 26 62 82 18 23 ... }
          1: { cd f0 28 85 bf b5 93 ed ... }
         ...
         15: { 3a 71 cc 09 ff 12 88 f7 ... }
```
