### PR TITLE
FW/child_debug/Unix: strip the trailing NUL gdb prints on internal error

### DIFF
--- a/framework/sysdeps/unix/child_debug.cpp
+++ b/framework/sysdeps/unix/child_debug.cpp
@@ -642,6 +642,12 @@ static auto communicate_gdb_backtrace(int in, int out, uintptr_t handle)
     // read until EOF as the backtrace
     read_until(in, result.backtrace, EOF);
 
+    // work around a gdb bug: on its internal-error abort path it emits a
+    // trailing NUL (an off-by-one error) that would make our YAML log
+    // unparseable.
+    if (result.backtrace.ends_with('\0'))
+        result.backtrace.pop_back();
+
     return result;
 }
 


### PR DESCRIPTION
When gdb hits a recursive internal error it aborts via `internal_vproblem()` in utils.c, whose fallback path does:
```
    static const char msg[] = "Recursive internal problem.\n";
    write (STDERR_FILENO, msg, sizeof (msg));
```
`sizeof(msg)` includes the string terminator, so gdb emits a trailing NUL byte after the message. We capture gdb's output verbatim into the backtrace and log it as a YAML scalar, and that NUL is illegal there, so our log becomes unparseable:

    yaml.reader.ReaderError: unacceptable character #x0000: special characters are not allowed

Work around gdb's bug by dropping the trailing NUL before logging.

Amends commit 7d5a252ce76327b27d16072a1937bb4d79989bde (PR #1174).

Upstream fix: https://inbox.sourceware.org/gdb-patches/20260820205605.16997-1-thiago.macieira@intel.com/T/#u