### PR TITLE
FW/CPU Topology: add support for splitting groups on CPU dies

### DIFF
--- a/bats/sanity-check/20-selftests.bats
+++ b/bats/sanity-check/20-selftests.bats
@@ -2229,13 +2229,20 @@ check_thread_ratio_plans() {
     local expected=$(thread_ratio_expected_threads "$fs_count" "$ratio")
     test_yaml_numeric "/test-plans/fullsocket/0/threads" "value == $expected"
 
-    # isolate_numa slices
-    local slice_count=${yamldump[/test-plans/isolate_numa@len]}
-    for ((i = 0; i < slice_count; i++)); do
-        local count=${yamldump[/test-plans/isolate_numa/$i/count]}
-        expected=$(thread_ratio_expected_threads "$count" "$ratio")
-        test_yaml_numeric "/test-plans/isolate_numa/$i/threads" "value == $expected"
-    done
+    local next_plan=
+    if [[ "$SANDSTONE_DEVICE_TYPE" == "CPU" ]]; then
+        next_plan=core_groups
+    elif [[ "$SANDSTONE_DEVICE_TYPE" == "GPU" ]]; then
+        next_plan=isolate_numa
+    fi
+    if [[ -n "$next_plan" ]]; then
+        local slice_count=${yamldump[/test-plans/$next_plan@len]}
+        for ((i = 0; i < slice_count; i++)); do
+            local count=${yamldump[/test-plans/$next_plan/$i/count]}
+            expected=$(thread_ratio_expected_threads "$count" "$ratio")
+            test_yaml_numeric "/test-plans/$next_plan/$i/threads" "value == $expected"
+        done
+    fi
 
     # heuristic slices
     slice_count=${yamldump[/test-plans/heuristic@len]}

--- a/bats/sanity-check/21-slicing.bats
+++ b/bats/sanity-check/21-slicing.bats
@@ -130,16 +130,50 @@ function cpuset_unique_modules() {
 
     # did we see different NUMA domains?
     local domains=(`query_jq -r '[ ."cpu-info"[].numa_node ] | unique | .[]'`)
-    test_yaml_numeric "/test-plans/core_groups@len" "value == ${#domains[@]}"
-
-    if [[ "${#domains[@]}" == 1 ]]; then
-        skip "Test only works with Debug builds (to mock the topology) or in systems with different NUMA domains"
+    local dies=`query_jq -r '[ ."cpu-info"[].die ] | unique | length'`
+    local core_types=`query_jq -r '[ ."cpu-info"[].core_type ] | unique | length'`
+    if [[ "${#domains[@]}" = 1 ]] || (( dies * core_types != 1 )); then
+        skip "Test only works with Debug builds (to mock the topology) or in systems with different NUMA domains and a single die"
     fi
+    test_yaml_numeric "/test-plans/core_groups@len" "value == ${#domains[@]}"
 
     local i idx
     for ((i = 0, idx = 0; i < ${#domains[@]}; ++i)); do
         local d=${domains[$i]}
         local cpucount=`query_jq -r '[ ."cpu-info"[] | select(.numa_node == '$d') ] | length'`
+        test_yaml_numeric "/test-plans/core_groups/$i/starting_cpu" "value == $idx"
+        test_yaml_numeric "/test-plans/core_groups/$i/count" "value == $cpucount"
+        idx=$((idx + cpucount))
+    done
+}
+
+@test "slicing CPU dies" {
+    declare -A yamldump
+
+    # attempt to run on one socket with multiple CPU dies (same NUMA node)
+    MAX_PROC=`nproc`
+    if (( `nproc` >= 8 )); then
+        export SANDSTONE_MOCK_TOPOLOGY='d0c0 d0c1 d0c2 d0c3 d1c64 d1c65 d1c66 d1c67'
+    elif (( MAX_PROC >= 4 )); then
+        export SANDSTONE_MOCK_TOPOLOGY='d0c0 d0c1 d1c64 d1c65'
+    else
+        skip "Test needs at least 4 different CPUs to test"
+    fi
+    sandstone_yq --cpuset=p0 --disable=\* --max-cores-per-slice=$MAX_PROC
+
+    # did we see different CPU dies?
+    local domains=`query_jq -r '[ ."cpu-info"[].numa_node ] | unique | length'`
+    local dies=(`query_jq -r '[ ."cpu-info"[].die ] | unique | .[]'`)
+    local core_types=`query_jq -r '[ ."cpu-info"[].core_type ] | unique | length'`
+    if [[ "${#dies[@]}" = 1 ]] || (( domains * core_types != 1 )); then
+        skip "Test only works with Debug builds (to mock the topology) or in systems with multiple CPU dies in a single NUMA domain"
+    fi
+
+    test_yaml_numeric "/test-plans/core_groups@len" "value == ${#dies[@]}"
+    local i idx
+    for ((i = 0, idx = 0; i < ${#dies[@]}; ++i)); do
+        local d=${dies[$i]}
+        local cpucount=`query_jq -r '[ ."cpu-info"[] | select(.die == '$d') ] | length'`
         test_yaml_numeric "/test-plans/core_groups/$i/starting_cpu" "value == $idx"
         test_yaml_numeric "/test-plans/core_groups/$i/count" "value == $cpucount"
         idx=$((idx + cpucount))
@@ -189,6 +223,12 @@ function cpuset_unique_modules() {
     echo "Found core types:" ${core_types[@]}
     if [[ ${#core_types[@]} -eq 0 ]]; then
         skip "Test only works with Debug builds (to mock the topology) or on systems reporting core type"
+    fi
+
+    local domains=`query_jq -r '[ ."cpu-info"[].numa_node ] | unique | length'`
+    local dies=`query_jq -r '[ ."cpu-info"[].die ] | unique | length'`
+    if (( domains * dies != 1 )); then
+        skip "Test only works with Debug builds (to mock the topology) or on systems with a single die and NUMA domain"
     fi
 
     local starting_cpu=0 slice=0

--- a/bats/sanity-check/21-slicing.bats
+++ b/bats/sanity-check/21-slicing.bats
@@ -130,7 +130,7 @@ function cpuset_unique_modules() {
 
     # did we see different NUMA domains?
     local domains=(`query_jq -r '[ ."cpu-info"[].numa_node ] | unique | .[]'`)
-    test_yaml_numeric "/test-plans/isolate_numa@len" "value == ${#domains[@]}"
+    test_yaml_numeric "/test-plans/core_groups@len" "value == ${#domains[@]}"
 
     if [[ "${#domains[@]}" == 1 ]]; then
         skip "Test only works with Debug builds (to mock the topology) or in systems with different NUMA domains"
@@ -140,8 +140,8 @@ function cpuset_unique_modules() {
     for ((i = 0, idx = 0; i < ${#domains[@]}; ++i)); do
         local d=${domains[$i]}
         local cpucount=`query_jq -r '[ ."cpu-info"[] | select(.numa_node == '$d') ] | length'`
-        test_yaml_numeric "/test-plans/isolate_numa/$i/starting_cpu" "value == $idx"
-        test_yaml_numeric "/test-plans/isolate_numa/$i/count" "value == $cpucount"
+        test_yaml_numeric "/test-plans/core_groups/$i/starting_cpu" "value == $idx"
+        test_yaml_numeric "/test-plans/core_groups/$i/count" "value == $cpucount"
         idx=$((idx + cpucount))
     done
 }
@@ -203,8 +203,8 @@ function cpuset_unique_modules() {
                          '[."cpu-info"[] | select(.core_type == $c and .numa_node == $n)] | length'`
             echo "$core_type-core CPUs in NUMA node $node:" "$count"
 
-            test_yaml_expr "/test-plans/isolate_numa/$slice/starting_cpu" = $starting_cpu
-            test_yaml_expr "/test-plans/isolate_numa/$slice/count" = $count
+            test_yaml_expr "/test-plans/core_groups/$slice/starting_cpu" = $starting_cpu
+            test_yaml_expr "/test-plans/core_groups/$slice/count" = $count
             test_yaml_expr "/test-plans/heuristic/$slice/starting_cpu" = $starting_cpu
             test_yaml_expr "/test-plans/heuristic/$slice/count" = $count
 
@@ -214,7 +214,7 @@ function cpuset_unique_modules() {
     done
 
     # Confirm we've reviewed all CPUs and plans
-    test_yaml_expr "/test-plans/isolate_numa@len" = $slice
+    test_yaml_expr "/test-plans/core_groups@len" = $slice
     test_yaml_expr "/test-plans/heuristic@len" = $slice
     test_yaml_expr "/test-plans/fullsocket/0/count" = $starting_cpu
 }

--- a/docs/opendcdiag-cpu.schema.json
+++ b/docs/opendcdiag-cpu.schema.json
@@ -176,6 +176,9 @@
         "numa_node": {
           "type": "integer"
         },
+        "die": {
+          "type": "integer"
+        },
         "module": {
           "type": "integer"
         },

--- a/docs/opendcdiag-cpu.schema.json
+++ b/docs/opendcdiag-cpu.schema.json
@@ -78,7 +78,7 @@
         "fullsocket": {
           "$ref": "#/$defs/test-plan-entry"
         },
-        "isolate_numa": {
+        "core_groups": {
           "$ref": "#/$defs/test-plan-entry"
         },
         "heuristic": {

--- a/docs/opendcdiag-cpu.schema.yaml
+++ b/docs/opendcdiag-cpu.schema.yaml
@@ -123,6 +123,8 @@ $defs:
         type: integer
       numa_node:
         type: integer
+      die:
+        type: integer
       module:
         type: integer
       core:

--- a/docs/opendcdiag-cpu.schema.yaml
+++ b/docs/opendcdiag-cpu.schema.yaml
@@ -54,7 +54,7 @@ properties:
     properties:
       fullsocket:
         $ref: '#/$defs/test-plan-entry'
-      isolate_numa:
+      core_groups:
         $ref: '#/$defs/test-plan-entry'
       heuristic:
         $ref: '#/$defs/test-plan-entry'

--- a/framework/device/cpu/cpu_device.cpp
+++ b/framework/device/cpu/cpu_device.cpp
@@ -42,11 +42,11 @@ void dump_device_info()
     printf("Detected CPU: %s; family-model-stepping (hex): %02x-%02x-%02x; CPU features: %s\n",
            detected, sApp->hwinfo.family, sApp->hwinfo.model, sApp->hwinfo.stepping,
            device_features_to_string(device_features).c_str());
-    printf("# CPU\tPkgID\tCoreID\tThrdID\tModId\tTileId\tNUMAId\tApicId\tMicrocode\tPPIN\n");
+    printf("# CPU\tPkgID\tCoreID\tThrdID\tModId\tDieId\tNUMAId\tApicId\tMicrocode\tPPIN\n");
     for (i = 0; i < device_count(); ++i) {
         printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t0x%" PRIx64, device_info[i].cpu_number,
                device_info[i].package_id, device_info[i].core_id, device_info[i].thread_id,
-               device_info[i].module_id, device_info[i].tile_id, device_info[i].numa_id, device_info[i].hwid,
+               device_info[i].module_id, device_info[i].die_id, device_info[i].numa_id, device_info[i].hwid,
                device_info[i].microcode);
         const HardwareInfo::PackageInfo *pkg = sApp->hwinfo.find_package_id(device_info[i].package_id);
         if (pkg && pkg->ppin)

--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -170,8 +170,8 @@ struct cpu_info_t
     int16_t core_id;
     /// Module ID inside of a package, -1 if not known.
     int16_t module_id;
-    /// Tile ID inside of a package, -1 if not known. May combine with the die ID.
-    int16_t tile_id;
+    /// Die ID inside of a package, -1 if not known.
+    int16_t die_id;
     /// The core type, if known. See enum definition.
     NativeCoreType native_core_type;
     /// NUMA node ID in the system, -1 if not known.

--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -407,8 +407,8 @@ static std::string full_cpu_info(LogicalProcessor lp, LogLevelVerbosity verbosit
 
     if (info) {
         line += stdprintf(", package: %d, numa_node: %d, ", info->package_id, info->numa_id);
-        if (info->tile_id >= 0)
-            line += stdprintf("tile: %d, ", info->tile_id);
+        if (info->die_id >= 0)
+            line += stdprintf("die: %d, ", info->die_id);
         line += stdprintf("module: %*d, core: %*d, thread: %d",
                           thread_core_spacing().core, info->module_id,
                           thread_core_spacing().core, info->core_id, info->thread_id);

--- a/framework/device/cpu/slicing.cpp
+++ b/framework/device/cpu/slicing.cpp
@@ -52,7 +52,7 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
 
         // set up proper plans
         auto &isolate_socket = plans[SlicePlans::IsolateSockets];
-        auto &isolate_numa = plans[SlicePlans::IsolateNuma];
+        auto &isolate_coregroup = plans[SlicePlans::IsolateCoreGroup];
         auto &split = plans[SlicePlans::Heuristic];
         auto push_to = [](SlicePlans::Slices &to, auto start, auto end) {
             int start_cpu = start[0].threads.front().cpu();
@@ -67,12 +67,12 @@ void slice_plan_init_for_device(SlicePlans::SlicesArray& plans, int max_cores_pe
 
             push_to(isolate_socket, p.cores.begin(), p.cores.end());
 
-            // if we have to split, we'll try to split along NUMA node lines
-            for (const Topology::NumaNode &n : p.numa_domains) {
+            // if we have to split, we'll try to split along the group lines (whatever they are)
+            for (const Topology::CoreGrouping &n : p.groups) {
                 if (n.cores.size() == 0)
                     continue;   // untested node (shouldn't happen!)
 
-                push_to(isolate_numa, n.cores.begin(), n.cores.end());
+                push_to(isolate_coregroup, n.cores.begin(), n.cores.end());
 
                 auto begin = n.cores.begin();
                 const auto end = n.cores.end();

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -483,6 +483,9 @@ bool TopologyDetector::create_mock_topology(const char *topo)
             case 'n':
                 parse_int_and_advance(&info->numa_id);
                 break;
+            case 'd':
+                parse_int_and_advance(&info->die_id);
+                break;
             case 'm':
                 parse_int_and_advance(&info->module_id);
                 break;
@@ -1649,11 +1652,12 @@ static Topology build_topology()
                 last_core_id = info->core_id;
             }
 
-            // We consider different core types in a heterogeneous system to be a
-            // different core groups
-            if (info->numa_id != groupfirst->numa_id
-                    || info->native_core_type != groupfirst->native_core_type) {
-                // start of a new NUMA or "NUMA" node inside of this Package
+            bool is_new_group = info->numa_id != groupfirst->numa_id;
+            if (!is_new_group)
+                is_new_group = info->die_id != groupfirst->die_id;
+            if (!is_new_group)
+                is_new_group = info->native_core_type != groupfirst->native_core_type;
+            if (is_new_group) {
                 populate_core_group(&pkg->groups.emplace_back(), groupfirst, info);
                 groupfirst = info;
             }

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1650,11 +1650,11 @@ static Topology build_topology()
             }
 
             // We consider different core types in a heterogeneous system to be a
-            // different "NUMA" nodes.
+            // different core groups
             if (info->numa_id != groupfirst->numa_id
                     || info->native_core_type != groupfirst->native_core_type) {
                 // start of a new NUMA or "NUMA" node inside of this Package
-                populate_core_group(&pkg->numa_domains.emplace_back(), groupfirst, info);
+                populate_core_group(&pkg->groups.emplace_back(), groupfirst, info);
                 groupfirst = info;
             }
         }
@@ -1663,12 +1663,12 @@ static Topology build_topology()
         pkg->cores.reserve(core_count + 1);
         populate_core_group(pkg, first, info);
 
-        // populate the last NUMA node/core type group, which may be the only one too
-        Topology::NumaNode *numa = &pkg->numa_domains.emplace_back();
-        if (pkg->numa_domains.size() == 1)
-            numa->CoreGrouping::operator=(*pkg);    // just copy the Package
+        // populate the last core group, which may be the only one too
+        Topology::CoreGrouping *lastgroup = &pkg->groups.emplace_back();
+        if (pkg->groups.size() == 1)
+            lastgroup->CoreGrouping::operator=(*pkg);    // just copy the Package
         else
-            populate_core_group(numa, groupfirst, info);
+            populate_core_group(lastgroup, groupfirst, info);
     }
 
     return Topology(std::move(packages));

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -68,8 +68,8 @@ private:
         Die = 5,
         DieGrp = 6,
     };
-    // we only want up to Tile
-    static constexpr Domain Package = Domain(Domain::Tile + 1);
+    // we only want up to Die
+    static constexpr Domain Package = Domain(Domain::Die + 1);
 
     bool is_hybrid = false;
     int8_t topology_leaf = -1;
@@ -361,7 +361,7 @@ static bool cpu_compare(const cpu_info_t &cpu1, const cpu_info_t &cpu2)
     static_assert(offsetof(cpu_info_t, cpu_number) + 14 == offsetof(cpu_info_t, package_id));
     static_assert(offsetof(cpu_info_t, cpu_number) + 12 == offsetof(cpu_info_t, numa_id));
     static_assert(offsetof(cpu_info_t, cpu_number) + 11 == offsetof(cpu_info_t, native_core_type));
-    static_assert(offsetof(cpu_info_t, cpu_number) + 9 == offsetof(cpu_info_t, tile_id));
+    static_assert(offsetof(cpu_info_t, cpu_number) + 9 == offsetof(cpu_info_t, die_id));
     static_assert(offsetof(cpu_info_t, cpu_number) + 7 == offsetof(cpu_info_t, module_id));
     static_assert(offsetof(cpu_info_t, cpu_number) + 5 == offsetof(cpu_info_t, core_id));
     static_assert(offsetof(cpu_info_t, cpu_number) + 4 == offsetof(cpu_info_t, thread_id));
@@ -462,7 +462,7 @@ bool TopologyDetector::create_mock_topology(const char *topo)
         ++cpu_count;
 
         info->package_id = info->core_id = info->thread_id = 0;
-        info->numa_id = info->module_id = info->tile_id = -1;
+        info->numa_id = info->module_id = info->die_id = -1;
         info->native_core_type = core_type_unknown;
 
         // mock cache too (8 kB L1, 32 kB L2, 256 kB L3)
@@ -726,6 +726,12 @@ bool TopologyDetector::detect_topology_via_os(Topology::Thread *info, int cpufd)
         info->module_id = info->core_id;
     }
 
+    f = fopenat(cpufd, "topology/die_id");
+    if (f) {
+        IGNORE_RETVAL(fscanf(f, "%hd", &info->die_id));
+        fclose(f);
+    }
+
     f = fopenat(cpufd, "topology/thread_siblings_list");
     if (!f)
         return false;
@@ -853,6 +859,7 @@ bool TopologyDetector::detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP rel
     unsigned char *end = ptr + length;
 
     int pkg_id = 0;
+    int die_id = 0;
     int module_id = 0;
     int core_id = 0;
     for ( ; ptr < end; ptr += lpi->Size) {
@@ -865,8 +872,18 @@ bool TopologyDetector::detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP rel
                              }
                 );
             ++pkg_id;
+            die_id = 0;
             module_id = 0;
             core_id = 0;
+            break;
+
+        case RelationProcessorDie:
+            for_each_proc_in(lpi->Processor.GroupCount, lpi->Processor.GroupMask,
+                             [&](cpu_info_t *info) {
+                                 info->die_id = die_id;
+                             }
+                 );
+            ++die_id;
             break;
 
         case RelationProcessorModule:
@@ -1106,11 +1123,11 @@ bool TopologyDetector::setup_cpuid_detection()
         case Domain::Logical:
         case Domain::Core:
         case Domain::Module:
-        case Domain::Tile:
+        case Domain::Die:
             width(domain) = a;
             break;
 
-        case Domain::Die:
+        case Domain::Tile:
         case Domain::DieGrp:
             // ignore
             break;
@@ -1175,9 +1192,9 @@ bool TopologyDetector::detect_topology_via_cpuid(Topology::Thread *info)
         // if neither CPUID nor cache provide module information, we assume module == core
         info->module_id = info->core_id;
     }
-    if (width(Domain::Tile)) {
-        info->tile_id = extract(next, width(Package));
-        next = width(Domain::Tile);
+    if (width(Domain::Die)) {
+        info->die_id = extract(next, width(Package));
+        next = width(Domain::Die);
     }
 
     return true;
@@ -1525,7 +1542,7 @@ void TopologyDetector::detect(const LogicalProcessorSet &enabled_cpus)
         // -1 to indicate unknown yet
         info->package_id = -1;
         info->numa_id = -1;
-        info->tile_id = -1;
+        info->die_id = -1;
         info->module_id = -1;
         info->core_id = -1;
         info->thread_id = -1;

--- a/framework/device/cpu/topology_cpu.h
+++ b/framework/device/cpu/topology_cpu.h
@@ -39,19 +39,10 @@ public:
         // std::vector<Module> modules;
     };
 
-    struct NumaNode : CoreGrouping
-    {
-        int id() const
-        {
-            return cores.size() ? cores.front().threads.front().numa_id : -1;
-        }
-    };
-
     struct Package : CoreGrouping
     {
-        // We consider different core types in a heterogeneous system to be a
-        // different "NUMA" nodes.
-        std::vector<NumaNode> numa_domains;
+        // any grouping inside of a package (see build_topology() for rules)
+        std::vector<CoreGrouping> groups;
         int id() const
         {
             return cores.size() ? cores.front().threads.front().package_id : -1;

--- a/framework/device/cpu/unit-tests/topology_tests.cpp
+++ b/framework/device/cpu/unit-tests/topology_tests.cpp
@@ -47,13 +47,13 @@ Topology make_two_numa_topology()
         package.cores.push_back(make_core(&device_info[i]));
     }
 
-    Topology::NumaNode numa0;
+    Topology::CoreGrouping numa0;
     numa0.cores.insert(numa0.cores.end(), package.cores.begin(), package.cores.begin() + 8);
-    package.numa_domains.push_back(std::move(numa0));
+    package.groups.push_back(std::move(numa0));
 
-    Topology::NumaNode numa1;
+    Topology::CoreGrouping numa1;
     numa1.cores.insert(numa1.cores.end(), package.cores.begin() + 8, package.cores.end());
-    package.numa_domains.push_back(std::move(numa1));
+    package.groups.push_back(std::move(numa1));
 
     topo.packages.push_back(std::move(package));
     return topo;
@@ -86,7 +86,7 @@ TEST(Topology, SlicePlansCreationMax3)
     expect_plan(plans.plans[SlicePlans::IsolateSockets], {
         { 0, 16 },
     });
-    expect_plan(plans.plans[SlicePlans::IsolateNuma], {
+    expect_plan(plans.plans[SlicePlans::IsolateCoreGroup], {
         { 0, 8 }, { 8, 8 },
     });
     expect_plan(plans.plans[SlicePlans::Heuristic], {

--- a/framework/device/cpu/unit-tests/topology_tests.cpp
+++ b/framework/device/cpu/unit-tests/topology_tests.cpp
@@ -24,7 +24,7 @@ std::vector<cpu_info_t> make_cpu_info_entries()
         cpu_info[i].thread_id = 0;
         cpu_info[i].core_id = i;
         cpu_info[i].module_id = i;
-        cpu_info[i].tile_id = -1;
+        cpu_info[i].die_id = -1;
         cpu_info[i].native_core_type = core_type_performance;
         cpu_info[i].package_id = 0;
         cpu_info[i].numa_id = (i < 8) ? 0 : 1;

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2336,7 +2336,7 @@ void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, 
                        thread_id_header_for_device(i, LOG_LEVEL_VERBOSE(2)).c_str(), i);
     }
 
-    auto make_plan_string = [](const SlicePlans::Slices &plan) {
+    auto print_plan = [](const char *name, const SlicePlans::Slices &plan) {
         std::string result;
         for (SlicePlans::Slice s : plan) {
             if (result.size())
@@ -2353,18 +2353,18 @@ void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, 
             result += std::to_string(s.thread_range.thread_count);
             result += " }";
         }
-        return result;
+        logging_printf(LOG_LEVEL_VERBOSE(1), "  %s: [ %s ]\n", name, result.c_str());
     };
     const SlicePlans::Slices &fullsocket = sApp->slice_plans.plans[SlicePlans::IsolateSockets];
-    const SlicePlans::Slices &isolatenuma = sApp->slice_plans.plans[SlicePlans::IsolateNuma];
     const SlicePlans::Slices &heuristic = sApp->slice_plans.plans[SlicePlans::Heuristic];
     logging_printf(LOG_LEVEL_VERBOSE(1), "test-plans:\n");
-    logging_printf(LOG_LEVEL_VERBOSE(1), "  fullsocket: [ %s ]\n",
-                   make_plan_string(fullsocket).c_str());
-    logging_printf(LOG_LEVEL_VERBOSE(1), "  isolate_numa: [ %s ]\n",
-                   make_plan_string(isolatenuma).c_str());
-    logging_printf(LOG_LEVEL_VERBOSE(1), "  heuristic: [ %s ]\n",
-                   make_plan_string(heuristic).c_str());
+    print_plan("fullsocket", fullsocket);
+#ifdef SANDSTONE_DEVICE_CPU
+    print_plan("core_groups", sApp->slice_plans.plans[SlicePlans::IsolateCoreGroup]);
+#elif defined(SANDSTONE_DEVICE_GPU)
+    print_plan("isolate_numa", sApp->slice_plans.plans[SlicePlans::IsolateNuma]);
+#endif
+    print_plan("heuristic", heuristic);
 }
 
 void YamlLogger::print_tests_header(TestHeaderTime mode)

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -279,11 +279,19 @@ typedef enum test_flag {
     /// system, with all cores.
     test_schedule_isolate_socket    = 3,
 
+#ifdef SANDSTONE_DEVICE_CPU
+    /// Asks the framework to run one child process per core group in each
+    /// socket in the system. Core groups can be:
+    /// - NUMA domains
+    /// - core types (efficiency/performance)
+    test_schedule_isolate_coregroup = 4,
+    test_schedule_isolate_numa_domain [[deprecated("use test_schedule_isolate_coregroup")]]
+        = test_schedule_isolate_coregroup,
+#elif defined(SANDSTONE_DEVICE_GPU)
     /// Asks the framework to run one child process per NUMA domain in each
-    /// socket in the system, with all cores. Note: on hybrid systems with
-    /// different core types, each core type is considered a different "NUMA"
-    /// domain.
+    /// socket in the system, with all devices.
     test_schedule_isolate_numa_domain = 4,
+#endif
 
     test_schedule_mask              = 0x0f,
 

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -283,6 +283,7 @@ typedef enum test_flag {
     /// Asks the framework to run one child process per core group in each
     /// socket in the system. Core groups can be:
     /// - NUMA domains
+    /// - CPU dies or die groups
     /// - core types (efficiency/performance)
     test_schedule_isolate_coregroup = 4,
     test_schedule_isolate_numa_domain [[deprecated("use test_schedule_isolate_coregroup")]]

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1412,8 +1412,13 @@ static int slices_for_test(const struct test *test)
         case test_schedule_isolate_socket:
             return SlicePlans::IsolateSockets;
 
+#ifdef SANDSTONE_DEVICE_CPU
+        case test_schedule_isolate_coregroup:
+            return SlicePlans::IsolateCoreGroup;
+#elif defined(SANDSTONE_DEVICE_GPU)
         case test_schedule_isolate_numa_domain:
             return SlicePlans::IsolateNuma;
+#endif
 
         case test_schedule_default:
             break;

--- a/framework/topology.h
+++ b/framework/topology.h
@@ -6,6 +6,7 @@
 #ifndef INC_TOPOLOGY_H
 #define INC_TOPOLOGY_H
 
+#include <sandstone_config.h>
 #include "test_data.h"
 
 #include <bit>
@@ -225,7 +226,11 @@ struct SlicePlans
     {
         FullSystem = -1,
         IsolateSockets,
+#ifdef SANDSTONE_DEVICE_CPU
+        IsolateCoreGroup,
+#elif defined(SANDSTONE_DEVICE_GPU)
         IsolateNuma,
+#endif
         Heuristic,
     };
     struct Slice {


### PR DESCRIPTION
Because on some Intel systems, we get no NUMA splitting inside of a package in spite of different memory channels. That may be a BIOS configuration. Without this change, we end up slicing the socket at boundaries that cause anywhere from "sub-optimal" to "incredibly bad" performance with some memory-intensive tests.

[ChangeLog][Topology] The framework will now use the CPU die information from CPUID to create a slicing plan.

[ChangeLog][YAML Schema Change] The `cpu-info` array in the log header will contain a `die` field for CPU cores, if the system provides that information. The field is absent otherwise. That replaces the `tile` field.
