### PR TITLE
FW/x86: Interleave EGPRs with GPRs

### DIFF
--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -203,7 +203,7 @@ static void print_segment(std::string &f, const char *name, uint16_t value)
 }
 
 #if defined(__linux__)
-void dump_gprs(std::string &f, SandstoneMachineContext mc)
+static void dump_gprs_only(std::string &f, SandstoneMachineContext mc)
 {
     static constexpr struct {
         char name[4];
@@ -228,6 +228,9 @@ void dump_gprs(std::string &f, SandstoneMachineContext mc)
     };
     for (auto reg : registers)
         print_gpr(f, reg.name, mc->gregs[reg.idx]);
+}
+static void dump_gprs_other(std::string &f, SandstoneMachineContext mc)
+{
     print_rip(f, mc->gregs[REG_RIP]);
     print_eflags(f, mc->gregs[REG_EFL]);
 
@@ -239,7 +242,7 @@ void dump_gprs(std::string &f, SandstoneMachineContext mc)
     }
 }
 #elif defined(__FreeBSD__)
-void dump_gprs(std::string &f, SandstoneMachineContext mc)
+static void dump_gprs_only(std::string &f, SandstoneMachineContext mc)
 {
     using register_t = decltype(mc->mc_rax);
     static constexpr struct {
@@ -265,13 +268,16 @@ void dump_gprs(std::string &f, SandstoneMachineContext mc)
     };
     for (auto reg : registers)
         print_gpr(f, reg.name, mc->*(reg.ptr));
+}
+static void dump_gprs_other(std::string &f, SandstoneMachineContext mc)
+{
     print_rip(f, mc->mc_rip);
     print_eflags(f, mc->mc_rflags);
     print_segment(f, "fs", mc->mc_fs);
     print_segment(f, "gs", mc->mc_gs);
 }
 #elif defined(__APPLE__) || defined(__MACH__)
-void dump_gprs(std::string &f, SandstoneMachineContext mc)
+static void dump_gprs_only(std::string &f, SandstoneMachineContext mc)
 {
     auto *state = &mc->__ss;
     using ThreadState = std::decay_t<decltype(*state)>;
@@ -299,13 +305,17 @@ void dump_gprs(std::string &f, SandstoneMachineContext mc)
     };
     for (auto reg : registers)
         print_gpr(f, reg.name, state->*(reg.ptr));
+}
+static void dump_gprs_other(std::string &f, SandstoneMachineContext mc)
+{
+    auto *state = &mc->__ss;
     print_rip(f, state->__rip);
     print_eflags(f, state->__rflags);
     print_segment(f, "fs", state->__fs);
     print_segment(f, "gs", state->__gs);
 }
 #elif defined(_WIN32)
