### PR TITLE
FW: fix DECLARE_TEST generating _testid_TEST_ID_<name> alias

### DIFF
--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -47,6 +47,9 @@ extern "C" {
 #define SANDSTONE_STRINGIFY(name)       SANDSTONE_STRINGIFY2(name)
 #define SANDSTONE_STRINGIFY2(name)      #name
 
+#define SANDSTONE_CONCAT(a, b)          SANDSTONE_CONCAT2(a, b)
+#define SANDSTONE_CONCAT2(a, b)         a ## b
+
 #define MAX_HWTHREADS_PER_CORE  4
 
 #ifdef __APPLE__
@@ -154,7 +157,7 @@ typedef enum TestQuality {
 
 /// force the alignment so the compiler won't try to (un)helpfully overalign it.
 #define DECLARE_TEST_SECTION(test_id, test_short_id) \
-    __attribute__((alias("_test_" SANDSTONE_STRINGIFY(test_id)))) extern struct test _testid_ ## test_short_id; \
+    __attribute__((alias("_test_" SANDSTONE_STRINGIFY(test_id)))) extern struct test SANDSTONE_CONCAT(_testid_, test_short_id); \
     __attribute__((aligned(alignof(struct test)), used, section(SANDSTONE_SECTION_PREFIX "tests")))
 
 #define DECLARE_TEST_STRUCT(test_id, test_id_str, test_short_id, test_description) \

--- a/framework/sandstone.h
+++ b/framework/sandstone.h
@@ -155,9 +155,12 @@ typedef enum TestQuality {
 /// used in a test's test_init function to indicate that a test should be skipped.
 #define EXIT_SKIP               -255
 
-/// force the alignment so the compiler won't try to (un)helpfully overalign it.
+/// The `_testid_<shortid>` symbol carries no data; it exists solely so the linker
+/// reports a multiple-definition error if two tests hash to the same short ID.
+/// Force the alignment so the compiler won't try to (un)helpfully overalign it.
 #define DECLARE_TEST_SECTION(test_id, test_short_id) \
-    __attribute__((alias("_test_" SANDSTONE_STRINGIFY(test_id)))) extern struct test SANDSTONE_CONCAT(_testid_, test_short_id); \
+    extern const char SANDSTONE_CONCAT(_testid_, test_short_id); \
+    __attribute__((used)) const char SANDSTONE_CONCAT(_testid_, test_short_id) = 0; \
     __attribute__((aligned(alignof(struct test)), used, section(SANDSTONE_SECTION_PREFIX "tests")))
 
 #define DECLARE_TEST_STRUCT(test_id, test_id_str, test_short_id, test_description) \


### PR DESCRIPTION
The DECLARE_TEST_SECTION macro built the test alias symbol with `_testid_ ## test_short_id`. Because operands of the `##` paste operator are not macro-expanded, the `TEST_ID_<name>` argument was pasted literally, producing a `_testid_TEST_ID_<name>` symbol instead of the intended short-ID alias `_testid_<hex>`.

Add a two-level indirection helper SANDSTONE_CONCAT/SANDSTONE_CONCAT2 (mirroring the existing SANDSTONE_STRINGIFY) so the TEST_ID_<name> macro expands to its 6-hex-digit value before being pasted onto the `_testid_` prefix.

This was likely introduced by commit eec07754522ed1ec271ff750fa700e5a8e52e6b9 ("FW: add `DECLARE_MANUAL_TEST` macro for declaring special tests").

Also split the symbols so that the debugger doesn't list the test name as the short ID. This will increase the binary size by 1 byte for each test we have...