### PR TITLE
FW/CPU: add support for apportioning the L3 to each core group

### DIFF
--- a/bats/sanity-check/25-cpu-topology.bats
+++ b/bats/sanity-check/25-cpu-topology.bats
@@ -129,6 +129,41 @@ test_fail_socket1() {
     ); done
 }
 
+@test "cache-info" {
+    declare -A yamldump
+    run_sandstone_yaml --disable=\*
+
+    # cache-info must be present
+    test_yaml_expr "/cache-info" != None
+
+    # Validate whichever cache levels were reported. We don't assume any
+    # particular sizes (unknown target machine), only that the structure is
+    # present and the reported sizes are non-zero.
+    local level
+    for level in L1 L2 L3; do
+        [[ -n "${yamldump[/cache-info/$level]:+1}" ]] || continue
+
+        if [[ -n "${yamldump[/cache-info/$level/size/unified]:+1}" ]]; then
+            test_yaml_numeric "/cache-info/$level/size/unified" "value > 0"
+        else
+            test_yaml_numeric "/cache-info/$level/size/instruction" "value > 0"
+            test_yaml_numeric "/cache-info/$level/size/data" "value > 0"
+        fi
+    done
+
+    # The last level must break down into one or more instances, each with a
+    # non-zero size, a valid starting CPU and a non-zero thread count.
+    if [[ -n "${yamldump[/cache-info/L3]:+1}" ]]; then
+        test_yaml_numeric "/cache-info/L3/breakdown@len" "value >= 1"
+        local i
+        for ((i=0; i < ${yamldump[/cache-info/L3/breakdown@len]}; ++i)); do
+            test_yaml_numeric "/cache-info/L3/breakdown/$i/size" "value > 0"
+            test_yaml_numeric "/cache-info/L3/breakdown/$i/starting_cpu" "value >= 0"
+            test_yaml_numeric "/cache-info/L3/breakdown/$i/count" "value > 0"
+        done
+    fi
+}
+
 @test "NUMA node parsing when first block skipped" {
     declare -A yamldump
     if ! [[ /sys/devices/system/node ]]; then

--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -144,12 +144,11 @@ typedef uint8_t NativeCoreType;                 // C17 or older
 /// data, only data is valid; if unified, both are set to the same value. In all
 /// the cases the value is the cache size in bytes.  A field is valid if it
 /// contains a value >= 0.  Fields with negative values are invalid.
-/// TODO: consider changing this, with L1D & L1I being the same size, they are
-/// indistinguishable from a unified cache.
 struct cache_info_t
 {
     int cache_instruction;
     int cache_data;
+    bool is_unified;
 };
 
 /// cpu_info_t contains information about a logical CPU

--- a/framework/device/cpu/cpu_device.h
+++ b/framework/device/cpu/cpu_device.h
@@ -148,7 +148,9 @@ struct cache_info_t
 {
     int cache_instruction;
     int cache_data;
+    int16_t id;
     bool is_unified;
+    int8_t _reserved;
 };
 
 /// cpu_info_t contains information about a logical CPU

--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -8,6 +8,8 @@
 #include "logging_cpu.h"
 
 #include <cinttypes>
+#include <climits>
+#include <map>
 
 static constexpr const char *native_device_type(const cpu_info_t *info)
 {
@@ -483,6 +485,64 @@ void AbstractLogger::print_fixed_for_device()
     const double freq_avg = freqs / cpus_measured;
     if (std::isfinite(freq_avg) && freq_avg != 0.0)
         logging_printf(LOG_LEVEL_VERBOSE(1), "  avg-freq-mhz: %.1f\n", freq_avg);
+}
+
+void AbstractLogger::device_print_extra_info()
+{
+    constexpr int cache_levels = sizeof(cpu_info_t::cache) / sizeof(cpu_info_t::cache[0]);
+    std::span<const cpu_info_t> infos(device_info, sApp->device_count);
+
+    struct InstanceInfo {
+        int cache_instruction = -1;
+        int cache_data = -1;
+        // assumption: the instances are stored contiguously
+        int starting_cpu = INT_MAX;
+        int count = 0;
+        bool is_unified = false;
+    };
+
+    logging_printf(LOG_LEVEL_VERBOSE(1), "cache-info:\n");
+
+    for (int level = 0; level < cache_levels; ++level) {
+        // Group the logical processors by which physical cache instance they
+        // share at this level, so we can count the instances and their sizes.
+        std::map<int, InstanceInfo> instances;
+        for (const cpu_info_t &info : infos) {
+            const cache_info_t &c = info.cache[level];
+            if (c.cache_instruction < 0 && c.cache_data < 0)
+                continue;
+            InstanceInfo &inst = instances[c.id];
+            inst.cache_instruction = c.cache_instruction;
+            inst.cache_data = c.cache_data;
+            inst.is_unified = c.is_unified;
+            inst.starting_cpu = std::min(inst.starting_cpu, info.cpu_number);
+            ++inst.count;
+        }
+        if (instances.empty())
+            continue;
+
+        const InstanceInfo &rep = instances.begin()->second;
+        logging_printf(LOG_LEVEL_VERBOSE(1), "  L%d:\n", level + 1);
+        if (rep.is_unified)
+            logging_printf(LOG_LEVEL_VERBOSE(1), "    size: { unified: %d }\n", rep.cache_data);
+        else
+            logging_printf(LOG_LEVEL_VERBOSE(1), "    size: { instruction: %d, data: %d }\n",
+                           rep.cache_instruction, rep.cache_data);
+
+        if (level == cache_levels - 1) {
+            logging_printf(LOG_LEVEL_VERBOSE(1), "    breakdown:\n");
+            for (const auto &[id, inst] : instances) {
+                int size = inst.is_unified ? inst.cache_data
+                        : std::max(inst.cache_instruction, 0) + std::max(inst.cache_data, 0);
+                logging_printf(LOG_LEVEL_VERBOSE(1),
+                               "    - { size: %d, starting_cpu: %d, count: %d }\n",
+                               size, inst.starting_cpu, inst.count);
+            }
+        } else {
+            // unnecessary information (for now)
+            // logging_printf(LOG_LEVEL_VERBOSE(1), "    instances: %zu\n", instances.size());
+        }
+    }
 }
 
 #endif // !SANDSTONE_NO_LOGGING

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -469,7 +469,6 @@ bool TopologyDetector::create_mock_topology(const char *topo)
         info->cache[0] = { 0x2000, 0x2000 };
         info->cache[1] = { 0x8000, 0x8000 };
         info->cache[2] = { 0x40000, 0x40000 };
-        info->cache[2].is_unified = true;
 
         char c = topo[0] | 0x20;  // lowercased (if a letter); numbers unchanged
         // parse the different fields of the topology
@@ -589,6 +588,18 @@ bool TopologyDetector::detect_cache_via_os(Topology::Thread *info, int cpufd)
                 info->cache[level - 1].cache_instruction = size;
             if (!is_instruction)
                 info->cache[level - 1].cache_data = size;
+
+            int id = -1;
+            if ((f = fopenat(cachefd, "id"))) {
+                IGNORE_RETVAL(fscanf(f, "%d", &id));
+                fclose(f);
+            } else if ((f = fopenat(cachefd, "shared_cpu_list"))) {
+                // fallback: the lowest CPU sharing this cache is a stable
+                // instance id that every sharer computes identically
+                IGNORE_RETVAL(fscanf(f, "%d", &id));
+                fclose(f);
+            }
+            info->cache[level - 1].id = id;
         }
     }
     return true;
