### PR TITLE
FW/Topology/CPU: add view-iterators for portions of a system

### DIFF
--- a/framework/device/cpu/meson.build
+++ b/framework/device/cpu/meson.build
@@ -20,15 +20,17 @@ generated_files += configure_file(
 
 framework_files += files(
     'cpu_device.cpp',
-    'topology.cpp',
     'logging_cpu.cpp',
     'slicing.cpp',
+    'topology.cpp',
+    'topology_cpu.cpp',
 )
 
 unittests_sources += files(
     'unit-tests/thermal_monitor_tests.cpp',
     'unit-tests/topology_tests.cpp',
     'slicing.cpp',
+    'topology_cpu.cpp',
 )
 
 premain_files += files(

--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1626,30 +1626,14 @@ void TopologyDetector::detect(const LogicalProcessorSet &enabled_cpus)
     detect_numa();
 }
 
-static void populate_core_group(Topology::CoreGrouping *group, const Topology::Thread *begin,
-                                const Topology::Thread *end)
+static void attribute_share_of_cache(Topology::CoreGrouping *group)
 {
-    // fill in the threads
-    auto fill_in_threads = [&](auto &where, auto what) {
-        const Topology::Thread *first = begin;
-        const Topology::Thread *last = first;
-        for ( ; last != end; ++last) {
-            if (last->*what == first->*what)
-                continue;
-            where.push_back({ { first, last } });
-            first = last;
-        }
-        // add any remainders
-        where.push_back({ { first, end } });
-    };
-
-    fill_in_threads(group->cores, &Topology::Thread::core_id);
-    // fill_in_threads(group->modules, &Topology::Thread::module_id);
-
     // Attribute a share of each L3 instance to this grouping: a grouping may
     // span several instances (summed) or only part of one (SNC, hybrid P/E),
     // so each instance contributes in_group/total of its size.
     constexpr int l3 = sizeof(cpu_info_t::cache) / sizeof(cpu_info_t::cache[0]) - 1;
+    const Topology::Thread *begin = std::to_address(group->cores.begin()->threads.begin());
+    const Topology::Thread *end = std::to_address(group->cores.begin()->threads.end());
     std::map<int, int> in_group;
     for (const Topology::Thread *t = begin; t != end; ++t) {
         const cache_info_t &c = t->cache[l3];
@@ -1677,82 +1661,20 @@ static void populate_core_group(Topology::CoreGrouping *group, const Topology::T
 
 static Topology build_topology()
 {
-    const cpu_info_t *info = device_info;
-    const cpu_info_t *const end = device_info + device_count();
+    Topology topo = Topology::build_topology({ device_info, device_info + device_count() });
 
-    std::vector<Topology::Package> packages;
-    if (int max_package_id = end[-1].package_id; max_package_id >= 0)
-        packages.reserve(max_package_id + 1);
-    else
-        return Topology({});
-
-    while (info != end) {
-        if (info->package_id < 0 || info->core_id < 0 || info->thread_id < 0)
-            return Topology({});
-
-        Topology::Package *pkg = &packages.emplace_back();
-
-        // scan forward to the end of this package
-        const Topology::Thread *first = info;
-        const Topology::Thread *groupfirst = info;
-        int core_count = 0;
-        for (int last_core_id = -1; info != end; ++info) {
-            if (info->core_id < 0 || info->thread_id < 0)
-                return Topology({});
-            if (info->package_id != first->package_id)
-                break;
-            if (info->core_id != last_core_id) {
-                ++core_count;
-                last_core_id = info->core_id;
-            }
-
-            bool is_new_group = info->numa_id != groupfirst->numa_id;
-            if (!is_new_group)
-                is_new_group = info->die_id != groupfirst->die_id;
-            if (!is_new_group)
-                is_new_group = info->native_core_type != groupfirst->native_core_type;
-            if (is_new_group) {
-                populate_core_group(&pkg->groups.emplace_back(), groupfirst, info);
-                groupfirst = info;
-            }
-        }
-
-        // populate the full core
-        pkg->cores.reserve(core_count + 1);
-        populate_core_group(pkg, first, info);
-
-        // populate the last core group, which may be the only one too
-        Topology::CoreGrouping *lastgroup = &pkg->groups.emplace_back();
-        if (pkg->groups.size() == 1)
-            lastgroup->CoreGrouping::operator=(*pkg);    // just copy the Package
-        else
-            populate_core_group(lastgroup, groupfirst, info);
+    // post-process every core group
+    for (Topology::Package &p : topo.packages) {
+        attribute_share_of_cache(&p);
+        for (Topology::CoreGrouping &g : p.groups)
+            attribute_share_of_cache(&g);
     }
-
-    return Topology(std::move(packages));
+    return topo;
 }
 
 const Topology &Topology::topology()
 {
     return cached_topology();
-}
-
-Topology::Data Topology::clone() const
-{
-    Data result;
-    result.all_threads.assign(device_info, device_info + device_count());
-    result.packages = packages;
-
-    // now update all spans to point to the data we carry
-    for (Package &pkg : result.packages) {
-        for (Core &core : pkg.cores) {
-            int starting_cpu = core.threads.front().cpu();
-            int ending_cpu = core.threads.back().cpu();
-            core.threads = { result.all_threads.data() + starting_cpu,
-                             result.all_threads.data() + ending_cpu + 1 };
-        }
-    }
-    return result;
 }
 
 void update_topology(std::span<const cpu_info_t> new_cpu_info,

--- a/framework/device/cpu/topology_cpu.cpp
+++ b/framework/device/cpu/topology_cpu.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "topology_cpu.h"
+
+#include <map>
+#include <vector>
+
+static void populate_core_group(Topology::CoreGrouping *group, const Topology::Thread *begin,
+                                const Topology::Thread *end)
+{
+    // fill in the threads
+    auto fill_in_threads = [&](auto &where, auto what) {
+        const Topology::Thread *first = begin;
+        const Topology::Thread *last = first;
+        for ( ; last != end; ++last) {
+            if (last->*what == first->*what)
+                continue;
+            where.push_back({ { first, last } });
+            first = last;
+        }
+        // add any remainders
+        where.push_back({ { first, end } });
+    };
+
+    fill_in_threads(group->cores, &Topology::Thread::core_id);
+    // fill_in_threads(group->modules, &Topology::Thread::module_id);
+}
+
+Topology Topology::build_topology(std::span<const Thread> threads)
+{
+    const cpu_info_t *info = threads.data();
+    const cpu_info_t *const end = threads.data() + threads.size();
+
+    std::vector<Topology::Package> packages;
+    if (threads.empty())
+        return Topology({});
+    if (int max_package_id = end[-1].package_id; max_package_id >= 0)
+        packages.reserve(max_package_id + 1);
+    else
+        return Topology({});
+
+    while (info != end) {
+        if (info->package_id < 0 || info->core_id < 0 || info->thread_id < 0)
+            return Topology({});
+
+        Topology::Package *pkg = &packages.emplace_back();
+
+        // scan forward to the end of this package
+        const Topology::Thread *first = info;
+        const Topology::Thread *groupfirst = info;
+        int core_count = 0;
+        for (int last_core_id = -1; info != end; ++info) {
+            if (info->core_id < 0 || info->thread_id < 0)
+                return Topology({});
+            if (info->package_id != first->package_id)
+                break;
+            if (info->core_id != last_core_id) {
+                ++core_count;
+                last_core_id = info->core_id;
+            }
+
+            bool is_new_group = info->numa_id != groupfirst->numa_id;
+            if (!is_new_group)
+                is_new_group = info->die_id != groupfirst->die_id;
+            if (!is_new_group)
+                is_new_group = info->native_core_type != groupfirst->native_core_type;
+            if (is_new_group) {
+                populate_core_group(&pkg->groups.emplace_back(), groupfirst, info);
+                groupfirst = info;
+            }
+        }
+
+        // populate the full core
+        pkg->cores.reserve(core_count + 1);
+        populate_core_group(pkg, first, info);
+
+        // populate the last core group, which may be the only one too
+        Topology::CoreGrouping *lastgroup = &pkg->groups.emplace_back();
+        if (pkg->groups.size() == 1)
+            lastgroup->CoreGrouping::operator=(*pkg);    // just copy the Package
+        else
+            populate_core_group(lastgroup, groupfirst, info);
+    }
+
+    return Topology(std::move(packages));
+}
+
+Topology::Data Topology::clone() const
+{
+    Data result;
+    result.all_threads.assign(device_info, device_info + device_count());
+    result.packages = packages;
+
+    // now update all spans to point to the data we carry
+    for (Package &pkg : result.packages) {
+        for (Core &core : pkg.cores) {
+            int starting_cpu = core.threads.front().cpu();
+            int ending_cpu = core.threads.back().cpu();
+            core.threads = { result.all_threads.data() + starting_cpu,
+                             result.all_threads.data() + ending_cpu + 1 };
+        }
+    }
+    return result;
+}

--- a/framework/device/cpu/topology_cpu.h
+++ b/framework/device/cpu/topology_cpu.h
@@ -62,6 +62,7 @@ public:
     std::string build_failure_mask(const struct test *test) const;
 
     static const Topology &topology();
+    static Topology build_topology(std::span<const Thread> threads);
     struct Data;
     Data clone() const;
 };

--- a/framework/device/cpu/topology_cpu.h
+++ b/framework/device/cpu/topology_cpu.h
@@ -28,15 +28,10 @@ public:
     {
         std::span<const Thread> threads;
     };
-    struct Module
-    {
-        std::span<const Thread> threads;
-    };
 
     struct CoreGrouping
     {
         std::vector<Core> cores;
-        // std::vector<Module> modules;
 
         /// Size in bytes of the last-level (L3) cache attributable to this grouping.
         size_t l3_cache_size = 0;

--- a/framework/device/cpu/topology_cpu.h
+++ b/framework/device/cpu/topology_cpu.h
@@ -22,11 +22,34 @@ using EnabledDevices = LogicalProcessorSet;
 
 class Topology
 {
+    template <auto Field, typename Source> struct CoreViewGroupedByField;
+    template <auto Field, typename Source> struct CoreGroupingView;
+
 public:
     using Thread = cpu_info_t;
     struct Core
     {
         std::span<const Thread> threads;
+        int id() const
+        { return threads.size() ? threads.front().core_id : -1; }
+    };
+
+    // Non-owning version of CoreGrouping
+    struct CoreGroupingViewBase
+    {
+        std::span<const Core> cores;
+
+        using Module = CoreGroupingView<&Thread::module_id, CoreGroupingViewBase>;
+        using ModuleView = CoreViewGroupedByField<&Thread::module_id, CoreGroupingViewBase>;
+        ModuleView modules() const noexcept;
+
+        using Die = CoreGroupingView<&Thread::die_id, CoreGroupingViewBase>;
+        using DieView = CoreViewGroupedByField<&Thread::die_id, CoreGroupingViewBase>;
+        DieView dies() const noexcept;
+
+        using NumaDomain = CoreGroupingView<&Thread::numa_id, CoreGroupingViewBase>;
+        using NumaDomainView = CoreViewGroupedByField<&Thread::numa_id, CoreGroupingViewBase>;
+        NumaDomainView numa_domains() const noexcept;
     };
 
     struct CoreGrouping
@@ -35,6 +58,18 @@ public:
 
         /// Size in bytes of the last-level (L3) cache attributable to this grouping.
         size_t l3_cache_size = 0;
+
+        using Module = CoreGroupingView<&Thread::module_id, CoreGrouping>;
+        using ModuleView = CoreViewGroupedByField<&Thread::module_id, CoreGrouping>;
+        ModuleView modules() const noexcept;
+
+        using Die = CoreGroupingView<&Thread::die_id, CoreGrouping>;
+        using DieView = CoreViewGroupedByField<&Thread::die_id, CoreGrouping>;
+        DieView dies() const noexcept;
+
+        using NumaDomain = CoreGroupingView<&Thread::numa_id, CoreGrouping>;
+        using NumaDomainView = CoreViewGroupedByField<&Thread::numa_id, CoreGrouping>;
+        NumaDomainView numa_domains() const noexcept;
     };
 
     struct Package : CoreGrouping
@@ -60,7 +95,171 @@ public:
     static Topology build_topology(std::span<const Thread> threads);
     struct Data;
     Data clone() const;
+
+    // using Core = Core;
+    using CoreView = CoreViewGroupedByField<&Thread::core_id, Package>;
+    CoreView cores() const noexcept;
+
+    using Module = CoreGroupingView<&Thread::module_id, Package>;
+    using ModuleView = CoreViewGroupedByField<&Thread::module_id, Package>;
+    ModuleView modules() const noexcept;
+
+    using Die = CoreGroupingView<&Thread::die_id, Package>;
+    using DieView = CoreViewGroupedByField<&Thread::die_id, Package>;
+    DieView dies() const noexcept;
+
+    using NumaDomain = CoreGroupingView<&Thread::numa_id, Package>;
+    using NumaDomainView = CoreViewGroupedByField<&Thread::numa_id, Package>;
+    NumaDomainView numa_domains() const noexcept;
 };
+
+template <auto Field, typename Source>
+struct Topology::CoreGroupingView : public CoreGroupingViewBase
+{
+    int id() const noexcept { return cores.size() ? cores[0].threads[0].*Field : -1; }
+};
+
+template <auto Field, typename Source> struct Topology::CoreViewGroupedByField :
+        public std::ranges::view_interface<CoreViewGroupedByField<Field, Source>>
+{
+private:
+    // If Source is Package, we are viewing the whole-system;
+    // if it is Core, we are inside of a package or a subdivision thereof.
+    using SourceSpan = std::span<const Source>;
+    using CoreGroupingView = Topology::CoreGroupingView<Field, Source>;
+
+    static constexpr bool is_view_of_cores = (Field == &Thread::core_id);
+
+    static int id_for(const Core &c) noexcept
+    { return c.threads[0].*Field; }
+
+public:
+    using element_type = std::conditional_t<is_view_of_cores, Core, CoreGroupingView>;
+    using value_type = element_type;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using pointer = const element_type *;
+    using const_pointer = const element_type *;
+    using reference = const element_type &;
+    using const_reference = const element_type &;
+
+    struct iterator {
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = CoreViewGroupedByField::element_type;
+        using difference_type = ptrdiff_t;
+        using pointer = const value_type *;
+        using reference = const value_type &;
+
+        constexpr iterator() noexcept = default;
+
+        const_pointer operator->() const noexcept
+        {
+            if constexpr (is_view_of_cores)
+                return current.cores.data();        // const Core *
+            else
+                return &current;                    // const value_type *
+        }
+        const_reference operator*() const noexcept
+        { return *operator->(); }
+
+        iterator &operator++() noexcept
+        {
+            auto next = current.cores.end();
+            if (next == segment().end()) {
+                // Move to the next grouping.
+                groupings = groupings.subspan(1);
+                if (groupings.empty()) {
+                    current.cores = {};             // the end
+                    return *this;
+                }
+                next = segment().begin();
+            }
+
+            current.cores = { next, find_end(next) };
+            return *this;
+        }
+
+        iterator operator++(int) noexcept
+        {
+            iterator tmp = *this;
+            operator++();
+            return tmp;
+        }
+
+        friend bool operator==(iterator l, iterator r) noexcept
+        {
+            if (l.current.cores.begin() != r.current.cores.begin())
+                return false;
+            assert(l.current.cores.end() == r.current.cores.end());
+            assert(l.groupings.begin() == r.groupings.begin());
+            assert(l.groupings.end() == r.groupings.end());
+            return true;
+        }
+        friend bool operator==(iterator it, std::default_sentinel_t) noexcept
+        { return it.current.cores.empty(); }
+    private:
+        friend struct CoreViewGroupedByField<Field, Source>;
+        SourceSpan groupings;
+        CoreGroupingView current = {};
+
+        constexpr explicit iterator(SourceSpan src) noexcept : groupings(src)
+        {
+            if (groupings.empty())
+                return;
+            if (std::span seg = segment(); !seg.empty())
+                current.cores = std::span<const Core>(seg.begin(), find_end(seg.begin()));
+        }
+
+        constexpr std::span<const Core> segment() const noexcept
+        {
+            return groupings.front().cores;
+        }
+
+        constexpr auto find_end(std::span<const Core>::iterator ptr) const noexcept
+        {
+            auto stop = segment().end();
+            int curr_id = id_for(*ptr);
+            for ( ; ptr != stop; ++ptr) {
+                if (id_for(*ptr) != curr_id)
+                    break;
+            }
+            return ptr;
+        };
+    };
+    using const_iterator = iterator;
+
+    constexpr iterator begin() const noexcept       { return iterator(source); }
+    constexpr std::default_sentinel_t end() const noexcept { return {}; }
+
+    constexpr CoreViewGroupedByField() = default;
+    constexpr explicit CoreViewGroupedByField(SourceSpan src) noexcept : source(src) {}
+    constexpr explicit CoreViewGroupedByField(const Source *src) noexcept : source(src, 1) {}
+private:
+    SourceSpan source;
+};
+
+inline auto Topology::CoreGroupingViewBase::modules() const noexcept -> ModuleView
+{ return ModuleView(this); }
+inline auto Topology::CoreGroupingViewBase::dies() const noexcept -> DieView
+{ return DieView(this); }
+inline auto Topology::CoreGroupingViewBase::numa_domains() const noexcept -> NumaDomainView
+{ return NumaDomainView(this); }
+
+inline auto Topology::CoreGrouping::modules() const noexcept -> ModuleView
+{ return ModuleView(this); }
+inline auto Topology::CoreGrouping::dies() const noexcept -> DieView
+{ return DieView(this); }
+inline auto Topology::CoreGrouping::numa_domains() const noexcept -> NumaDomainView
+{ return NumaDomainView(this); }
+
+inline auto Topology::numa_domains() const noexcept -> NumaDomainView
+{ return NumaDomainView(packages); }
+inline auto Topology::dies() const noexcept -> DieView
+{ return DieView(std::span<const Package>(packages)); }
+inline auto Topology::modules() const noexcept -> ModuleView
+{ return ModuleView(std::span<const Package>(packages)); }
+inline auto Topology::cores() const noexcept -> CoreView
+{ return CoreView(std::span<const Package>(packages)); }
 
 struct Topology::Data
 {

--- a/framework/device/cpu/unit-tests/topology_tests.cpp
+++ b/framework/device/cpu/unit-tests/topology_tests.cpp
@@ -88,6 +88,19 @@ void expect_plan(const SlicePlans::Slices &actual, const std::vector<std::pair<i
     }
 }
 
+// Saves and restores the mutable globals the framework stubs expose, so a test
+// that describes an unusual topology cannot leak state into later tests.
+struct TopologyStateGuard
+{
+    device_info_t *saved_device_info = device_info;
+    int saved_device_count = unittests_device_count;
+    ~TopologyStateGuard()
+    {
+        device_info = saved_device_info;
+        unittests_device_count = saved_device_count;
+    }
+};
+
 
 // Replicates TopologyDetector's ordering so tests can assert their storage is
 // laid out the way build_topology() requires.
@@ -334,4 +347,523 @@ TEST(BuildTopology, ManySinglecorePackages)
     for (int pkg = 0; pkg < packages; ++pkg)
         expected.push_back({ pkg, { { { pkg, 1 } } } });
     expect_topology(topo, storage.threads.data(), expected);
+}
+
+// ---- Grouped-core view tests ---------------------------------
+
+TEST(ViewTopology, EmptyYieldsNothing)
+{
+    TopologyStateGuard guard;
+    device_info = nullptr;
+
+    {
+        Topology topo;
+        auto cores = topo.cores();
+        static_assert(std::ranges::forward_range<decltype(cores)>);
+        static_assert(std::ranges::view<decltype(cores)>);
+        EXPECT_TRUE(cores.begin() == cores.begin());
+        EXPECT_FALSE(cores.begin() != cores.begin());
+        EXPECT_TRUE(cores.begin() == cores.end());          // range is empty
+        EXPECT_FALSE(cores.begin() != cores.end());
+        EXPECT_TRUE(cores.empty());
+        EXPECT_FALSE(cores);
+        for (auto it = cores.begin(); it != cores.end(); ++it) {
+            static_assert(std::forward_iterator<decltype(it)>);
+            // range was empty
+            FAIL();
+        }
+
+        EXPECT_TRUE(topo.modules().empty());
+        EXPECT_TRUE(topo.dies().empty());
+        EXPECT_TRUE(topo.numa_domains().empty());
+        EXPECT_FALSE(topo.modules());
+        EXPECT_FALSE(topo.dies());
+        EXPECT_FALSE(topo.numa_domains());
+    }
+    {
+        Topology::CoreGrouping group;
+        auto modules = group.modules();
+        static_assert(std::ranges::forward_range<decltype(modules)>);
+        static_assert(std::ranges::view<decltype(modules)>);
+        EXPECT_TRUE(modules.begin() == modules.begin());
+        EXPECT_FALSE(modules.begin() != modules.begin());
+        EXPECT_TRUE(modules.begin() == modules.end());          // range is empty
+        EXPECT_FALSE(modules.begin() != modules.end());
+        EXPECT_TRUE(modules.empty());
+        EXPECT_FALSE(modules);
+        for (auto it = modules.begin(); it != modules.end(); ++it) {
+            static_assert(std::forward_iterator<decltype(it)>);
+            // range was empty
+            FAIL();
+        }
+
+        EXPECT_TRUE(group.dies().empty());
+        EXPECT_TRUE(group.numa_domains().empty());
+        EXPECT_FALSE(group.dies());
+        EXPECT_FALSE(group.numa_domains());
+    }
+}
+
+// module/die/numa are all -1 here; the views group them like any other id (one
+// run of -1), whereas find_*_by_id(-1) returns empty.
+TEST(ViewTopology, NonEmptyBasics)
+{
+    static constexpr int core_count = 8;
+    TopologyStateGuard guard;
+    device_info = nullptr;
+
+    StorageBuilder storage;
+    for (int core = 0; core < core_count; ++core)
+        storage.add_core(0, -1, -1, -1, core, 2, core_type_unknown);
+    ASSERT_TRUE(std::ranges::is_sorted(storage.threads, detector_less));
+    ASSERT_EQ(storage.threads.size(), core_count * 2); // two threads per core
+    Topology topo = Topology::build_topology(storage.threads);
+
+    {
+        auto cores = topo.cores();
+        EXPECT_TRUE(cores.begin() == cores.begin());
+        EXPECT_FALSE(cores.begin() != cores.begin());
+        EXPECT_TRUE(cores.begin() != cores.end());
+        EXPECT_FALSE(cores.begin() == cores.end());
+        EXPECT_FALSE(cores.empty());
+        int core_counter = 0;
+        for (const Topology::Core &core : cores) {
+            EXPECT_EQ(core.id(), core_counter);
+            EXPECT_EQ(&core.threads.front(), &storage.threads[core_counter * 2]);
+            ++core_counter;
+        }
+        EXPECT_EQ(core_counter, core_count);
+
+        auto it = cores.begin();
+        auto copy = it;
+        EXPECT_EQ(it->id(), copy->id());
+        EXPECT_EQ(it++, copy++);
+        EXPECT_EQ(++it, ++copy);
+        EXPECT_EQ(it->id(), copy->id());
+        EXPECT_EQ(std::to_address(it), std::to_address(copy));  // they still point to the same Core
+        EXPECT_EQ(std::next(cores.begin(), core_count), cores.end());
+    }
+
+    // we should find exactly one of the following
+    auto check_view_has_one_element = [](const auto &view) {
+        using View = std::decay_t<decltype(view)>;
+        static_assert(std::ranges::forward_range<View>);
+        static_assert(std::ranges::view<View>);
+        EXPECT_TRUE(view);
+        EXPECT_FALSE(view.empty());
+        auto it = view.begin();
+        EXPECT_EQ(std::ranges::distance(it, view.end()), 1);
+        EXPECT_TRUE(it != view.end());
+        EXPECT_FALSE(it == view.end());
+        EXPECT_EQ(it->id(), -1);
+        EXPECT_EQ(std::next(it), view.end());
+        std::span cores = it->cores;
+        EXPECT_EQ(++it, view.end());
+
+        EXPECT_FALSE(cores.empty());
+        EXPECT_EQ(cores.size(), core_count);
+        EXPECT_EQ(cores.data()->threads.size(), 2);
+    };
+    check_view_has_one_element(topo.modules());
+    check_view_has_one_element(topo.dies());
+    check_view_has_one_element(topo.numa_domains());
+    check_view_has_one_element(topo.packages[0].modules());
+    check_view_has_one_element(topo.packages[0].dies());
+    check_view_has_one_element(topo.packages[0].numa_domains());
+}
+
+// 24 quad-core modules (still homogeneous)
+TEST(ViewTopology, ModulesWithinSinglePackage)
+{
+    static constexpr int module_count = 24;
+    static constexpr int cores_per_module = 4;
+    static constexpr int core_count = module_count * cores_per_module;
+    TopologyStateGuard guard;
+    device_info = nullptr;
+
+    StorageBuilder storage;
+    int module = 0;
+    for (int i = 0; i < module_count; ++i, module += 64) {
+        for (int j = 0; j < cores_per_module; ++j)
+            storage.add_core(5, -1, 0, module, module + j, 1, core_type_efficiency);
+    }
+    ASSERT_TRUE(std::ranges::is_sorted(storage.threads, detector_less));
+    ASSERT_EQ(storage.threads.size(), core_count);
+    Topology topo = Topology::build_topology(storage.threads);
+
+    {
+        auto modules = topo.modules();
+        EXPECT_TRUE(modules.begin() == modules.begin());
+        EXPECT_FALSE(modules.begin() != modules.begin());
+        EXPECT_TRUE(modules.begin() != modules.end());
+        EXPECT_FALSE(modules.begin() == modules.end());
+        EXPECT_FALSE(modules.empty());
+
+        int module_counter = 0;
+        for (auto module : modules) {
+            EXPECT_EQ(module.cores.size(), cores_per_module);
+            EXPECT_EQ(module.cores.front().id(), module_counter * 64);
+            EXPECT_EQ(&module.cores.front().threads.front(), &storage.threads[module_counter * cores_per_module]);
+            ++module_counter;
+        }
+        EXPECT_EQ(module_counter, module_count);
+
+        auto it = modules.begin();
+        auto copy = it;
+        EXPECT_EQ(it++, copy++);
+        EXPECT_EQ(++it, ++copy);
+        EXPECT_EQ(it->cores.data(), copy->cores.data());  // they still point to the same thing
+    }
+
+    // single one of each of the following
+    auto check_view_has_one_element = [](const auto &view, int id) {
+        EXPECT_TRUE(view);
+        EXPECT_FALSE(view.empty());
+        auto it = view.begin();
+        EXPECT_EQ(std::ranges::distance(it, view.end()), 1);
+        EXPECT_TRUE(it != view.end());
+        EXPECT_FALSE(it == view.end());
+        EXPECT_EQ(it->id(), id);
+        std::span cores = it->cores;
+        EXPECT_EQ(++it, view.end());
+
+        EXPECT_EQ(cores.size(), core_count);
+        EXPECT_FALSE(cores.empty());
+        EXPECT_EQ(cores.size(), core_count);
+        EXPECT_EQ(cores.data()->threads.size(), 1);
+    };
+    check_view_has_one_element(topo.dies(), 0);
+    check_view_has_one_element(topo.numa_domains(), -1);
+    check_view_has_one_element(topo.packages[0].dies(), 0);
+    check_view_has_one_element(topo.packages[0].numa_domains(), -1);
+}
+
+// Two packages, 4 dies / 2 NUMA domains each, 1 thread per core. die_id and
+// module_id repeat in package 1.
+TEST(ViewTopology, WholeSystemChainsAndResetsPerPackage)
+{
+    static constexpr int cores_per_die = 2;
+    static constexpr int dies_per_pkg = 4;
+    static constexpr int numa_domains_per_pkg = 2;
+    static constexpr int cores_per_numa_domain = cores_per_die * dies_per_pkg / numa_domains_per_pkg;
+    static constexpr int cores_per_pkg = cores_per_die * dies_per_pkg;
+    auto size = [](const auto &view) { return std::ranges::distance(view); };
+    TopologyStateGuard guard;
+    device_info = nullptr;
+
+    StorageBuilder storage;
+    for (int pkg = 0, numa = 0; pkg < 2; ++pkg) {
+        int core = 0;
+        for (int die = 0; die < dies_per_pkg; ++die) {
+            for (int c = 0; c < cores_per_die; ++c, ++core)
+                storage.add_core(pkg, numa, die, core, core * 2, 1, core_type_unknown);
+            numa += (die & 1);
+        }
+    }
+    ASSERT_TRUE(std::ranges::is_sorted(storage.threads, detector_less));
+    Topology topo = Topology::build_topology(storage.threads);
+    ASSERT_EQ(topo.packages.size(), 2u);
+    ASSERT_EQ(topo.packages[0].groups.size(), dies_per_pkg);
+    ASSERT_EQ(topo.packages[1].groups.size(), dies_per_pkg);
+
+    EXPECT_EQ(size(topo.cores()), cores_per_pkg * topo.packages.size());
+    EXPECT_EQ(size(topo.packages[0].cores), cores_per_pkg);
+    EXPECT_EQ(size(topo.packages[1].cores), cores_per_pkg);
+
+    {
+        int numa_id = 0;
+        auto sysnuma = topo.numa_domains();
+        auto pkgnuma = topo.packages[0].numa_domains();
+        EXPECT_FALSE(sysnuma.empty());
+        EXPECT_FALSE(pkgnuma.empty());
+        EXPECT_EQ(size(pkgnuma), numa_domains_per_pkg);
+        EXPECT_EQ(size(sysnuma), numa_domains_per_pkg * topo.packages.size());
+
+        // co-iteration on the first package:
+        auto sit = sysnuma.begin();
+        auto pit = pkgnuma.begin();
+        for ( ; pit != pkgnuma.end(); ++pit, ++sit, ++numa_id) {
+            EXPECT_NE(sit, sysnuma.end());
+            EXPECT_EQ(sit->id(), numa_id);
+            EXPECT_EQ(pit->id(), numa_id);
+
+            Topology::NumaDomain group = *sit;
+            EXPECT_EQ(&group.cores.front().threads.front(), &storage.threads[numa_id * cores_per_numa_domain]);
+            EXPECT_EQ(group.cores.size(), cores_per_numa_domain);
+            EXPECT_EQ(sit->cores.size(), cores_per_numa_domain);
+        }
+
+        // co-iteration on the second package:
+        // numa_ids are not repeated
+        pkgnuma = topo.packages[1].numa_domains();
+        EXPECT_FALSE(pkgnuma.empty());
+        EXPECT_EQ(size(pkgnuma), numa_domains_per_pkg);
+        for (pit = pkgnuma.begin(); pit != pkgnuma.end(); ++pit, ++sit, ++numa_id) {
+            EXPECT_NE(sit, sysnuma.end());
+            EXPECT_EQ(sit->id(), numa_id);
+            EXPECT_EQ(pit->id(), numa_id);
+
+            Topology::NumaDomain group = *sit;
+            EXPECT_EQ(&group.cores.front().threads.front(), &storage.threads[numa_id * cores_per_numa_domain]);
+            EXPECT_EQ(group.cores.size(), cores_per_numa_domain);
+            EXPECT_EQ(sit->cores.size(), cores_per_numa_domain);
+        }
+        EXPECT_EQ(sit, sysnuma.end());
+    }
+    {
+        int die_id = 0;
+        auto sysdie = topo.dies();
+        auto pkgdie = topo.packages[0].dies();
+        EXPECT_FALSE(sysdie.empty());
+        EXPECT_FALSE(pkgdie.empty());
+        EXPECT_EQ(size(pkgdie), dies_per_pkg);
+        EXPECT_EQ(size(sysdie), dies_per_pkg * topo.packages.size());
+
+        // co-iteration on the first package:
+        auto sit = sysdie.begin();
+        auto pit = pkgdie.begin();
+        for ( ; pit != pkgdie.end(); ++pit, ++sit, ++die_id) {
+            EXPECT_NE(sit, sysdie.end());
+            EXPECT_EQ(sit->id(), die_id);
+            EXPECT_EQ(pit->id(), die_id);
+
+            Topology::Die group = *sit;
+            EXPECT_EQ(&group.cores.front().threads.front(), &storage.threads[die_id * cores_per_die]);
+            EXPECT_EQ(group.cores.size(), cores_per_die);
+            EXPECT_EQ(sit->cores.size(), cores_per_die);
+        }
+
+        // co-iteration on the second package:
+        die_id = 0;         // die IDs are repeated
+        pkgdie = topo.packages[1].dies();
+        EXPECT_FALSE(pkgdie.empty());
+        EXPECT_EQ(size(pkgdie), dies_per_pkg);
+        for (pit = pkgdie.begin(); pit != pkgdie.end(); ++pit, ++sit, ++die_id) {
+            EXPECT_NE(sit, sysdie.end());
+            EXPECT_EQ(sit->id(), die_id);
+            EXPECT_EQ(pit->id(), die_id);
+
+            Topology::Die group = *sit;
+            EXPECT_EQ(&group.cores.front().threads.front(), &storage.threads[cores_per_pkg + die_id * cores_per_die]);
+            EXPECT_EQ(group.cores.size(), cores_per_die);
+            EXPECT_EQ(sit->cores.size(), cores_per_die);
+        }
+        EXPECT_EQ(sit, sysdie.end());
+    }
+}
+
+TEST(ViewTopology, SystemIteration)
+{
+    static constexpr int threads_per_core = 2;
+    static constexpr int cores_per_module = 4;
+    static constexpr int modules_per_die = 16;
+    static constexpr int cores_per_die = cores_per_module * modules_per_die;
+    static constexpr int dies_per_pkg = 4;
+    static constexpr int cores_per_pkg = cores_per_die * dies_per_pkg;
+    static constexpr int numa_domains_per_pkg = 2;
+    static constexpr int cores_per_numa_domain = cores_per_die * dies_per_pkg / numa_domains_per_pkg;
+    auto size = [](const auto &view) { return std::ranges::distance(view); };
+    TopologyStateGuard guard;
+    device_info = nullptr;
+
+    StorageBuilder storage;
+    for (int pkg = 0, numa = 0; pkg < 2; ++pkg) {
+        int core = 0;
+        int module = 0;
+        for (int die = 0; die < dies_per_pkg; ++die) {
+            for (int m = 0; m < modules_per_die; ++m, ++module) {
+                for (int c = 0; c < cores_per_module; ++c, ++core)
+                    storage.add_core(pkg, numa, die, module, core * threads_per_core,
+                                     threads_per_core, core_type_performance);
+            }
+            numa += (die & 1);
+        }
+    }
+    ASSERT_TRUE(std::ranges::is_sorted(storage.threads, detector_less));
+    Topology topo = Topology::build_topology(storage.threads);
+    ASSERT_EQ(topo.packages.size(), 2u);
+    ASSERT_EQ(topo.packages[0].groups.size(), dies_per_pkg);
+    ASSERT_EQ(topo.packages[1].groups.size(), dies_per_pkg);
+
+    const Topology::Thread *current_core = &storage.threads[0];
+    for (const Topology::Package &p : topo.packages) {
+        EXPECT_EQ(size(p.cores), cores_per_pkg);
+        EXPECT_EQ(size(p.numa_domains()), numa_domains_per_pkg);
+
+        for (const auto numa_domain : p.numa_domains()) {
+            EXPECT_EQ(size(numa_domain.cores), cores_per_numa_domain);
+            for (const auto die : numa_domain.dies()) {
+                EXPECT_EQ(size(die.cores), cores_per_die);
+                for (const auto module : die.modules()) {
+                    EXPECT_EQ(size(module.cores), cores_per_module);
+                    for (const auto core : module.cores) {
+                        EXPECT_EQ(core.id(), current_core->core_id);
+                        EXPECT_EQ(&core.threads.front(), current_core);
+                        current_core += threads_per_core;
+                    }
+
+                    // verify we don't exceed the module
+                    EXPECT_EQ(size(module.modules()), 1);
+                    EXPECT_EQ(size(module.dies()), 1);
+                    EXPECT_EQ(size(module.numa_domains()), 1);
+                }
+                // verify we don't exceed the die
+                EXPECT_EQ(size(die.dies()), 1);
+                EXPECT_EQ(size(die.numa_domains()), 1);
+            }
+            // verify we don't exceed the NUMA domain
+            EXPECT_EQ(size(numa_domain.numa_domains()), 1);
+        }
+    }
+
+    current_core = &storage.threads[0];
+    for (const Topology::Package &p : topo.packages) {
+        EXPECT_EQ(size(p.dies()), dies_per_pkg);
+        for (const auto die : p.dies()) {
+            EXPECT_EQ(size(die.cores), cores_per_die);
+            for (const auto module : die.modules()) {
+                EXPECT_EQ(size(module.cores), cores_per_module);
+                for (const auto core : module.cores) {
+                    EXPECT_EQ(core.id(), current_core->core_id);
+                    current_core += threads_per_core;
+                }
+
+                // verify we don't exceed the module
+                EXPECT_EQ(size(module.modules()), 1);
+                EXPECT_EQ(size(module.dies()), 1);
+                EXPECT_EQ(size(module.numa_domains()), 1);
+            }
+            // verify we don't exceed the die
+            EXPECT_EQ(size(die.dies()), 1);
+            EXPECT_EQ(size(die.numa_domains()), 1);
+        }
+    }
+
+    current_core = &storage.threads[0];
+    for (const Topology::Package &p : topo.packages) {
+        for (const Topology::CoreGrouping &g : p.groups) {
+            // there should be one die in each group (and half a NUMA domain)
+            EXPECT_EQ(g.cores.size(), cores_per_die);
+            EXPECT_EQ(size(g.modules()), modules_per_die);
+            for (const auto module : g.modules()) {
+                EXPECT_EQ(size(module.cores), cores_per_module);
+                for (const auto core : module.cores) {
+                    EXPECT_EQ(core.id(), current_core->core_id);
+                    current_core += threads_per_core;
+                }
+
+                // verify we don't exceed the module
+                EXPECT_EQ(size(module.modules()), 1);
+                EXPECT_EQ(size(module.dies()), 1);
+                EXPECT_EQ(size(module.numa_domains()), 1);
+            }
+
+            // verify we don't exceed the group
+            EXPECT_EQ(size(g.numa_domains()), 1);
+            EXPECT_EQ(size(g.dies()), 1);
+        }
+    }
+
+    current_core = &storage.threads[0];
+    for (const Topology::Package &p : topo.packages) {
+        EXPECT_EQ(size(p.modules()), modules_per_die * dies_per_pkg);
+        for (const auto module : p.modules()) {
+            EXPECT_EQ(size(module.cores), cores_per_module);
+            for (const auto core : module.cores) {
+                EXPECT_EQ(core.id(), current_core->core_id);
+                current_core += threads_per_core;
+            }
+
+            // verify we don't exceed the module
+            EXPECT_EQ(size(module.modules()), 1);
+            EXPECT_EQ(size(module.dies()), 1);
+            EXPECT_EQ(size(module.numa_domains()), 1);
+        }
+    }
+
+    current_core = &storage.threads[0];
+    for (const auto numa_domain : topo.numa_domains()) {
+        EXPECT_EQ(size(numa_domain.cores), cores_per_numa_domain);
+        for (const auto die : numa_domain.dies()) {
+            EXPECT_EQ(size(die.cores), cores_per_die);
+            for (const auto module : die.modules()) {
+                EXPECT_EQ(size(module.cores), cores_per_module);
+                for (const auto core : module.cores) {
+                    EXPECT_EQ(core.id(), current_core->core_id);
+                    current_core += threads_per_core;
+                }
+
+                // verify we don't exceed the module
+                EXPECT_EQ(size(module.modules()), 1);
+                EXPECT_EQ(size(module.dies()), 1);
+                EXPECT_EQ(size(module.numa_domains()), 1);
+            }
+            // verify we don't exceed the die
+            EXPECT_EQ(size(die.dies()), 1);
+            EXPECT_EQ(size(die.numa_domains()), 1);
+        }
+        // verify we don't exceed the NUMA domain
+        EXPECT_EQ(size(numa_domain.numa_domains()), 1);
+    }
+
+    current_core = &storage.threads[0];
+    for (const auto numa_domain : topo.numa_domains()) {
+        EXPECT_EQ(size(numa_domain.cores), cores_per_numa_domain);
+        for (const auto module : numa_domain.modules()) {
+            EXPECT_EQ(size(module.cores), cores_per_module);
+            for (const auto core : module.cores) {
+                EXPECT_EQ(core.id(), current_core->core_id);
+                current_core += threads_per_core;
+            }
+
+            // verify we don't exceed the module
+            EXPECT_EQ(size(module.modules()), 1);
+            EXPECT_EQ(size(module.dies()), 1);
+            EXPECT_EQ(size(module.numa_domains()), 1);
+        }
+        // verify we don't exceed the NUMA domain
+        EXPECT_EQ(size(numa_domain.numa_domains()), 1);
+    }
+
+    current_core = &storage.threads[0];
+    for (const auto die : topo.dies()) {
+        EXPECT_EQ(size(die.cores), cores_per_die);
+        for (const auto module : die.modules()) {
+            EXPECT_EQ(size(module.cores), cores_per_module);
+            for (const auto core : module.cores) {
+                EXPECT_EQ(core.id(), current_core->core_id);
+                current_core += threads_per_core;
+            }
+
+            // verify we don't exceed the module
+            EXPECT_EQ(size(module.modules()), 1);
+            EXPECT_EQ(size(module.dies()), 1);
+            EXPECT_EQ(size(module.numa_domains()), 1);
+        }
+        // verify we don't exceed the die
+        EXPECT_EQ(size(die.dies()), 1);
+        EXPECT_EQ(size(die.numa_domains()), 1);
+    }
+
+    current_core = &storage.threads[0];
+    for (const auto module : topo.modules()) {
+        EXPECT_EQ(size(module.cores), cores_per_module);
+        for (const auto core : module.cores) {
+            EXPECT_EQ(core.id(), current_core->core_id);
+            current_core += threads_per_core;
+        }
+
+        // verify we don't exceed the module
+        EXPECT_EQ(size(module.modules()), 1);
+        EXPECT_EQ(size(module.dies()), 1);
+        EXPECT_EQ(size(module.numa_domains()), 1);
+    }
+
+    auto cores = topo.cores();
+    EXPECT_EQ(size(cores), cores_per_pkg * topo.packages.size());
+    current_core = &storage.threads[0];
+    for (const auto core : cores) {
+        EXPECT_EQ(core.id(), current_core->core_id);
+        current_core += threads_per_core;
+    }
 }

--- a/framework/device/cpu/unit-tests/topology_tests.cpp
+++ b/framework/device/cpu/unit-tests/topology_tests.cpp
@@ -9,12 +9,32 @@
 
 #include "gtest/gtest.h"
 
+#include <cstddef>
+#include <cstring>
 #include <span>
 #include <utility>
 #include <vector>
 
 namespace {
+using Thread = Topology::Thread;
+
 Topology topo_global;
+
+Thread make_thread(int cpu, int hwid, int thread_id, int core_id, int module_id,
+                   int die_id, int numa_id, int package_id, NativeCoreType type)
+{
+    Thread t = {};
+    t.cpu_number = cpu;
+    t.hwid = hwid;
+    t.thread_id = int8_t(thread_id);
+    t.core_id = int16_t(core_id);
+    t.module_id = int16_t(module_id);
+    t.die_id = int16_t(die_id);
+    t.numa_id = int16_t(numa_id);
+    t.package_id = int16_t(package_id);
+    t.native_core_type = type;
+    return t;
+}
 
 std::vector<cpu_info_t> make_cpu_info_entries()
 {
@@ -67,12 +87,87 @@ void expect_plan(const SlicePlans::Slices &actual, const std::vector<std::pair<i
         EXPECT_EQ(actual[i].device_range.device_count, expected[i].second);
     }
 }
+
+
+// Replicates TopologyDetector's ordering so tests can assert their storage is
+// laid out the way build_topology() requires.
+bool detector_less(const Thread &a, const Thread &b)
+{
+    unsigned __int128 x, y;
+    std::memcpy(&x, &a.cpu_number, sizeof(x));
+    std::memcpy(&y, &b.cpu_number, sizeof(y));
+    return x < y;
+}
+
+// To add a new topology: fill a StorageBuilder in that sorted order (add_core()
+// keeps cpu_number/hwid unique and sequential) and describe the expected result
+// with a vector<ExpectedPackage>.
+struct StorageBuilder
+{
+    std::vector<Thread> threads;
+
+    void add_core(int package_id, int numa_id, int die_id, int module_id, int core_id,
+                  int threads_per_core, NativeCoreType type)
+    {
+        for (int t = 0; t < threads_per_core; ++t) {
+            int index = int(threads.size());
+            threads.push_back(make_thread(index, index, t, core_id, module_id, die_id,
+                                          numa_id, package_id, type));
+        }
+    }
+};
+
+// A core is described by the index of its first Thread in the storage and the
+// number of Threads it holds.
+struct ExpectedCore
+{
+    int first_thread_index;
+    int thread_count;
+};
+struct ExpectedPackage
+{
+    int id;
+    // groups[g] lists the cores of the g-th CoreGrouping; the package's own
+    // cores are the concatenation of all groups, in order.
+    std::vector<std::vector<ExpectedCore>> groups;
+};
+
+void expect_cores(std::span<const Topology::Core> cores, const Thread *storage,
+                  const std::vector<ExpectedCore> &expected)
+{
+    ASSERT_EQ(cores.size(), expected.size());
+    for (size_t i = 0; i < cores.size(); ++i) {
+        EXPECT_EQ(cores[i].threads.data(), storage + expected[i].first_thread_index);
+        EXPECT_EQ(cores[i].threads.size(), size_t(expected[i].thread_count));
+    }
+}
+
+void expect_topology(const Topology &topo, const Thread *storage,
+                     const std::vector<ExpectedPackage> &expected)
+{
+    ASSERT_EQ(topo.packages.size(), expected.size());
+    for (size_t p = 0; p < expected.size(); ++p) {
+        const Topology::Package &pkg = topo.packages[p];
+        EXPECT_EQ(pkg.id(), expected[p].id);
+
+        std::vector<ExpectedCore> all_cores;
+        for (const auto &group : expected[p].groups)
+            all_cores.insert(all_cores.end(), group.begin(), group.end());
+        expect_cores(pkg.cores, storage, all_cores);
+
+        ASSERT_EQ(pkg.groups.size(), expected[p].groups.size());
+        for (size_t g = 0; g < pkg.groups.size(); ++g)
+            expect_cores(pkg.groups[g].cores, storage, expected[p].groups[g]);
+    }
+}
 }
 
 const Topology &Topology::topology()
 {
     return topo_global;
 }
+
+// ---- Slice planning tests ------------------------------------
 
 TEST(Topology, SlicePlansCreationMax3)
 {
@@ -107,4 +202,136 @@ TEST(Topology, SlicePlansCreationDefaultMax)
     expect_plan(plans.plans[SlicePlans::Heuristic], {
         { 0, 8 }, { 8, 8 },
     });
+}
+
+// ---- Topology::build_topology() tests ------------------------------------
+
+TEST(BuildTopology, Empty)
+{
+    Topology topo = Topology::build_topology({});
+    EXPECT_FALSE(topo.isValid());
+    EXPECT_TRUE(topo.packages.empty());
+}
+
+// single package (id 0), two threads per core, module/die/numa unknown (-1),
+// unknown core type: a single core-group holding every core.
+TEST(BuildTopology, SinglePackageTwoThreadsPerCore)
+{
+    constexpr int core_count = 8;
+    StorageBuilder storage;
+    for (int core = 0; core < core_count; ++core)
+        storage.add_core(0, -1, -1, -1, core, 2, core_type_unknown);
+    ASSERT_TRUE(std::ranges::is_sorted(storage.threads, detector_less));
+
+    Topology topo = Topology::build_topology(storage.threads);
+
+    std::vector<ExpectedCore> cores;
+    for (int core = 0; core < core_count; ++core)
+        cores.push_back({ core * 2, 2 });
+    expect_topology(topo, storage.threads.data(), {
+        { 0, { cores } },
+    });
+}
+
+// single package (id != 0), one thread per core, module_id == core_id / 2,
+// homogeneous known core type: still a single core-group.
+TEST(BuildTopology, SinglePackageHomogeneousCoreType)
+{
+    constexpr int core_count = 8;
+    StorageBuilder storage;
+    for (int core = 0; core < core_count; ++core)
+        storage.add_core(3, -1, -1, core / 2, core, 1, core_type_performance);
+    ASSERT_TRUE(std::ranges::is_sorted(storage.threads, detector_less));
+
+    Topology topo = Topology::build_topology(storage.threads);
+
+    std::vector<ExpectedCore> cores;
+    for (int core = 0; core < core_count; ++core)
+        cores.push_back({ core, 1 });
+    expect_topology(topo, storage.threads.data(), {
+        { 3, { cores } },
+    });
+}
+
+// single package (id != 0), one thread per core, module_id == core_id / 2,
+// heterogeneous known core type: the change of native_core_type splits the
+// package into two core-groups. Performance (1) sorts before efficiency (2).
+TEST(BuildTopology, SinglePackageHeterogeneousCoreType)
+{
+    constexpr int perf_cores = 4;
+    constexpr int eff_cores = 4;
+    StorageBuilder storage;
+    int core = 0;
+    for (int i = 0; i < perf_cores; ++i, ++core)
+        storage.add_core(5, -1, -1, core / 2, core, 1, core_type_performance);
+    for (int i = 0; i < eff_cores; ++i, ++core)
+        storage.add_core(5, -1, -1, core / 4 * 2, core, 1, core_type_efficiency);
+    ASSERT_TRUE(std::ranges::is_sorted(storage.threads, detector_less));
+
+    Topology topo = Topology::build_topology(storage.threads);
+
+    std::vector<ExpectedCore> perf, eff;
+    for (int c = 0; c < perf_cores; ++c)
+        perf.push_back({ c, 1 });
+    for (int c = 0; c < eff_cores; ++c)
+        eff.push_back({ perf_cores + c, 1 });
+    expect_topology(topo, storage.threads.data(), {
+        { 5, { perf, eff } },
+    });
+}
+
+// two packages, two threads per core, module_id == core_id / 2, 4 dies and
+// 2 NUMA domains per socket (2 dies per NUMA domain). numa_id is globally
+// unique; die_id is per-package. Each die becomes its own core-group.
+TEST(BuildTopology, TwoPackagesDiesAndNuma)
+{
+    constexpr int packages = 2;
+    constexpr int dies_per_package = 4;
+    constexpr int cores_per_die = 2;
+    StorageBuilder storage;
+    for (int pkg = 0; pkg < packages; ++pkg) {
+        int core = 0;
+        for (int die = 0; die < dies_per_package; ++die) {
+            int numa = pkg * 2 + die / 2;       // globally unique NUMA ids
+            for (int c = 0; c < cores_per_die; ++c, ++core)
+                storage.add_core(pkg, numa, die, core / 2, core, 2, core_type_unknown);
+        }
+    }
+    ASSERT_TRUE(std::ranges::is_sorted(storage.threads, detector_less));
+
+    Topology topo = Topology::build_topology(storage.threads);
+
+    std::vector<ExpectedPackage> expected;
+    constexpr int threads_per_package = dies_per_package * cores_per_die * 2;
+    for (int pkg = 0; pkg < packages; ++pkg) {
+        int base = pkg * threads_per_package;
+        ExpectedPackage ep{ pkg, {} };
+        for (int die = 0; die < dies_per_package; ++die) {
+            std::vector<ExpectedCore> group;
+            for (int c = 0; c < cores_per_die; ++c) {
+                int first = base + (die * cores_per_die + c) * 2;
+                group.push_back({ first, 2 });
+            }
+            ep.groups.push_back(std::move(group));
+        }
+        expected.push_back(std::move(ep));
+    }
+    expect_topology(topo, storage.threads.data(), expected);
+}
+
+// 16 packages, one core per package, one thread per core, unknown core type.
+TEST(BuildTopology, ManySinglecorePackages)
+{
+    constexpr int packages = 16;
+    StorageBuilder storage;
+    for (int pkg = 0; pkg < packages; ++pkg)
+        storage.add_core(pkg, -1, -1, -1, 0, 1, core_type_unknown);
+    ASSERT_TRUE(std::ranges::is_sorted(storage.threads, detector_less));
+
+    Topology topo = Topology::build_topology(storage.threads);
+
+    std::vector<ExpectedPackage> expected;
+    for (int pkg = 0; pkg < packages; ++pkg)
+        expected.push_back({ pkg, { { { pkg, 1 } } } });
+    expect_topology(topo, storage.threads.data(), expected);
 }

--- a/framework/sandstone_unittests_utils.cpp
+++ b/framework/sandstone_unittests_utils.cpp
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "sandstone.h"
-
-#define UNITTESTS_THREAD_COUNT 16
-#define UNITTESTS_DEVICE_COUNT UNITTESTS_THREAD_COUNT
+#include "sandstone_unittests_utils.h"
 
 /* Define dummy setup struct that can be used by unittests when needed */
 device_info_t *device_info = nullptr;
 
-/* Define dummy number of dummy threads */
-int device_count() { return UNITTESTS_DEVICE_COUNT; }
-int thread_count() { return UNITTESTS_THREAD_COUNT; }
+/* Number of dummy threads/devices; tests may override this global to describe
+ * topologies with more (or fewer) than the default count. */
+int unittests_device_count = UNITTESTS_THREAD_COUNT;
+
+int device_count() { return unittests_device_count; }
+int thread_count() { return unittests_device_count; }
 int num_cpus() { return thread_count(); }
 
 bool test_is_retry() noexcept { return false; }

--- a/framework/sandstone_unittests_utils.h
+++ b/framework/sandstone_unittests_utils.h
@@ -7,6 +7,11 @@
 
 #define UNITTESTS_THREAD_COUNT 16
 
+/* Number of dummy threads/devices returned by device_count()/thread_count().
+ * Defaults to UNITTESTS_THREAD_COUNT; tests may assign a different value to
+ * describe topologies with more (or fewer) threads. */
+extern int unittests_device_count;
+
 /* Define empty log_* macros not useful for unittests */
 #undef  log_warning
 #define log_warning(...)


### PR DESCRIPTION
This removes the older `struct Module` and replaces it with a view-like type that can be iterated on. For example:
```c++
    for (const Topology::Package &p : topo.packages) {
        EXPECT_EQ(size(p.dies()), dies_per_pkg);
        for (const auto die : p.dies()) {
            EXPECT_EQ(size(die.cores), cores_per_die);
            for (const auto module : die.modules()) {
                EXPECT_EQ(size(module.cores), cores_per_module);
                for (const auto core : module.cores) {
                    EXPECT_EQ(core.id(), current_core->core_id);
                    current_core += threads_per_core;
                }
```

See the unit-test for more.