### PR TITLE
FW: add `group_special` for easier disabling of special tests

### DIFF
--- a/bats/sanity-check/helpers.bash
+++ b/bats/sanity-check/helpers.bash
@@ -4,7 +4,7 @@
 
 sandstone_selftest() {
     VALIDATION=dump
-    run_sandstone_yaml ${MAX_PROC:+-n$MAX_PROC} --ignore-mce-errors --selftests --timeout=20s --retest-on-failure=0 -Y2 "$@"
+    run_sandstone_yaml ${MAX_PROC:+-n$MAX_PROC} --ignore-mce-errors --disable "@special" --selftests --timeout=20s --retest-on-failure=0 -Y2 "$@"
 }
 
 extract_from_yaml() {

--- a/framework/sandstone_test_groups.cpp
+++ b/framework/sandstone_test_groups.cpp
@@ -26,6 +26,11 @@ constexpr struct test_group group_fuzzing = {
                "Tests that fuzz framework functions using AFL++ persistent mode"),
 };
 
+constexpr struct test_group group_special = {
+    TEST_GROUP("special",
+               "Special framework-inserted tests"),
+};
+
 #if defined(SANDSTONE_DEVICE_CPU) && defined(__x86_64__)
 constexpr struct test_group group_kvm = {
     TEST_GROUP("kvm",

--- a/framework/sandstone_test_groups.h
+++ b/framework/sandstone_test_groups.h
@@ -16,7 +16,8 @@ struct test_group;
 extern const struct test_group
         group_compression,
         group_math,
-        group_fuzzing;
+        group_fuzzing,
+        group_special;
 
 #if defined(SANDSTONE_DEVICE_CPU) && defined(__x86_64__)
 extern const struct test_group

--- a/framework/sandstone_tests.cpp
+++ b/framework/sandstone_tests.cpp
@@ -17,23 +17,31 @@
 void SandstoneTestSet::load_all_tests()
 {
     std::span<struct test> known_tests = test_source();
+
+    auto add_to_all_group_map = [&](struct test &t) {
+        if (SandstoneConfig::RestrictedCommandLine)
+            return;
+        // only populate all_group_map if we're parsing command-line
+        for (auto ptr = t.groups; ptr && *ptr; ++ptr) {
+            all_group_map[(*ptr)->id].push_back(&t);
+        }
+    };
+
     for (struct test &t : known_tests) {
         all_tests.push_back(&t);
         if (is_selftest()) {
             // self tests don't have hardcoded test IDs, so add them now
             t.shortid = std::hash<std::string_view>()(t.id) & 0xffffff;
         }
-        if (!SandstoneConfig::RestrictedCommandLine) {
-            // only populate all_group_map if we're parsing command-line
-            for (auto ptr = t.groups; ptr && *ptr; ++ptr) {
-                all_group_map[(*ptr)->id].push_back(&t);
-            }
-        }
+        add_to_all_group_map(t);
     }
 
     /* add "special" tests */
     special_tests = special_tests_for_device();
     special_tests.push_back(&_test_mce_check); // mce always added last
+    for (struct test *t : special_tests) {
+        add_to_all_group_map(*t);
+    }
 }
 
 /* Looks up a name or a pattern among all "known" tests. Returns all the

--- a/tests/common/mce_check/mce_check.cpp
+++ b/tests/common/mce_check/mce_check.cpp
@@ -126,6 +126,7 @@ static_assert(!InterruptMonitor::InterruptMonitorWorks);
 #endif
 
 DECLARE_MANUAL_TEST(mce_check, "Machine Check Exceptions/Events count")
+        .groups = DECLARE_TEST_GROUPS(&group_special),
 #if defined(__linux__) && defined(__x86_64__)
         .test_preinit = mce_check_preinit,
         .test_run = mce_check_run,

--- a/tests/gpu/event_monitor/event_monitor.cpp
+++ b/tests/gpu/event_monitor/event_monitor.cpp
@@ -157,6 +157,7 @@ int listener_postcleanup(struct test* test)
 } // unnamed namespace
 
 DECLARE_MANUAL_TEST(event_monitor, "Monitor GPU device events for hardware issues")
+    .groups = DECLARE_TEST_GROUPS(&group_special),
     .test_preinit = listener_preinit,
     .test_run = [](struct test*, int) { return EXIT_SUCCESS; },
     .test_postcleanup = listener_postcleanup,


### PR DESCRIPTION
In selftests, using `--ignore-mce-errors` for this purpose is good enough for CPUs, but not for other devices.