-void dump_gprs(std::string &f, SandstoneMachineContext mc)
+static void dump_gprs_only(std::string &f, SandstoneMachineContext mc)
 {
     static constexpr struct {
         char name[4];
@@ -330,6 +340,9 @@ void dump_gprs(std::string &f, SandstoneMachineContext mc)
     };
     for (auto reg : registers)
         print_gpr(f, reg.name, mc->*(reg.ptr));
+}
+static void dump_gprs_other(std::string &f, SandstoneMachineContext mc)
+{
     print_rip(f, mc->Rip);
     print_eflags(f, mc->EFlags);
     print_segment(f, "fs", mc->SegFs);
@@ -545,6 +558,12 @@ void dump_xsave(std::string &f, const void *xsave_area, size_t xsave_size, int x
 
     if (mask & XSave::AmxState)
         print_amx_state(f, state, mask);
+}
+
+void dump_gprs(std::string &out, SandstoneMachineContext mc)
+{
+    dump_gprs_only(out, mc);
+    dump_gprs_other(out, mc);
 }
 
 // C API

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -582,6 +582,18 @@ void dump_xsave(std::string &f, const void *xsave_area, size_t xsave_size, int x
         dump_xsave_internal(f, xsave_area, xsave_size, mask);
 }
 
+void dump_context(std::string &out, SandstoneMachineContext mc, const void *xsave_area,
+                  size_t xsave_size)
+{
+    // interleave output so r16-r31 EGPRs appear next to the base ones
+    dump_gprs_only(out, mc);
+    XSave mask = get_xsave_mask(xsave_area, xsave_size, XSave(-1));
+    if (mask & XSave::ApxState)
+        dump_xsave_internal(out, xsave_area, xsave_size, XSave::ApxState);
+    dump_gprs_other(out, mc);
+    dump_xsave_internal(out, xsave_area, xsave_size, XSave(mask & ~XSave::ApxState));
+}
+
 // C API
 char *dump_gprs(SandstoneMachineContext mc)
 {

--- a/framework/sandstone_context_dump.cpp
+++ b/framework/sandstone_context_dump.cpp
@@ -16,6 +16,7 @@
 #include <array>
 #include <limits>
 
+#include <assert.h>
 #ifdef __unix__
 #  include <dlfcn.h>
 #endif
@@ -513,18 +514,17 @@ static inline uint64_t __attribute__((target("xsave"))) do_xgetbv()
     return _xgetbv(0);
 }
 
-void dump_xsave(std::string &f, const void *xsave_area, size_t xsave_size, int xsave_dump_mask)
+static XSave get_xsave_mask(const void *xsave_area, size_t xsave_size, XSave mask)
 {
     // sanity check the state
-    XSave mask = XSave(xsave_dump_mask);
     if (xsave_size < Fxsave::size)
-        return;         // too small to be FXSAVE state
+        return {};      // too small to be FXSAVE state
 
     auto state = static_cast<const Fxsave *>(xsave_area);
 
     if (xsave_size > Fxsave::size) {
         if (xsave_size < Fxsave::size + 64)
-            return;     // XSAVE extended header missing
+            return {};  // XSAVE extended header missing
 
         // get the bit vector of saved features
         uint64_t xsave_bv;
@@ -541,11 +541,20 @@ void dump_xsave(std::string &f, const void *xsave_area, size_t xsave_size, int x
         }
 
         if (xsave_bv & ~xgetbv0)
-            return;     // bit vector contains invalid bits
+            return {};  // bit vector contains invalid bits
     } else {
         // only the legacy state
         mask = XSave(mask & (XSave::X87 | XSave::SseState));
     }
+    return mask;
+}
+
+static void dump_xsave_internal(std::string &f, const void *xsave_area, size_t xsave_size, XSave mask)
+{
+    if (!mask)
+        return;
+    assert(xsave_size >= Fxsave::size);
+    auto state = static_cast<const Fxsave *>(xsave_area);
 
     if (mask & XSave::ApxState)
         print_egprs(f, state);
@@ -564,6 +573,13 @@ void dump_gprs(std::string &out, SandstoneMachineContext mc)
 {
     dump_gprs_only(out, mc);
     dump_gprs_other(out, mc);
+}
+
+void dump_xsave(std::string &f, const void *xsave_area, size_t xsave_size, int xsave_dump_mask)
+{
+    XSave mask = get_xsave_mask(xsave_area, xsave_size, XSave(xsave_dump_mask));
+    if (mask)
+        dump_xsave_internal(f, xsave_area, xsave_size, mask);
 }
 
 // C API

--- a/framework/sandstone_context_dump.h
+++ b/framework/sandstone_context_dump.h
@@ -32,6 +32,8 @@ extern char *dump_xsave(const void *xsave_area, size_t xsave_size, int xsave_dum
 
 void dump_gprs(std::string &out, SandstoneMachineContext);
 void dump_xsave(std::string &out, const void *xsave_area, size_t xsave_size, int xsave_dump_mask);
+void dump_context(std::string &out, SandstoneMachineContext, const void *xsave_area,
+                  size_t xsave_size);
 #endif  // __cplusplus
 
 #endif  // SANDSTONE_CONTEXT_DUMP_H

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -867,9 +867,7 @@ static void cause_sigill()
 #ifndef __APX_F__
     if (cpu_has_feature(cpu_feature_apx_f)) {
         // force-init the APX state
-        // encodes to:   movl  $0x12345678, %r17d
-        asm (".byte 0xd5, 0x10\n"
-             "movl  %0, %%ecx" : : "i" (0x12345678));
+        asm ("movl %0, %%r17d" : : "i" (0x12345678));
     }
 #endif
 #ifndef __clang__

--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -983,8 +983,7 @@ static void print_crash_info(int slice, const char *pidstr, CrashContext &ctx)
         std::string log;
 
 #ifdef __x86_64__
-        dump_gprs(log, &ctx.mc);
-        dump_xsave(log, ctx.xsave_buffer.data(), ctx.xsave_buffer.size(), -1);
+        dump_context(log, &ctx.mc, ctx.xsave_buffer.data(), ctx.xsave_buffer.size());
 #endif
         dump_device_state(log, thread);
 

--- a/framework/sysdeps/windows/child_debug.cpp
+++ b/framework/sysdeps/windows/child_debug.cpp
@@ -192,7 +192,7 @@ static LONG WINAPI handler(EXCEPTION_POINTERS *info)
 }
 
 #ifdef __x86_64__
-static void print_non_gprs(std::string &log, PCONTEXT ctx)
+static void print_context(std::string &log, PCONTEXT ctx)
 {
     // Windows doesn't store the XSAVE state in a contiguous block, so
     // we have to put it back together.
@@ -229,7 +229,7 @@ static void print_non_gprs(std::string &log, PCONTEXT ctx)
         }
     }
 
-    dump_xsave(log, xsave_area, xsave_size, -1);
+    dump_context(log, ctx, xsave_area, xsave_size);
 }
 #endif
 
