### PR TITLE
FW: do not declare lambdas with ref capture as static

### DIFF
--- a/framework/device/gpu/topology.cpp
+++ b/framework/device/gpu/topology.cpp
@@ -129,7 +129,7 @@ void apply_deviceset_param(const char *param)
         ++param;
     }
 
-    static const auto apply_to_set = [&](const gpu_info_t &gpu) {
+    const auto apply_to_set = [&](const gpu_info_t &gpu) {
         if (result.contains(gpu.gpu_number)) { // we've got a duplicate
             return;
         }

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -1045,7 +1045,7 @@ int main(int argc, char **argv)
         }
     }
 
-    static auto check_and_exit_for_no_device = [&]() {
+    const auto check_and_exit_for_no_device = [&]() {
         if (!any_device) {
             fprintf(stderr, "%s: error: no devices found\n",
                     program_invocation_name);


### PR DESCRIPTION
This is bad, as captured references to local variables survive the function call.