### PR TITLE
CI: move GPU builds to Ubuntu

### DIFF
--- a/.github/actions/build-gpu/action.yaml
+++ b/.github/actions/build-gpu/action.yaml
@@ -28,11 +28,17 @@ runs:
       shell: bash
       run: |
         DEBIAN_FRONTEND=noninteractive apt-get -y update
+        DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates gpg software-properties-common wget
+        add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        install -d -m 0755 /etc/apt/keyrings
+        wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | gpg --dearmor --yes -o /etc/apt/keyrings/intel-graphics.gpg
+        printf 'deb [arch=amd64 signed-by=/etc/apt/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu noble unified\n' >/etc/apt/sources.list.d/intel-gpu.list
+        DEBIAN_FRONTEND=noninteractive apt-get -y update
         echo "::group::Installing build dependencies"
         DEBIAN_FRONTEND=noninteractive apt-get -y install \
             bats \
             ca-certificates \
-            ${CC-g++} \
+            ${CXX:-g++} \
             elfutils \
             file \
             gawk \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -144,12 +144,12 @@ jobs:
     name: Build binary for GPU
     needs: [ lint, git-sanity ]
     runs-on: ubuntu-24.04${{ matrix.archsuffix }}
-    container: debian:sid
+    container: ubuntu:24.04
     strategy:
       matrix:
         include:
-        - { name: GCC, unittests: "unittests" }
-        - { name: GCC-NoLogging, unittests: "unittests", meson_args: "-Dlogging_format=no_output" }
+        - { name: GCC, unittests: "unittests", env: "CC=gcc-16 CXX=g++-16" }
+        - { name: GCC-NoLogging, unittests: "unittests", env: "CC=gcc-16 CXX=g++-16", meson_args: "-Dlogging_format=no_output" }
     steps:
       - name: Checkout the PR merge point
         uses: actions/checkout@v6


### PR DESCRIPTION
Ubuntu provides only stable versions of the libs. Debian Stable does not provide them at all (only some)