### PR TITLE
FW/child_debug/Unix: don't print NUL when gdb encounters an error

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -583,12 +583,11 @@ static auto communicate_gdb_backtrace(int in, int out, uintptr_t handle)
             size_t old_size = buf.size();
             buf.resize(old_size + more);
             ret = read(in, &buf[old_size], more);
+            buf.resize(old_size + std::max(ret, ssize_t(0)));
             if (ret < 0)
                 return false;
             if (ret == 0)
                 return ReadUntilEof;
-
-            buf.resize(old_size + ret);
 
             if constexpr (!ReadUntilEof) {
                 std::string_view n = needle;


### PR DESCRIPTION
read_until() over-allocates the buffer with FIONREAD's count (or a guessed 128 bytes when the ioctl fails) before read(), intending to trim it back down afterwards. But the ret <= 0 checks returned early, before the trim, so on EOF or EAGAIN the NUL padding stayed in the buffer. The backtrace read always terminates on EOF, so gdb's output ended up with trailing NUL bytes whenever the final read hit a non-zero over- allocation
-- which is exactly what happens when gdb aborts partway through (e.g. after printing "Recursive internal problem."). Those NULs then made the log YAML unparseable:
```
    yaml.reader.ReaderError: unacceptable character #x0000
```
Trim the buffer to the actual number of bytes read before the early returns so no stray NULs can survive.

Fixes #1173

[ChangeLog][Framework] Fixed a bug that would cause the tool to print stray NUL bytes to the log output if gdb encountered a problem when producing a backtrace for a crashed test.