### PR TITLE
FW/Win32: fix several mmap() permission errors

### DIFF
--- a/framework/sysdeps/windows/mman.c
+++ b/framework/sysdeps/windows/mman.c
@@ -78,7 +78,17 @@ static DWORD map_max_protection(int prot, int flags)
     DWORD flProtect = PAGE_NOACCESS;
     if (flags & MAP_PRIVATE) {
         if (flags & MAP_ANONYMOUS)
-            flProtect = PAGE_EXECUTE_WRITECOPY;
+            // Anonymous private mappings are backed by the page file, not a
+            // real file, so there's no reason to restrict the section to
+            // copy-on-write protection. Use PAGE_EXECUTE_READWRITE instead,
+            // so later mprotect()/VirtualProtect() calls can grant any
+            // combination of read/write/exec permissions (e.g. JIT buffers
+            // toggling between writable and executable). Per MS docs,
+            // mapping such a view with FILE_MAP_COPY access (below) also
+            // requires the section's protection to be PAGE_READWRITE,
+            // PAGE_EXECUTE_READWRITE, PAGE_READONLY, or PAGE_EXECUTE_READ --
+            // not one of the WRITECOPY variants.
+            flProtect = PAGE_EXECUTE_READWRITE;
         else
             flProtect = priv_mapping[prot & PROT_MASK];
     } else {


### PR DESCRIPTION
`map_max_protection()` capped anonymous `MAP_PRIVATE|MAP_ANONYMOUS` mappings at `PAGE_EXECUTE_WRITECOPY,` which Windows does not allow VirtualProtect() to upgrade to `PAGE_EXECUTE_READWRITE`. This broke self-modifying-code JIT tests that legitimately need a buffer transitioned to simultaneously writable and executable (PROTECT_RWE) via Xbyak's MmapAllocator, causing a "can't protect" exception. And it was not ideal for file-backed (not anonymous mappings).

Instead, for file-backed mappings, let's query what the file was opened with. We do that using the undocumented `NtQueryObject` function, but which has been available in ntdll.dll for decades (and is not the first function from ntdll.dll we use). For anonymous ones, we can simply grant max permissions (`PAGE_EXECUTE_READWRITE`). This should allow the test to use `mprotect()` to change permissions at will, so long as it's an anonymous mapping or opened with `open_memfd()` (see #1225).