### PR TITLE
FW: add `DECLARE_MANUAL_TEST` macro for declaring special tests

### DIFF
--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1141,7 +1141,7 @@ int main(int argc, char **argv)
     /* Add device-specific monitoring tests to the set. They will be kept last by
      * SandstoneTestSet in case randomization is requested. */
     for (auto special_test : test_set->get_special_tests()) {
-        if (special_test != &mce_test || (special_test == &mce_test && !sApp->ignore_mce_errors))
+        if (special_test != &_test_mce_check || (special_test == &_test_mce_check && !sApp->ignore_mce_errors))
             test_set->add(special_test);
     }
 
@@ -1158,12 +1158,12 @@ int main(int argc, char **argv)
             sApp->shmem->cfg.verbosity = LOG_LEVEL_VERBOSE(1);
     }
 
-    if (InterruptMonitor::InterruptMonitorWorks && test_set->contains(&mce_test)) {
+    if (InterruptMonitor::InterruptMonitorWorks && test_set->contains(&_test_mce_check)) {
         if (sApp->current_fork_mode() == SandstoneApplication::ForkMode::exec_each_test) {
-            test_set->remove(&mce_test);
+            test_set->remove(&_test_mce_check);
         } else if (InterruptMonitor::get_mce_interrupt_counts().empty()) {
             logging_printf(LOG_LEVEL_QUIET, "# WARNING: Cannot detect MCE events - you may be running in a VM - MCE checking disabled\n");
-            test_set->remove(&mce_test);
+            test_set->remove(&_test_mce_check);
         }
     }
 

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -153,22 +153,29 @@ typedef enum TestQuality {
 #define EXIT_SKIP               -255
 
 /// force the alignment so the compiler won't try to (un)helpfully overalign it.
-#define DECLARE_TEST_INNER2(test_id, test_id_str, test_short_id, test_description)  \
+#define DECLARE_TEST_SECTION(test_id, test_short_id) \
     __attribute__((alias("_test_" SANDSTONE_STRINGIFY(test_id)))) extern struct test _testid_ ## test_short_id; \
-    __attribute__((aligned(alignof(struct test)), used, section(SANDSTONE_SECTION_PREFIX "tests"))) \
+    __attribute__((aligned(alignof(struct test)), used, section(SANDSTONE_SECTION_PREFIX "tests")))
+
+#define DECLARE_TEST_STRUCT(test_id, test_id_str, test_short_id, test_description) \
     struct test _test_ ## test_id = {                                   \
         .compiler_minimum_device = device_compiler_features,            \
         .shortid = 0x ## test_short_id,                                 \
         .id = SANDSTONE_STRINGIFY(test_id_str),                         \
         .description = test_description,
+
 #if SANDSTONE_NO_TEST_NAMES
 #  define DECLARE_TEST_INNER(test_id, test_short_id, test_description)  \
-    DECLARE_TEST_INNER2(test_id, test_short_id, test_short_id, NULL)
+    DECLARE_TEST_STRUCT(test_id, test_short_id, test_short_id, NULL)
 #else
 #  define DECLARE_TEST_INNER(test_id, test_short_id, test_description)  \
-    DECLARE_TEST_INNER2(test_id, test_id, test_short_id, test_description)
+    DECLARE_TEST_STRUCT(test_id, test_id, test_short_id, test_description)
 #endif
 #define DECLARE_TEST(test_id, test_description)                         \
+    DECLARE_TEST_SECTION(test_id, TEST_ID_ ## test_id)                  \
+    DECLARE_TEST_INNER(test_id, TEST_ID_ ## test_id, test_description)
+
+#define DECLARE_MANUAL_TEST(test_id, test_description)                  \
     DECLARE_TEST_INNER(test_id, TEST_ID_ ## test_id, test_description)
 
 #define DECLARE_TEST_GROUPS(...)                                      \

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -327,7 +327,7 @@ static bool shouldTestTheTest(const struct test *the_test)
     if (!sApp->test_tests_enabled())
         return false;
     if constexpr (InterruptMonitor::InterruptMonitorWorks)
-        if (the_test == &mce_test)
+        if (the_test == &_test_mce_check)
             return false;
 
     // check some flags in the_test

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -33,7 +33,7 @@ void SandstoneTestSet::load_all_tests()
 
     /* add "special" tests */
     special_tests = special_tests_for_device();
-    special_tests.push_back(&mce_test); // mce always added last
+    special_tests.push_back(&_test_mce_check); // mce always added last
 }
 
 /* Looks up a name or a pattern among all "known" tests. Returns all the

--- a/framework/sandstone_tests.h
+++ b/framework/sandstone_tests.h
@@ -25,7 +25,7 @@ extern "C" {
 extern struct test __start_tests;
 extern struct test __stop_tests;
 
-extern struct test mce_test;
+extern struct test _test_mce_check;
 
 struct test_set_cfg {
     bool ignore_unknown_tests;  /* whether an error should be reported if

--- a/framework/unit-tests/tests_dummy.cpp
+++ b/framework/unit-tests/tests_dummy.cpp
@@ -8,6 +8,7 @@
 // This defines a dummy test just so the __start_tests and __stop_tests
 // symbols get defined by the linker.
 
+DECLARE_TEST_SECTION(dummy, 1)
 DECLARE_TEST_INNER(dummy, 1, nullptr)
 END_DECLARE_TEST
 

--- a/tests/common/mce_check/mce_check.cpp
+++ b/tests/common/mce_check/mce_check.cpp
@@ -117,7 +117,7 @@ bool InterruptMonitor::observed_mce_events()
 
 // The MCE test is special in that it is not handled like a normal test
 // We do not use the macros to specify it because we do not want it to
-// be in the acutal test list - it is an "inserted" test in that the test
+// be in the actual test list - it is an "inserted" test in that the test
 // is always inserted in the end.
 
 #if !defined(__linux__) || !defined(__x86_64__)
@@ -125,18 +125,7 @@ bool InterruptMonitor::observed_mce_events()
 static_assert(!InterruptMonitor::InterruptMonitorWorks);
 #endif
 
-#define CONCAT(x, y)    CONCAT2(x, y)
-#define CONCAT2(x, y)    x ## y
-struct test mce_test = {
-        .shortid = CONCAT(0x, TEST_ID_mce_check),
-#if SANDSTONE_NO_TEST_NAMES
-        .id = SANDSTONE_STRINGIFY(TEST_ID_mce_check),
-        .description = nullptr,
-#else
-        .id = "mce_check",
-        .description = "Machine Check Exceptions/Events count",
-#endif // SANDSTONE_NO_TEST_NAMES
-
+DECLARE_MANUAL_TEST(mce_check, "Machine Check Exceptions/Events count")
 #if defined(__linux__) && defined(__x86_64__)
         .test_preinit = mce_check_preinit,
         .test_run = mce_check_run,
@@ -147,6 +136,6 @@ struct test mce_test = {
 #else
         .quality_level = TEST_QUALITY_SKIP,
 #endif // __linux__ && __x86_64__
-};
+END_DECLARE_TEST
 
 // Do not convert to use the test declaration macros - read above


### PR DESCRIPTION
### **To discuss**
The variable name changed, but I don't think it's worth altering the macro to create a nicer names for manual declarations. It is what it is. 
Also, note that we now set
```
.compiler_minimum_device = device_compiler_features
```
for the `mce_check` test. Is this ok?