@@ -866,6 +877,8 @@ bool TopologyDetector::detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP rel
     int die_id = 0;
     int module_id = 0;
     int core_id = 0;
+    constexpr int cache_levels = sizeof(cpu_info_t::cache) / sizeof(cpu_info_t::cache[0]);
+    int cache_id[cache_levels] = {};
     for ( ; ptr < end; ptr += lpi->Size) {
         lpi = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *>(ptr);
         switch (lpi->Relationship) {
@@ -911,11 +924,12 @@ bool TopologyDetector::detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP rel
 
         case RelationCache: {
             auto &cache = *reinterpret_cast<CACHE_RELATIONSHIP_2 *>(&lpi->Cache);
+            int level = cache.Level - 1;
+            if (level >= cache_levels)
+                break;
+            int id = cache_id[level]++;    // one id per physical cache instance
             for_each_proc_in(cache.GroupCount, cache.GroupMasks,
                              [&](cpu_info_t *info) {
-                                 int level = cache.Level - 1;
-                                 if (level >= std::size(info->cache))
-                                     return;
                                  if (cache.Type == CacheUnified
                                          || cache.Type == CacheInstruction)
                                      info->cache[level].cache_instruction = cache.CacheSize;
@@ -924,6 +938,7 @@ bool TopologyDetector::detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP rel
                                      info->cache[level].cache_data = cache.CacheSize;
                                  if (cache.Type == CacheUnified)
                                      info->cache[level].is_unified = true;
+                                 info->cache[level].id = id;
                              }
                 );
             break;
@@ -1046,8 +1061,14 @@ bool TopologyDetector::detect_cache_via_cpuid(Topology::Thread *info,
         sets = c + 1; /* entire ecx plus 1 */
 
         size = ways * parts * line_sz * sets;
+
+        /* eax 11 bits 25:14 plus 1 = maximum IDs sharing this cache */
+        uint32_t max_cpus_sharing = ((a >> 14) & ((1 << 11) - 1)) + 1;
         if (level == 2 && max_cpus_sharing_l2)
-            *max_cpus_sharing_l2 = ((a >> 14) & ((1 << 11) - 1)) + 1; /* eax 11 bits 25:14 plus 1 */
+            *max_cpus_sharing_l2 = max_cpus_sharing;
+
+        /* drop the low APIC ID bits that address within the sharing domain */
+        info->cache[level - 1].id = info->hwid >> std::bit_width(max_cpus_sharing - 1);
 
         switch (a & 0xf) { /* first four eax bits are type */
             case 1: /* data */
@@ -1162,12 +1183,13 @@ bool TopologyDetector::detect_topology_via_cpuid(Topology::Thread *info)
     uint32_t a, b, c, apicid;
     uint32_t max_cpus_sharing_l2 = 0;
 
-    if (!detect_cache_via_cpuid(info, &max_cpus_sharing_l2))
-        return false;
-
     // get this processor's APIC ID
     assert(topology_leaf > 0);
     __cpuid_count(topology_leaf, 0, a, b, c, apicid);
+    info->hwid = apicid;
+
+    if (!detect_cache_via_cpuid(info, &max_cpus_sharing_l2))
+        return false;
 
     // process the widths
     auto extract = [&](uint32_t start, uint32_t end) {
@@ -1178,7 +1200,6 @@ bool TopologyDetector::detect_topology_via_cpuid(Topology::Thread *info)
         return value;
     };
 
-    info->hwid = apicid;
     info->package_id = extract(width(Package), -1);
     info->thread_id = extract(0, width(Domain::Logical));
     info->core_id = extract(width(Domain::Logical), width(Package));
@@ -1555,7 +1576,8 @@ void TopologyDetector::detect(const LogicalProcessorSet &enabled_cpus)
         info->thread_id = -1;
         info->hwid = -1;
 
-        std::fill(std::begin(info->cache), std::end(info->cache), cache_info_t{-1, -1});
+        std::fill(std::begin(info->cache), std::end(info->cache),
+                  cache_info_t{ -1, -1, -1, false, 0 });
     }
     // replicate device_info[0] over the entire range
     std::fill_n(&device_info[1], count - 1, device_info[0]);

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1645,6 +1645,34 @@ static void populate_core_group(Topology::CoreGrouping *group, const Topology::T
 
     fill_in_threads(group->cores, &Topology::Thread::core_id);
     // fill_in_threads(group->modules, &Topology::Thread::module_id);
+
+    // Attribute a share of each L3 instance to this grouping: a grouping may
+    // span several instances (summed) or only part of one (SNC, hybrid P/E),
+    // so each instance contributes in_group/total of its size.
+    constexpr int l3 = sizeof(cpu_info_t::cache) / sizeof(cpu_info_t::cache[0]) - 1;
+    std::map<int, int> in_group;
+    for (const Topology::Thread *t = begin; t != end; ++t) {
+        const cache_info_t &c = t->cache[l3];
+        if (c.cache_instruction >= 0 || c.cache_data >= 0)
+            ++in_group[c.id];
+    }
+    for (auto [id, count] : in_group) {
+        int total = 0;
+        size_t size = 0;
+        // Count the instance's threads across the whole system, not just this
+        // (possibly restricted) topology, so a grouping that covers only part
+        // of an instance is attributed its true fraction.
+        for (const cpu_info_t &info : std::span(sApp->shmem->device_info, sApp->shmem->total_device_count)) {
+            const cache_info_t &c = info.cache[l3];
+            if (c.id != id || (c.cache_instruction < 0 && c.cache_data < 0))
+                continue;
+            ++total;
+            size = c.is_unified ? c.cache_data
+                    : std::max(c.cache_instruction, 0) + std::max(c.cache_data, 0);
+        }
+        if (total > 0)
+            group->l3_cache_size += size * count / total;
+    }
 }
 
 static Topology build_topology()

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -469,6 +469,7 @@ bool TopologyDetector::create_mock_topology(const char *topo)
         info->cache[0] = { 0x2000, 0x2000 };
         info->cache[1] = { 0x8000, 0x8000 };
         info->cache[2] = { 0x40000, 0x40000 };
+        info->cache[2].is_unified = true;
 
         char c = topo[0] | 0x20;  // lowercased (if a letter); numbers unchanged
         // parse the different fields of the topology
@@ -581,13 +582,13 @@ bool TopologyDetector::detect_cache_via_os(Topology::Thread *info, int cpufd)
             IGNORE_RETVAL(fscanf(f, "%255s", buf));
             fclose(f);
 
-            if (strcmp(buf, "Instruction") == 0)
+            bool is_instruction = strcmp(buf, "Instruction") == 0;
+            bool is_data = strcmp(buf, "Data") == 0;
+            info->cache[level - 1].is_unified = !is_instruction && !is_data;
+            if (!is_data)
                 info->cache[level - 1].cache_instruction = size;
-            else if (strcmp(buf, "Data") == 0)
+            if (!is_instruction)
                 info->cache[level - 1].cache_data = size;
-            else
-                info->cache[level - 1].cache_instruction =
-                        info->cache[level - 1].cache_data = size;
         }
     }
     return true;
@@ -921,6 +922,8 @@ bool TopologyDetector::detect_topology_via_os(LOGICAL_PROCESSOR_RELATIONSHIP rel
                                  if (cache.Type == CacheUnified
                                          || cache.Type == CacheData)
                                      info->cache[level].cache_data = cache.CacheSize;
+                                 if (cache.Type == CacheUnified)
+                                     info->cache[level].is_unified = true;
                              }
                 );
             break;
@@ -1057,6 +1060,7 @@ bool TopologyDetector::detect_cache_via_cpuid(Topology::Thread *info,
                 info->cache[level - 1].cache_data =
                     info->cache[level - 1].cache_instruction =
                     size;
+                info->cache[level - 1].is_unified = true;
                 break;
             default: /* at this point it's > 3, i.e. a reserved value. */
                 return 1;

--- a/framework/device/cpu/topology_cpu.h
+++ b/framework/device/cpu/topology_cpu.h
@@ -37,6 +37,9 @@ public:
     {
         std::vector<Core> cores;
         // std::vector<Module> modules;
+
+        /// Size in bytes of the last-level (L3) cache attributable to this grouping.
+        size_t l3_cache_size = 0;
     };
 
     struct Package : CoreGrouping

--- a/framework/device/gpu/logging_gpu.cpp
+++ b/framework/device/gpu/logging_gpu.cpp
@@ -493,6 +493,11 @@ void AbstractLogger::print_fixed_for_device()
 
 }
 
+void AbstractLogger::device_print_extra_info()
+{
+
+}
+
 #else
 void dump_device_state(std::string&, int)
 {}

--- a/framework/device/idxd/logging_idxd.cpp
+++ b/framework/device/idxd/logging_idxd.cpp
@@ -22,6 +22,11 @@ void AbstractLogger::print_fixed_for_device()
 
 }
 
