### PR TITLE
FW/IDXD: fill `device_info` and `Topology`

### DIFF
--- a/framework/device/idxd/idxd_device.h
+++ b/framework/device/idxd/idxd_device.h
@@ -6,7 +6,18 @@
 #ifndef INC_IDXD_DEVICE_H
 #define INC_IDXD_DEVICE_H
 
+#include <accel-config/libaccel_config.h>
+
 #include <stdint.h>
+
+
+struct bdf_t
+{
+    uint16_t domain;
+    uint8_t bus;
+    uint8_t device : 5;
+    uint8_t function : 3;
+};
 
 // Work Queue is an atomic piece of a programmable accelerator HW,
 // therefore device_info should store WQs, not DSA/IAX devices.
@@ -21,9 +32,20 @@ struct wq_info_t
     /// Package ID in the system.
     int16_t package_id;
 
-    /// ...
-    /// ...
-    /// ...
+    /// PCI location.
+    struct bdf_t bdf;
+
+    /// WQ unique index within a device.
+    int wq_id;
+
+    /// Device that this WQ belongs to.
+    int device_id;
+
+    /// Device type that this WQ belongs to (DSA/IAX).
+    enum accfg_device_type dev_type;
+
+    /// Device version (V1/V2/V3).
+    enum accfg_device_version dev_version;
 
 #ifdef __cplusplus
     int wq() const;        ///! Internal WQ number

--- a/framework/device/idxd/topology.cpp
+++ b/framework/device/idxd/topology.cpp
@@ -39,60 +39,43 @@ void print_temperature_of_device()
 {
 }
 
