### PR TITLE
FW: introduce new `idxd` device_type

### DIFF
--- a/.github/actions/build-idxd/action.yaml
+++ b/.github/actions/build-idxd/action.yaml
@@ -1,0 +1,73 @@
+name: Build for IDXD
+
+inputs:
+  name:
+    description: Name of target
+    type: string
+    required: true
+  env:
+    description: Environment for the build
+    type: string
+    required: false
+    default: ''
+  meson_args:
+    description: Meson arguments for the build
+    type: string
+    required: true
+  unittests:
+    description: Unittests
+    type: string
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: setup environment
+      shell: bash
+      run: printf '%s\n' ${{ inputs.env }} | tee -a ${GITHUB_ENV}
+    - name: Install distro packages
+      shell: bash
+      run: |
+        DEBIAN_FRONTEND=noninteractive apt-get -y update
+        echo "::group::Installing build dependencies"
+        DEBIAN_FRONTEND=noninteractive apt-get -y install \
+            bats \
+            ca-certificates \
+            ${CC-g++} \
+            elfutils \
+            file \
+            gawk \
+            git \
+            jq \
+            libboost-dev \
+            libeigen3-dev \
+            libgtest-dev \
+            libhwloc-dev \
+            libssl-dev \
+            libzstd-dev \
+            meson \
+            ninja-build \
+            python3-yaml \
+            yq \
+            zlib1g-dev
+        echo "::endgroup::"
+    - uses: actions/checkout@v6
+    - name: meson setup
+      shell: bash
+      run: meson setup builddir -Ddevice_type=idxd -Dbuildtype=debugoptimized ${{ inputs.meson_args }}
+    - name: ninja build
+      shell: bash
+      run: ninja -C builddir
+    - uses: actions/upload-artifact@v4
+      with:
+        name: linux-${{ inputs.name }}-binary-idxd
+        path: builddir/opendcdiag
+        retention-days: 3
+    - name: confirm opendcdiag runs
+      shell: bash
+      run: |
+        builddir/opendcdiag --version
+    - name: ninja build unittests
+      if: ${{ inputs.unittests }}
+      shell: bash
+      run: ninja -C builddir unittests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -158,3 +158,29 @@ jobs:
         shell: bash
         run: |
           ./builddir/unittests
+
+  build-idxd:
+    name: Build binary for IDXD
+    needs: [ lint, git-sanity ]
+    runs-on: ubuntu-24.04
+    container: debian:sid
+    strategy:
+      matrix:
+        include:
+        - { name: GCC, unittests: "unittests" }
+        - { name: GCC-NoLogging, unittests: "unittests", meson_args: "-Dlogging_format=no_output" }
+    steps:
+      - name: Checkout the PR merge point
+        uses: actions/checkout@v6
+      - name: Build for IDXD
+        uses: ./.github/actions/build-idxd
+        with:
+            name: ${{ matrix.name }}
+            env: ${{ matrix.env }}
+            meson_args: ${{ matrix.meson_args }}
+            unittests: ${{ matrix.unittests }}
+      - name: run unittests
+        if: ${{ matrix.unittests }}
+        shell: bash
+        run: |
+          ./builddir/unittests

--- a/framework/device/device.h
+++ b/framework/device/device.h
@@ -12,6 +12,8 @@
 #include <device/cpu/cpu_device.h>
 #elif SANDSTONE_DEVICE_GPU
 #include <device/gpu/gpu_device.h>
+#elif SANDSTONE_DEVICE_IDXD
+#include <device/idxd/idxd_device.h>
 #endif
 
 #endif /* INC_DEVICE_H */

--- a/framework/device/device_topology.h
+++ b/framework/device/device_topology.h
@@ -12,6 +12,8 @@
 #include <device/cpu/topology_cpu.h>
 #elif SANDSTONE_DEVICE_GPU
 #include <device/gpu/topology_gpu.h>
+#elif SANDSTONE_DEVICE_IDXD
+#include <device/idxd/topology_idxd.hpp>
 #endif
 
 #endif /* INC_DEVICE_TOPOLOGY_H */

