### PR TITLE
FW/Logging/CPU: ensure we print a map for an empty `cache-info`

### DIFF
--- a/framework/device/cpu/logging_cpu.cpp
+++ b/framework/device/cpu/logging_cpu.cpp
@@ -502,6 +502,7 @@ void AbstractLogger::device_print_extra_info()
     };
 
     logging_printf(LOG_LEVEL_VERBOSE(1), "cache-info:\n");
+    bool any_cache_levels = false;
 
     for (int level = 0; level < cache_levels; ++level) {
         // Group the logical processors by which physical cache instance they
@@ -542,6 +543,12 @@ void AbstractLogger::device_print_extra_info()
             // unnecessary information (for now)
             // logging_printf(LOG_LEVEL_VERBOSE(1), "    instances: %zu\n", instances.size());
         }
+
+        any_cache_levels = true;
+    }
+    if (!any_cache_levels) {
+        // print an empty map to satisy the schema requirements
+        logging_printf(LOG_LEVEL_VERBOSE(1), "  {}\n");
     }
 }
 


### PR DESCRIPTION
Without any entries afterwards, the single YAML line
```yaml
cache-info:
```
Expands to null ("None" in Python), instead of the map our bats tests require.

Observed in the Windows VMs in the GitHub Actions CI:
```yaml
cpu-info:
- { logical-group:  0, logical:  0, package: 0, numa_node: 0, module: 0, core: 0, thread: 0, family: 25, model: 0x1, stepping: 1, microcode: null, ppin: null }   # 0
- { logical-group:  0, logical:  1, package: 0, numa_node: 0, module: 0, core: 0, thread: 1, family: 25, model: 0x1, stepping: 1, microcode: null, ppin: null }   # 1
- { logical-group:  0, logical:  2, package: 0, numa_node: 0, module: 1, core: 1, thread: 0, family: 25, model: 0x1, stepping: 1, microcode: null, ppin: null }   # 2
- { logical-group:  0, logical:  3, package: 0, numa_node: 0, module: 1, core: 1, thread: 1, family: 25, model: 0x1, stepping: 1, microcode: null, ppin: null }   # 3
cache-info:
test-plans:
  fullsocket: [ { starting_cpu: 0, count: 4, threads: 4 } ]
  core_groups: [ { starting_cpu: 0, count: 4, threads: 4 } ]
  heuristic: [ { starting_cpu: 0, count: 4, threads: 4 } ]
```