### PR TITLE
bats: fix reschedule tests to not depend on real CPU topology

### DIFF
--- a/bats/sanity-check/25-cpu-topology.bats
+++ b/bats/sanity-check/25-cpu-topology.bats
@@ -616,6 +616,9 @@ function selftest_cpuset_accumulate() {
         skip "Not supported"
     fi
 
+    $is_debug || skip "Test only works with Debug builds to mock the topology"
+
+    export SANDSTONE_MOCK_TOPOLOGY='p0c0 p0c1 p1c0 p1c1'
     run $SANDSTONE --selftests -e selftest_logs_reschedule --reschedule=queue
     [[ $status == 64 ]] && false
 
@@ -645,6 +648,9 @@ function selftest_cpuset_accumulate() {
 }
 
 @test "selftest_fail_after_reschedule" {
+    $is_debug || skip "Test only works with Debug builds to mock the topology"
+
+    export SANDSTONE_MOCK_TOPOLOGY='p0c0 p0c1 p1c0 p1c1'
     run $SANDSTONE --selftests -e selftest_pass --reschedule=queue
     if [[ $status == 64 ]] || [[ "`uname -m`" != "x86_64" ]]; then
         skip "Not supported"


### PR DESCRIPTION
The `thread queue reschedule` and `selftest_fail_after_reschedule` tests hardcode expected CPU assignments after rescheduling, assuming a fixed seed is enough to make the queue shuffle deterministic.

It's not. The shuffle is seeded from thread 0's per-thread RNG, which is derived from both the global seed *and* the core/package ID of the physical CPU it's running on. On systems where the first CPU isn't core 0, the mixin is different and the shuffle comes out in a different order — causing the test to fail even though nothing is actually wrong.

Fix it by mocking the topology to a known layout (p0c0, p0c1, p1c0, p1c1), which guarantees thread 0 always runs on core 0 and the shuffle is reproducible. Since topology mocking requires a debug build, the tests are skipped on release builds.