### PR TITLE
FW/Topology/CPU: rename `l3_cache_size` to `llc_cache_slice`

### DIFF
--- a/framework/device/cpu/topology.cpp
+++ b/framework/device/cpu/topology.cpp
@@ -1649,10 +1649,10 @@ static void populate_core_group(Topology::CoreGrouping *group, const Topology::T
     // Attribute a share of each L3 instance to this grouping: a grouping may
     // span several instances (summed) or only part of one (SNC, hybrid P/E),
     // so each instance contributes in_group/total of its size.
-    constexpr int l3 = sizeof(cpu_info_t::cache) / sizeof(cpu_info_t::cache[0]) - 1;
+    constexpr int LLC = sizeof(cpu_info_t::cache) / sizeof(cpu_info_t::cache[0]) - 1;
     std::map<int, int> in_group;
     for (const Topology::Thread *t = begin; t != end; ++t) {
-        const cache_info_t &c = t->cache[l3];
+        const cache_info_t &c = t->cache[LLC];
         if (c.cache_instruction >= 0 || c.cache_data >= 0)
             ++in_group[c.id];
     }
@@ -1663,7 +1663,7 @@ static void populate_core_group(Topology::CoreGrouping *group, const Topology::T
         // (possibly restricted) topology, so a grouping that covers only part
         // of an instance is attributed its true fraction.
         for (const cpu_info_t &info : std::span(sApp->shmem->device_info, sApp->shmem->total_device_count)) {
-            const cache_info_t &c = info.cache[l3];
+            const cache_info_t &c = info.cache[LLC];
             if (c.id != id || (c.cache_instruction < 0 && c.cache_data < 0))
                 continue;
             ++total;
@@ -1671,7 +1671,7 @@ static void populate_core_group(Topology::CoreGrouping *group, const Topology::T
                     : std::max(c.cache_instruction, 0) + std::max(c.cache_data, 0);
         }
         if (total > 0)
-            group->l3_cache_size += size * count / total;
+            group->llc_cache_slice += size * count / total;
     }
 }
 

--- a/framework/device/cpu/topology_cpu.h
+++ b/framework/device/cpu/topology_cpu.h
@@ -39,7 +39,7 @@ public:
         // std::vector<Module> modules;
 
         /// Size in bytes of the last-level (L3) cache attributable to this grouping.
-        size_t l3_cache_size = 0;
+        size_t llc_cache_slice = 0;
     };
 
     struct Package : CoreGrouping

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -228,9 +228,9 @@ static int selftest_logs_l3cachesize_init(struct test *)
         for (const Topology::CoreGrouping &group : pkg.groups) {
             if (group_sizes.size())
                 group_sizes += ", ";
-            group_sizes += std::to_string(group.l3_cache_size);
+            group_sizes += std::to_string(group.llc_cache_slice);
         }
-        aggregate += pkg.l3_cache_size;
+        aggregate += pkg.llc_cache_slice;
     }
 
     log_yaml(SANDSTONE_LOG_INFO,


### PR DESCRIPTION
To indicate it's the slice of the Last Level Cache (LLC) that is attributed to this `CoreGrouping` (which can be a Package).