-namespace {
-struct AccfgCtx
+int AccfgCtx::init()
 {
-    accfg_ctx* ctx = nullptr;
-
-    AccfgCtx() = default;
-
-    ~AccfgCtx() {
-        if (ctx) accfg_unref(ctx);
+    if (accfg_new(&ctx) < 0) {
+        return log_skip_or_print(RuntimeSkipCategory, "Failed to initialize accfg_ctx");
     }
-
-    // non-copyable
-    AccfgCtx(const AccfgCtx&) = delete;
-    AccfgCtx& operator=(const AccfgCtx&) = delete;
-
-    int init() {
-        if (accfg_new(&ctx) < 0)
-            return log_skip_or_print(RuntimeSkipCategory, "Failed to initialize libaccel-config");
-        return EXIT_SUCCESS;
-    }
-
-    accfg_ctx* get() const { return ctx; }
-};
-} // end anonymous namespace
+    return EXIT_SUCCESS;
+}
 
 /// Collect all WQs visible in the system. Do not create any hierarchy of them at this point.
 template <>
 WorkQueueSet detect_devices<WorkQueueSet>()
 {
-    WorkQueueSet visible_wqs;
+    WorkQueueSet res;
 
-    AccfgCtx ctx;
-    if (auto ret = ctx.init(); ret) {
-        return visible_wqs;
+    if (auto ret = res.ctx.init(); ret) {
+        return res;
     }
 
     accfg_device* device;
-    accfg_device_foreach(ctx.get(), device) {
+    accfg_device_foreach(res.ctx.get(), device) {
         auto device_type = accfg_device_get_type(device);
         auto device_id   = accfg_device_get_id(device);
 
         accfg_wq* wq;
         accfg_wq_foreach(device, wq) {
-            auto& v = visible_wqs.emplace_back();
+            auto& v = res.visible_wqs.emplace_back();
+            v.device_handle = device;
             v.device_type = device_type;
             v.device_id   = device_id;
             v.wq_id       = accfg_wq_get_id(wq);
         }
     }
 
-    sApp->device_count = visible_wqs.size();
+    sApp->device_count = res.visible_wqs.size();
     sApp->user_thread_data.resize(sApp->device_count);
 
-    return visible_wqs;
+    return res;
 }
 
 void create_mock_topology(const char *topo)

--- a/framework/device/idxd/topology_idxd.hpp
+++ b/framework/device/idxd/topology_idxd.hpp
@@ -6,29 +6,138 @@
 #ifndef INC_TOPOLOGY_IDXD_HPP
 #define INC_TOPOLOGY_IDXD_HPP
 
+#include "idxd_device.h"
+
 #include <accel-config/libaccel_config.h>
 
+#include <cstdint>
+#include <optional>
+#include <utility>
 #include <vector>
 
-/// Immutable and unique id of a queue: device_id and wq_id, as in qw<device_id>.<wq_id>.
-struct WorkQueueId
+/// RAII wrapper around accfg_ctx. The lifetime of the underlying context is the same as this wrapper's.
+/// accfg_ref is not used at this point.
+struct AccfgCtx
 {
-    accfg_device_type device_type;
-    int device_id;
-    int wq_id;
+    accfg_ctx* ctx = nullptr;
+
+    AccfgCtx() = default;
+    AccfgCtx(AccfgCtx&& other) noexcept
+        : ctx(std::exchange(other.ctx, nullptr))
+    {}
+    ~AccfgCtx() {
+        if (ctx) accfg_unref(ctx);
+    }
+
+    // non-copyable
+    AccfgCtx(const AccfgCtx&) = delete;
+    AccfgCtx& operator=(const AccfgCtx&) = delete;
+
+    int init();
+    accfg_ctx* get() const { return ctx; }
 };
 
-using WorkQueueSet = std::vector<WorkQueueId>;
+/// Immutable and unique id of a queue: device_id and wq_id, as in qw<device_id>.<wq_id>.
+/// Since detect/setup_devices() is guaranteed to happen in the same process, we can store
+/// accfg handles as they won't become invalid in the meantime (require accfg_ctx* though).
+struct WorkQueueId
+{
+    accfg_device* device_handle = nullptr;
+    accfg_device_type device_type = accfg_device_type::ACCFG_DEVICE_TYPE_UNKNOWN;
+    int device_id = -1;
+    int wq_id = -1;
+};
+
+/// To be able to store handles, we must carry around the ctx as well.
+struct WorkQueueSet
+{
+    AccfgCtx ctx;
+    std::vector<WorkQueueId> visible_wqs;
+    bool empty() const noexcept { return visible_wqs.empty(); }
+};
+
 using EnabledDevices = WorkQueueSet;
 
+// TODO: Apart from obvious Enabled and Disabled states, there are also Quiescing
+// and Locked transitional/protective states. If those states are spotted during
+// reconfiguration process, I don't know what should we do. Probably poll until
+// Quiescing turns into a stable state, and maybe treat Locked as Locked.
+// Ideally WQs should be either enabled or disabled.
+
+/// Unlike for other devices, IDXD Topology is subject to change in-between tests.
 class Topology
 {
 public:
     using Thread = struct wq_info_t;
 
-    // ...
-    // ...
-    // ...
+    struct Device;
+    struct WorkQueue
+    {
+        /// Immutable part.
+        const wq_info_t* wq = nullptr;
+        int id = -1;
+
+        /// Mutable part, either configurable or just observed/effective.
+        accfg_wq_mode mode = accfg_wq_mode::ACCFG_WQ_MODE_UNKNOWN;
+        accfg_wq_state state = accfg_wq_state::ACCFG_WQ_UNKNOWN;
+        accfg_wq_type type = accfg_wq_type::ACCFG_WQT_NONE;
+
+        int group_id = -1; // same as Group::id
+
+        // present on all queues
+        uint32_t max_batch_size = 0;
+        uint64_t size = 0;
+        uint64_t max_transfer_size = 0;
+
+        // for shared WQs
+        std::optional<uint32_t> threshold;
+
+        // optional features
+        std::optional<uint32_t> priority;
+        std::optional<bool> block_on_fault;
+        std::optional<bool> ats_disable;
+        std::optional<bool> prs_disable;
+
+        accfg_op_config op_config = {}; // for effective op check: this_device->op_cap[i] & op_config[i]
+
+        // TODO: experimental: set to true only if: state is enabled, ownership allows using it, and mode allows using it.
+        // later we can add a function iterating over all targetable wqs or something...
+        // this variable is derived, not set manually
+        bool targetable = false;
+
+        const Device* this_device = nullptr;
+    };
+
+    struct Engine
+    {
+        int id = -1;
+    };
+
+    struct Group
+    {
+        int id = -1;
+        std::vector<WorkQueue> wqs;
+        std::vector<Engine> engines; // TODO: I wonder if num_engines would suffice, since we cannot target them to test.
+    };
+
+    struct Device
+    {
+        int id = -1;
+        accfg_device_type dev_type = accfg_device_type::ACCFG_DEVICE_TYPE_UNKNOWN;
+
+        uint32_t max_batch_size = 0;
+        uint64_t max_transfer_size = 0;
+
+        accfg_op_cap op_cap = {};
+
+        std::vector<Group> groups;
+    };
+
+    // Decide:
+    //   - std::vector<std::variant<DsaDevice, IaxDevice>>
+    //   - std::vector<DsaDevice> and std::vector<IaxDevice>
+    //   - one std::vector<Device> and a type member to Device?
+    std::vector<Device> devices;
 };
 
 struct HardwareInfo


### PR DESCRIPTION
The idea is to store immutable features of a work queue in `wq_info_t`. `Topology` is assumed to be changing in-between tests due to reconfiguration of the system. Each test is assumed to be able to adjust the current config of the system (and therefore the `Topology`) to its needs.