### PR TITLE
FW/cpuid: suppress unused variable warning

### DIFF
--- a/framework/device/cpu/cpuid_internal.h
+++ b/framework/device/cpu/cpuid_internal.h
@@ -175,7 +175,7 @@ static device_features_t detect_cpu()
         // extract the version number from CPUID
         __cpuid_count(0x1d, 2, eax, ebx, ecx, edx);
 
-        int acever = ecx & 0xff;
+        int acever __attribute__((unused)) = ecx & 0xff;
 #ifdef cpu_feature_ace1
         if (acever >= 1)
             features |= cpu_feature_ace1;


### PR DESCRIPTION
The acever variable is only ever assert'ed, so you'll get an unused variable warning if building with buildtype `release`. Given this is a bleeding-edge bit of code (ACE), I'm fine with suppressing the warning for now.

Fixes: 64912ae73dfb ("simd.conf: add support for detecting ACEv1")