--- a/framework/device/idxd/idxd_device.cpp
+++ b/framework/device/idxd/idxd_device.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "sandstone_p.h"
+#include "idxd_device.h"
+
+std::string device_features_to_string(device_features_t f)
+{
+    std::string result;
+    return result;
+}
+
+void dump_device_info()
+{
+}
+
+TestResult prepare_test_for_device(struct test *test)
+{
+    return TestResult::Passed;
+}
+
+void finish_test_for_device(struct test *test)
+{
+}
+
+std::vector<struct test*> special_tests_for_device()
+{
+    return {};
+}

--- a/framework/device/idxd/idxd_device.h
+++ b/framework/device/idxd/idxd_device.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INC_IDXD_DEVICE_H
+#define INC_IDXD_DEVICE_H
+
+#include <stdint.h>
+
+// Work Queue is an atomic piece of a programmable accelerator HW,
+// therefore device_info should store WQs, not DSA/IAX devices.
+// Inside it we should only store immutable fields.
+struct wq_info_t
+{
+    /// Logical OS processor number.
+    /// On Unix systems, this is a sequential ID; on Windows, it encodes
+    /// 64 * ProcessorGroup + ProcessorNumber
+    int cpu_number;
+
+    /// Package ID in the system.
+    int16_t package_id;
+
+    /// ...
+    /// ...
+    /// ...
+
+#ifdef __cplusplus
+    int wq() const;        ///! Internal WQ number
+#endif
+};
+
+// Alias for use in common framework code
+typedef struct wq_info_t device_info_t;
+
+extern struct wq_info_t *device_info;
+
+#ifdef __cplusplus
+inline int wq_info_t::wq() const
+{
+    return this - ::device_info;
+}
+#endif
+
+// Not used at the moment
+typedef unsigned __int128 device_features_t;
+static const device_features_t device_compiler_features = 0;
+#define cpu_has_feature(f)      ((device_compiler_features & (f)) == (f) || (device_features & (f)) == (f))
+
+#endif // INC_IDXD_DEVICE_H

--- a/framework/device/idxd/logging_idxd.cpp
+++ b/framework/device/idxd/logging_idxd.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "logging.h"
+
+#if !SANDSTONE_NO_LOGGING
+std::string AbstractLogger::thread_id_header_for_device(int thread, LogLevelVerbosity verbosity)
+{
+    std::string line;
+    return line;
+}
+
+void AbstractLogger::print_thread_header_for_device(int fd, PerThreadData::Test *thr)
+{
+
+}
+
+void AbstractLogger::print_fixed_for_device()
+{
+
+}
+
+void dump_device_state(std::string&, int)
+{
+
+}
+
+#else
+void dump_device_state(std::string&, int)
+{}
+#endif // !SANDSTONE_NO_LOGGING

--- a/framework/device/idxd/meson.build
+++ b/framework/device/idxd/meson.build
@@ -1,0 +1,11 @@
+# Copyright 2026 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+target_deps += [
+]
+
+framework_files += files(
+    'idxd_device.cpp',
+    'topology.cpp',
+    'logging_idxd.cpp',
+)

--- a/framework/device/idxd/test_data_idxd.h
+++ b/framework/device/idxd/test_data_idxd.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INC_TEST_DATA_IDXD_H
+#define INC_TEST_DATA_IDXD_H
+
+#include "test_data.h"
+
+namespace PerThreadData {
+
+using Test = TestCommon;
+
+} // namespace PerThreadData
+
+#endif /* INC_TEST_DATA_IDXD_H */