+void AbstractLogger::device_print_extra_info()
+{
+
+}
+
 void dump_device_state(std::string&, int)
 {
 

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -2336,6 +2336,8 @@ void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, 
                        thread_id_header_for_device(i, LOG_LEVEL_VERBOSE(2)).c_str(), i);
     }
 
+    device_print_extra_info();
+
     auto print_plan = [](const char *name, const SlicePlans::Slices &plan) {
         std::string result;
         for (SlicePlans::Slice s : plan) {

--- a/framework/logging.h
+++ b/framework/logging.h
@@ -130,6 +130,7 @@ public:
     static std::string thread_id_header_for_device(int device, LogLevelVerbosity verbosity);
     static void print_thread_header_for_device(int fd, PerThreadData::Test *thr);
     static void print_fixed_for_device();
+    static void device_print_extra_info();
 
 #ifdef SANDSTONE_DEVICE_CPU
     static std::string thread_id_header_for_cpu(LogicalProcessor lp, int device, LogLevelVerbosity verbosity);
@@ -199,6 +200,8 @@ inline std::string AbstractLogger::thread_id_header_for_device(int device, LogLe
 inline void AbstractLogger::print_thread_header_for_device(int fd, PerThreadData::Test *thr)
 { __builtin_unreachable(); }
 inline void AbstractLogger::print_fixed_for_device()
+{ __builtin_unreachable(); }
+inline void AbstractLogger::device_print_extra_info()
 { __builtin_unreachable(); }
 
 #  ifdef SANDSTONE_DEVICE_CPU

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -31,6 +31,7 @@
 #include "sandstone_kvm.h"
 #endif // _WIN32
 #include "sandstone_p.h"
+#include "topology.h"
 
 #include <exception>
 #include <unordered_map>
@@ -215,6 +216,31 @@ static int selftest_logformattedyaml_run(struct test *test, int cpu)
     log_yaml(SANDSTONE_LOG_INFO, "Some details from the test", map);
     return EXIT_SUCCESS;
 }
+
+#if SANDSTONE_DEVICE_CPU
+static int selftest_logs_l3cachesize_init(struct test *)
+{
+    const Topology &topology = Topology::topology();
+
+    size_t aggregate = 0;
+    std::string group_sizes;
+    for (const Topology::Package &pkg : topology.packages) {
+        for (const Topology::CoreGrouping &group : pkg.groups) {
+            if (group_sizes.size())
+                group_sizes += ", ";
+            group_sizes += std::to_string(group.l3_cache_size);
+        }
+        aggregate += pkg.l3_cache_size;
+    }
+
+    log_yaml(SANDSTONE_LOG_INFO,
+             stdprintf("L3 cache size for this topology\n"
+                       "l3-aggregate-size: %zu\n"
+                       "l3-group-sizes: [ %s ]\n\n",
+                       aggregate, group_sizes.c_str()).c_str());
+    return EXIT_SUCCESS;
+}
+#endif // SANDSTONE_DEVICE_CPU
 
 static int selftest_logs_options_init(struct test *test)
 {
@@ -1466,6 +1492,37 @@ static struct test selftests_array[] = {
     .desired_duration = -1,
     .quality_level = TEST_QUALITY_PROD,
 },
+#if SANDSTONE_DEVICE_CPU
+{
+    .id = "selftest_logs_l3cachesize",
+    .description = "Reports the aggregate L3 cache size of the topology (heuristic scheduling)",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_init = selftest_logs_l3cachesize_init,
+    .test_run = selftest_pass_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+},
+{
+    .id = "selftest_logs_l3cachesize_coregroup",
+    .description = "Reports the aggregate L3 cache size of the topology (core-group scheduling)",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_init = selftest_logs_l3cachesize_init,
+    .test_run = selftest_pass_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+    .flags = test_schedule_isolate_coregroup,
+},
+{
+    .id = "selftest_logs_l3cachesize_socket",
+    .description = "Reports the aggregate L3 cache size of the topology (socket scheduling)",
+    .groups = DECLARE_TEST_GROUPS(&group_positive),
+    .test_init = selftest_logs_l3cachesize_init,
+    .test_run = selftest_pass_run,
+    .desired_duration = -1,
+    .quality_level = TEST_QUALITY_PROD,
+    .flags = test_schedule_isolate_socket,
+},
+#endif // SANDSTONE_DEVICE_CPU
 {
     .id = "selftest_logdata",
     .description = "Logs data for later parsing",


### PR DESCRIPTION
Following up on #1160, this PR adds support for `l3_cache_size` in `Topology::CoreGroup`. For C code, there's a new `id` field in `struct cache_info_t` that can be used to match with other CPU's cache IDs and confirm whether they are the same (shared) or not.

The YAML header will also include the detected cache information. For example, on my TGL laptop:
```yaml
cache-info:
  L1:
    size: { instruction: 32768, data: 49152 }
  L2:
    size: { unified: 1310720 }
  L3:
    size: { unified: 12582912 }
    breakdown:
    - { size: 12582912, starting_cpu: 0, count: 8 }
```

The apportionment per core group is only reported in a self-test, because it depends on how the slice planning went (and is thus dependent on the `--max-cores-per-slice=` command-line option).