### PR TITLE
meson: build fully position-independent

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,9 @@ project(
     'OpenDCDiag',
     ['c', 'cpp'],
     default_options: [
+        'b_pie=true',
         'b_ndebug=if-release',
+        'b_staticpic=true',
         'c_std=gnu17',
         'cpp_std=gnu++23',
     ],
@@ -128,7 +130,6 @@ endforeach
 foreach lflag : [
     '-Wl,-z,relro',
     '-Wl,-z,noexecstack',
-    '-pie',
 ]
     if cc.links('int main() { return 0; }', args: [lflag], name: lflag)
         add_project_link_arguments(lflag, language: ['c', 'cpp'])


### PR DESCRIPTION
At the project level, build all our internal static_libraries and executables with -fPIC and -fPIE, respectively.

Some position independent flags have been in OpenDCDiag for a while. Now, it's thorough. We leverage global meson built-in options to facilitate position-independent builds of our `static_library`s and executables.

Fixes: f8dcbb86fb92 ("Meson: Add multiple compilation flags")