--- a/framework/device/idxd/topology.cpp
+++ b/framework/device/idxd/topology.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "topology.h"
+#include "sandstone_p.h"
+#include "idxd_device.h"
+#include "topology_idxd.hpp"
+
+struct wq_info_t *device_info = nullptr;
+
+int num_packages()
+{
+    return 1;
+}
+
+void make_rescheduler(RescheduleMode mode)
+{
+}
+
+void apply_deviceset_param(const char *param)
+{
+}
+
+std::string build_failure_mask_for_topology(const struct test* test)
+{
+    return {};
+}
+
+uint32_t mixin_from_device_info(int thread_num)
+{
+    return 1;
+}
+
+void print_temperature_of_device()
+{
+}
+
+template <>
+WorkQueueSet detect_devices<WorkQueueSet>()
+{
+    WorkQueueSet enabled_devices;
+
+    // ...
+    // ...
+    // ...
+
+    return enabled_devices;
+}
+
+void create_mock_topology(const char *topo)
+{
+}
+
+template <>
+void setup_devices<WorkQueueSet>(const WorkQueueSet &enabled_devices)
+{
+}
+
+void restrict_topology(DeviceRange range)
+{
+}
+
+void rebuild_topology()
+{
+}
+
+void analyze_test_failures_for_topology(const struct test *test, const PerThreadFailures &per_thread_failures)
+{
+}
+
+void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_per_slice)
+{
+    SlicePlans::Slices plan = { SlicePlans::Slice{ DeviceRange{ 0, device_count() }, {} } };
+    plans.fill(plan);
+}
+
+int slice_plan_init_for_threads(SlicePlans::SlicesArray& plans, ThreadRatio ratio_type)
+{
+    for (auto &plan : plans) {
+        for (auto &slice : plan)
+            slice.thread_range = { slice.device_range.starting_device, slice.device_range.device_count }; // 1:1 for now...
+    }
+    return device_count();
+}

--- a/framework/device/idxd/topology_idxd.hpp
+++ b/framework/device/idxd/topology_idxd.hpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef INC_TOPOLOGY_IDXD_HPP
+#define INC_TOPOLOGY_IDXD_HPP
+
+#include <vector>
+
+/// Immutable and unique id of a queue: device_id and wq_id, as in qw<device_id>.<wq_id>.
+struct WorkQueueId
+{
+    int device_id;
+    int wq_id;
+};
+
+using WorkQueueSet = std::vector<WorkQueueId>;
+using EnabledDevices = WorkQueueSet;
+
+class Topology
+{
+public:
+    using Thread = struct wq_info_t;
+
+    // ...
+    // ...
+    // ...
+};
+
+struct HardwareInfo
+{};
+
+#endif // INC_TOPOLOGY_IDXD_HPP

--- a/framework/device/test_data_device.h
+++ b/framework/device/test_data_device.h
@@ -12,6 +12,8 @@
 #include <device/cpu/test_data_cpu.h>
 #elif SANDSTONE_DEVICE_GPU
 #include <device/gpu/test_data_gpu.h>
+#elif SANDSTONE_DEVICE_IDXD
+#include <device/idxd/test_data_idxd.h>
 #endif
 
 #endif /* INC_TEST_DATA_DEVICE_H */

--- a/framework/meson.build
+++ b/framework/meson.build
@@ -56,6 +56,8 @@ if device_type == 'cpu'
     )
 elif device_type == 'gpu'
     framework_config.set10('SANDSTONE_DEVICE_GPU', true)
+elif device_type == 'idxd'
+    framework_config.set10('SANDSTONE_DEVICE_IDXD', true)
 else
     error('Unknown device type: ' + device_type)
 endif

--- a/framework/sandstone_config.h.in
+++ b/framework/sandstone_config.h.in
@@ -37,6 +37,7 @@
 
 #mesondefine SANDSTONE_DEVICE_CPU
 #mesondefine SANDSTONE_DEVICE_GPU
+#mesondefine SANDSTONE_DEVICE_IDXD
 
 #mesondefine SANDSTONE_FREQUENCY_MANAGER
 #mesondefine SANDSTONE_ULOG

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -33,7 +33,7 @@ option('afl_inc', type : 'string', value : '',
     description : '(Optional) Directory with AFL header files (absolute path).')
 option('coverage', type : 'boolean', value : false,
     description : 'Enable code coverage (default false)')
-option('device_type', type: 'combo', choices : ['cpu', 'gpu'], value: 'cpu',
+option('device_type', type: 'combo', choices : ['cpu', 'gpu', 'idxd'], value: 'cpu',
     description : 'Device type for the build (default cpu).')
 option('target_device', type : 'string', value: 'bmg',
     description : 'Type of the device to be used for the build. Run `ocloc compile --help` for a full list of available device types. Defaults to "bmg". For SPIR-V intermediate format use "spirv".')


### PR DESCRIPTION
With empty implementations and an only assumption that device in this context is the IDXD work queue.