### PR TITLE
Logging/CPU: Enhance print_thread_header to print more data on CPU.

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -290,8 +290,9 @@ void TapFormatLogger::print_thread_header(int fd, int thread, int device, LogLev
     }
 
     const cpu_info_t *info = device_info + device;
-    std::string line = stdprintf("  Thread %d on CPU %d (pkg %d, core %d, thr %d", thread,
-            info->cpu_number, info->package_id, info->core_id, info->thread_id);
+    std::string line = stdprintf("  Thread %d on CPU %d (pkg %d, core %d, thr %d, numa %d, module %d",
+            thread, info->cpu_number, info->package_id, info->core_id,
+            info->thread_id, info->numa_id, info->module_id);
     if (const char *type = native_device_type(info))
         line += stdprintf(", core_type: %s", type);
 


### PR DESCRIPTION
Add numa_node and module.

Rationale:
When debugging some OpenDCDiag reports we're missing `cpu_info` data. Especially when the logs are in TAP format. We'll have complete set of information about CPU  near the issue that needs to be checked.

[Changelog] Log numa_node and module in TAP logger during failure.

Example log now:

```
  Thread 20 on CPU 10 (pkg 0, core 13, thr 0, numa 0, module 13, family/model/stepping 06-55-07, microcode 0x5003901, PPIN N/A):
  - failed: { time: 2.409, loop-count: 0 }
   - 'E> Failed at ../opendcdiag/framework/selftest.cpp:658'
```