### PR TITLE
simf.conf: update to match ISE manual revision 062

### DIFF
--- a/framework/device/cpu/simd.conf
+++ b/framework/device/cpu/simd.conf
@@ -119,7 +119,6 @@ apx-f			Leaf07_01EDX	    21		# Advanced Performance Extensions
 #amx-complex		Leaf1E_01EDX	    2	amx-tile	# (repeated) AMX Tile multiplication for complex matrices
 #amx-fp16		Leaf1E_01EAX	    3	amx-tile	# (repeated) AMX Tile multiplication in FP16
 amx-fp8			Leaf1E_01EAX	    4	amx-tile	# AMX Tile multiplication in FP8
-amx-tf32		Leaf1E_01EAX	    6	amx-tile	# AMX Tile multiplications in TF32 (FP19)
 amx-avx512		Leaf1E_01EAX	    7	amx-tile,avx10_2	# AMX instructions moving rows into AVX512 registers
 amx-movrs		Leaf1E_01EAX	    8	amx-tile	# AMX loads with Read-Shared hint
 avx10.2			Leaf24_00EBX	    0_7==2	avx10.1	# AVX10.2
@@ -209,7 +208,7 @@ arch=ICX	SNC	pconfig
 arch=SPR	GLC	pconfig,amx-tile,amx-bf16,amx-int8	# enqcmd
 arch=EMR	RPC	pconfig,amx-tile,amx-bf16,amx-int8	# enqcmd
 arch=GNR	RWC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16	# enqcmd,amx-complex
-arch=DMR	PNC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16,amx-fp8,amx-tf32,amx-avx512,amx-movrs		# enqcmd,amx-complex
+arch=DMR	PNC	pconfig,amx-tile,amx-bf16,amx-int8,amx-fp16,amx-fp8,amx-avx512,amx-movrs		# enqcmd,amx-complex
 arch=SRF	CMT	cmpccxadd,avxifma,avxneconvert,avxvnniint8	# enqcmd
 arch=GRR	SRF	raoint
 arch=CWF	DKT	user_msr


### PR DESCRIPTION
This removes the AMX-TF32 ISA extension. The other feature that was remove we had never added to this file.