@@ -368,8 +368,7 @@ void debug_crashed_child(std::span<const pid_t> children)
 
         std::string log;
 #ifdef __x86_64__
-        dump_gprs(log, &ctx->fixedContext);
-        print_non_gprs(log, &ctx->fixedContext);
+        print_context(log, &ctx->fixedContext);
 #endif
 
         if (log.size()) {


### PR DESCRIPTION
This  PR refactors the context dumper so we interleave the EGPR state (registers r16-r31) with the base context, so r16 appears after r15 and before rip.

The Intel Software Development Emulator tool[1] does not support saving additional the context than what the OS does. Testing with GDB while forcing the bit on produces:
```
       Registers:
        rax   = 0x000000000000002a (42)
        rbx   = 0x0000000000000000 (0)
        rcx   = 0x000000000000feed
        rdx   = 0x0000000000c0ffee
        rsi   = 0x00007fc04fffd640
        rdi   = 0x0000000027634b9c
        rbp   = 0x00007fc04fffcca0
        rsp   = 0x00007fc04fffcb90
        r8    = 0x0000000000000000 (0)
        r9    = 0x0000000000000000 (0)
        r10   = 0x0000000000000000 (0)
        r11   = 0x00007fc04fffd6c0
        r12   = 0x00007fffdd493db0
        r13   = 0x00007fffdd493ea6
        r14   = 0x00007fc04fffdce4
        r15   = 0x00007fc04f7fe000
        r16   = 0x0000000000000000 (0)
        r17   = 0x0000000000000000 (0)
        r18   = 0x0000000000000000 (0)
        r19   = 0x0000000000000000 (0)
        r20   = 0x0000000000000000 (0)
        r21   = 0x0000000000000000 (0)
        r22   = 0x0000000000000000 (0)
        r23   = 0x0000000000000000 (0)
        r24   = 0x0000000000000000 (0)
        r25   = 0x0000000000000000 (0)
        r26   = 0x0000000000000000 (0)
        r27   = 0x0000000000000000 (0)
        r28   = 0x0000000000000000 (0)
        r29   = 0x0000000000000000 (0)
        r30   = 0x0000000000000000 (0)
        r31   = 0x0000000000000000 (0)
        rip   = 0x000055b4057bed3c
```

[1] https://www.intel.com/content/www/us/en/download/684897/intel-software-development-emulator.html
