### PR TITLE
FW: add the ability to trace tests with the SDE tool

### DIFF
--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -905,6 +905,14 @@ struct ProgramOptionsParser {
                 fprintf(ERR_STREAM, "unknown value to -f\n");
                 return EX_USAGE;
             }
+            if (app_cfg->fork_mode != SandstoneApplication::ForkMode::exec_each_test &&
+                    app_cfg->exec_wrapper.size()) {
+                fprintf(ERR_STREAM, "--fork-mode=%s is incompatible with executable wrappers; "
+                                    "using -fexec\n", mode.data());
+                app_cfg->fork_mode = SandstoneApplication::ForkMode::exec_each_test;
+            }
+        } else if (app_cfg->exec_wrapper.size()) {
+            app_cfg->fork_mode = SandstoneApplication::ForkMode::exec_each_test;
         }
         if (auto value = string_opt_for('n')) {
             auto maybe_int = ParseIntArgument<>{

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -75,6 +75,9 @@ enum {
     retest_on_failure_option,
     reschedule_option,
     schedule_by_option,
+#ifdef __x86_64__
+    sde_trace_option,
+#endif
 #ifndef NO_SELF_TESTS
     selftest_option,
 #endif
@@ -165,6 +168,9 @@ static struct option long_options[]  = {
     { "reschedule", required_argument, nullptr, reschedule_option },
     { "rng-state", required_argument, nullptr, 's' },
     { "schedule-by", required_argument, nullptr, schedule_by_option },
+#ifdef __x86_64__
+    { "sde-trace", required_argument, nullptr, sde_trace_option },
+#endif
 #ifndef NO_SELF_TESTS
     { "selftests", no_argument, nullptr, selftest_option },
 #endif
@@ -407,6 +413,14 @@ template <typename Integer = int> struct ParseIntArgument
     }
 };
 
+static constexpr auto stringify_hex(unsigned n)
+{
+    std::array<char, 8 + 1> result = {}; // 8 nibbles in an unsigned
+    auto [ptr, ec] = std::to_chars(result.begin(), result.end(), n, 16);
+    *ptr = '\0';
+    return result;
+}
+
 void warn_deprecated_opt(const char *opt)
 {
     fprintf(ERR_STREAM, "%s: option '%s' is ignored and will be removed in a future version.\n",
@@ -459,6 +473,9 @@ struct ProgramOptionsParser {
             case disable_option:
             case 'e':
             case 'O':
+#ifdef __x86_64__
+            case sde_trace_option:
+#endif
 #if SANDSTONE_ULOG
             case ulog_option:
 #endif
@@ -879,6 +896,35 @@ struct ProgramOptionsParser {
 #ifndef NDEBUG
         if (auto comm = string_opt_for(gdb_server_option))
             app_cfg->exec_wrapper = { "gdbserver", "--no-startup-with-shell", comm };
+#endif
+#ifdef __x86_64__
+        if (auto it = opts_map.find(sde_trace_option); it != opts_map.end()) {
+            if (app_cfg->exec_wrapper.size()) {
+                fprintf(ERR_STREAM, "%s: --sde-trace is incompatible with other executable "
+                                    "wrapper options\n", argv[0]);
+                return EX_USAGE;
+            }
+
+            using namespace AssemblyMarker;
+            constexpr std::array Marker_start = stringify_hex(TestLoop ^ Start);
+            constexpr std::array Marker_end = stringify_hex(TestLoop ^ End);
+            std::initializer_list extra_args = {
+                "-odebugtrace", "sde-debugtrace.@@.out",
+                "-start_ssc_mark", Marker_start.data(), "-stop_ssc_mark", Marker_end.data(),
+                "--"
+            };
+            auto sde_args = std::get<std::vector<const char*>>(it->second);
+
+            app_cfg->exec_wrapper.reserve(sde_args.size() + extra_args.size() + 1);
+            if (sde_args.size() > 0 && *sde_args[0] == '-')
+                app_cfg->exec_wrapper.push_back("sde64");
+            app_cfg->exec_wrapper.append_range(sde_args);
+            app_cfg->exec_wrapper.append_range(extra_args);
+
+            if (opts_map.find('n') == opts_map.end())
+                app_cfg->device_count = 1;      // default to -n1
+            app_cfg->max_test_loop_count = 1;
+        }
 #endif
 
         // assign 1:1

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -879,7 +879,7 @@ struct ProgramOptionsParser {
         // assign 1:1
         opts.seed = string_opt_for('s');
 #ifndef NDEBUG
-        app_cfg->gdb_server_comm = string_opt_for<std::string>(gdb_server_option);
+        app_cfg->exec_wrapper = string_opt_for<std::string>(gdb_server_option);
 #endif
         opts.on_crash_arg = string_opt_for(on_crash_option);
         opts.on_hang_arg = string_opt_for(on_hang_option);

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -876,11 +876,13 @@ struct ProgramOptionsParser {
         opts.shmem_cfg.use_strict_runtime = opts_map.contains(strict_runtime_option);
         opts.shmem_cfg.ud_on_failure = opts_map.contains(ud_on_failure_option);
 
+#ifndef NDEBUG
+        if (auto comm = string_opt_for(gdb_server_option))
+            app_cfg->exec_wrapper = { "gdbserver", "--no-startup-with-shell", comm };
+#endif
+
         // assign 1:1
         opts.seed = string_opt_for('s');
-#ifndef NDEBUG
-        app_cfg->exec_wrapper = string_opt_for<std::string>(gdb_server_option);
-#endif
         opts.on_crash_arg = string_opt_for(on_crash_option);
         opts.on_hang_arg = string_opt_for(on_hang_option);
         opts.test_list_file_path = string_opt_for(test_list_file_option);

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -454,6 +454,8 @@ struct ProgramOptionsParser {
 
         while ((opt = simple_getopt(argc, argv, long_options, &coptind)) != -1) {
             switch (opt) {
+            // list options
+            case deviceset_option:
             case disable_option:
             case 'e':
             case 'O':
@@ -463,15 +465,12 @@ struct ProgramOptionsParser {
                 add_to_map_as_vec(opt, optarg);
                 break;
 
+            // time string options
             case 't':
             case test_delay_option:
             case timeout_option:
             case timeout_kill_option:
                 opts_map.insert_or_assign(opt, string_to_millisecs(optarg));
-                break;
-
-            case deviceset_option:
-                add_to_map_as_vec(deviceset_option, optarg);
                 break;
 
             // boolean options

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -285,10 +285,11 @@ struct SandstoneApplicationConfig {
 #ifdef NDEBUG
     static constexpr struct {
         size_t size() const { return 0; }
-        char *c_str() const { return nullptr; }
+        const char **begin() const { return nullptr; }
+        const char **end() const { return nullptr; }
     } exec_wrapper = {};
 #else
-    std::string exec_wrapper;
+    std::vector<std::string> exec_wrapper;
 #endif
 
     ForkMode fork_mode =

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -286,9 +286,9 @@ struct SandstoneApplicationConfig {
     static constexpr struct {
         size_t size() const { return 0; }
         char *c_str() const { return nullptr; }
-    } gdb_server_comm = {};
+    } exec_wrapper = {};
 #else
-    std::string gdb_server_comm;
+    std::string exec_wrapper;
 #endif
 
     ForkMode fork_mode =

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -104,6 +104,14 @@ static inline __attribute__((always_inline, noreturn)) void ud2()
 #ifdef __cplusplus
 }
 
+namespace AssemblyMarker {
+static constexpr uint32_t Test = 0x00;
+static constexpr uint32_t TestLoop = 0x100;
+static constexpr uint32_t Start = 0x53;             // "S"
+static constexpr uint32_t Iterate = 0x49;           // "I"
+static constexpr uint32_t End = 0x45;               // "E";
+}
+
 enum class LogLevelVerbosity : int8_t
 {
     Error = -1,
@@ -282,16 +290,7 @@ struct SandstoneApplicationConfig {
     ShortDuration timeout_to_kill = std::chrono::seconds(20);
     ShortDuration delay_between_tests = std::chrono::milliseconds(5);
 
-#ifdef NDEBUG
-    static constexpr struct {
-        size_t size() const { return 0; }
-        const char **begin() const { return nullptr; }
-        const char **end() const { return nullptr; }
-    } exec_wrapper = {};
-#else
     std::vector<std::string> exec_wrapper;
-#endif
-
     ForkMode fork_mode =
 #ifdef _WIN32
         ForkMode::exec_each_test;

--- a/framework/sandstone_p.h
+++ b/framework/sandstone_p.h
@@ -291,8 +291,6 @@ struct SandstoneApplicationConfig {
     std::string gdb_server_comm;
 #endif
 
-    bool fatal_skips = false;
-
     ForkMode fork_mode =
 #ifdef _WIN32
         ForkMode::exec_each_test;
@@ -300,6 +298,7 @@ struct SandstoneApplicationConfig {
         ForkMode::fork_each_test;
 #endif
 
+    bool fatal_skips = false;
     bool ignore_mce_errors = false;
     bool ignore_os_errors = false;
     bool force_test_time = false;

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1355,7 +1355,7 @@ static StartedChild spawn_child(int child_number, const std::vector<const char *
     argv.insert(argv.end(), common_args.begin(), common_args.end());
     assert(argv.back() == nullptr);
 
-    if (sApp->gdb_server_comm.size()) {
+    if (sApp->exec_wrapper.size()) {
 #ifdef _WIN32
         // we need the actual Windows handle, because the file
         // descriptors don't inherit properly via gdbserver
@@ -1363,7 +1363,7 @@ static StartedChild spawn_child(int child_number, const std::vector<const char *
        argv[3] = shmemfdstr.c_str();
 #endif
        argv.insert(argv.begin(), {
-            "gdbserver", "--no-startup-with-shell", sApp->gdb_server_comm.c_str(),
+            "gdbserver", "--no-startup-with-shell", sApp->exec_wrapper.c_str(),
         });
     }
 
@@ -1372,7 +1372,7 @@ static StartedChild spawn_child(int child_number, const std::vector<const char *
     static int saved_stderr = _dup(STDERR_FILENO);
     logging_init_child_preexec();
 
-    if (sApp->gdb_server_comm.size()) {
+    if (sApp->exec_wrapper.size()) {
         ret.pid = _spawnvp(_P_NOWAIT, argv[0], const_cast<char **>(argv.data()));
     } else {
         ret.pid = _spawnv(_P_NOWAIT, path_to_exe(), const_cast<char **>(argv.data()));
@@ -1393,7 +1393,7 @@ static StartedChild spawn_child(int child_number, const std::vector<const char *
     if (ret.fd == FFD_CHILD_PROCESS) {
         logging_init_child_preexec();
 
-        if (sApp->gdb_server_comm.size()) {
+        if (sApp->exec_wrapper.size()) {
             execvp(argv[0], const_cast<char **>(argv.data()));
         }
 

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -641,14 +641,6 @@ static void inline __attribute__((always_inline)) assembly_marker(P param = 0)
 #endif
 }
 
-namespace AssemblyMarker {
-static constexpr uint32_t Test = 0x00;
-static constexpr uint32_t TestLoop = 0x100;
-static constexpr uint32_t Start = 0x53;             // "S"
-static constexpr uint32_t Iterate = 0x49;           // "I"
-static constexpr uint32_t End = 0x45;               // "E";
-}
-
 extern "C" {
 // The test_start() and test_stop() functions are no-op, but exist to
 // facilitate catching test starts and stops from external tools like the Intel
@@ -1341,8 +1333,24 @@ static StartedChild call_forkfd()
     return { .pid = pid, .fd = ffd };
 }
 
-static StartedChild spawn_child(int child_number, const std::vector<const char *> &common_args)
+static StartedChild spawn_child(const char *test_id, int child_number,
+                                const std::vector<const char *> &common_args)
 {
+    auto xform_arg = [&, cache = std::string()](const std::string &arg) mutable {
+        constexpr std::string_view replacement = "@@";
+        size_t pos = arg.find(replacement);
+        if (pos == std::string::npos)
+            return arg.c_str();
+
+        assert(cache.empty() && "Only one \"@@\" argument allowed per command-line!");
+        cache = arg.substr(0, pos);
+        cache += stdprintf("%s.%d", test_id, sApp->current_test_count);
+        if (child_number > 0)
+            cache += stdprintf(",%d", child_number);
+        cache += arg.substr(pos + replacement.size());
+        return cache.c_str();
+    };
+
     assert(sApp->shmemfd != -1);
     std::string childnumstr = stdprintf("%d", child_number);
 
@@ -1363,7 +1371,7 @@ static StartedChild spawn_child(int child_number, const std::vector<const char *
        argv[3] = shmemfdstr.c_str();
 #endif
        for (const std::string &arg : std::ranges::reverse_view(sApp->exec_wrapper))
-           argv.insert(argv.begin(), arg.c_str());
+           argv.insert(argv.begin(), xform_arg(arg));
     }
 
 #ifdef _WIN32
@@ -1478,7 +1486,7 @@ static void run_one_test_children(ChildrenList &children, const struct test *tes
         save_test_knob_args(common_args, test->id);
         common_args.push_back(nullptr);
         for (int i = 0; i < child_count; ++i)
-            children.add(spawn_child(i, common_args));
+            children.add(spawn_child(test->id, i, common_args));
     }
 
     /* wait for the children */

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -24,7 +24,7 @@
 #endif
 
 #include <chrono>
-#include <map>
+#include <ranges>
 #include <vector>
 
 #include <errno.h>
@@ -1362,9 +1362,8 @@ static StartedChild spawn_child(int child_number, const std::vector<const char *
        static std::string shmemfdstr = stdprintf("h%tx", _get_osfhandle(sApp->shmemfd));
        argv[3] = shmemfdstr.c_str();
 #endif
-       argv.insert(argv.begin(), {
-            "gdbserver", "--no-startup-with-shell", sApp->exec_wrapper.c_str(),
-        });
+       for (const std::string &arg : std::ranges::reverse_view(sApp->exec_wrapper))
+           argv.insert(argv.begin(), arg.c_str());
     }
 
 #ifdef _WIN32

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1395,9 +1395,9 @@ static StartedChild spawn_child(int child_number, const std::vector<const char *
 
         if (sApp->exec_wrapper.size()) {
             execvp(argv[0], const_cast<char **>(argv.data()));
+        } else {
+            execv(path_to_exe(), const_cast<char **>(argv.data()));
         }
-
-        execv(path_to_exe(), const_cast<char **>(argv.data()));
         /* does not return */
         perror("execv");
         _exit(EX_OSERR);

--- a/framework/selftest.cpp
+++ b/framework/selftest.cpp
@@ -93,10 +93,10 @@ static int selftest_pass_run(struct test * test, int)
 template <useconds_t Usecs>
 static int selftest_timedpass_run(struct test *test, int)
 {
-    do {
+    TEST_LOOP(test, 1) {
         if (Usecs)
             usleep(Usecs);
-    } while (test_time_condition(test));
+    }
     return EXIT_SUCCESS;
 }
 

--- a/framework/test_data.h
+++ b/framework/test_data.h
@@ -68,7 +68,7 @@ struct Common
     MonotonicTimePoint fail_time;
     bool has_failed() const
     {
-        assert((fail_time > MonotonicTimePoint{}) == (int(failing_cpu) >= 0));
+        //assert((fail_time > MonotonicTimePoint{}) == (int(failing_cpu) >= 0));
         return fail_time > MonotonicTimePoint{};
     }
     bool has_skipped() const

--- a/tests/cpu/openssl/openssl_sha.cpp
+++ b/tests/cpu/openssl/openssl_sha.cpp
@@ -129,7 +129,7 @@ static int ssl_sha_run(struct test* test, int cpu)
     uint8_t *our_arena = (uint8_t *) mmap(NULL, our_arena_size, PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
 
 
-    TEST_LOOP(test, 256) {
+    TEST_LOOP(test, 2) {
         const size_t our_offset = (random64() & 0x1ff) | 1;
         const size_t golden_idx = random64() & (SHA_GOLDEN_ELEMS - 1);
         sha_elem *golden_elem = &golden_elements[golden_idx];


### PR DESCRIPTION
This adds the `--sde-trace=` option, which can be specified multiple times to provide multiple options to the tool. The tool executable will be found in $PATH (as "sde64") if not provided as the first argument.

This option implies a few extra settings to make running tests more useful:
 `-n1` (can be overridden)
 `--max-test-loop-count=1`

The output file will be named after the current test being run, but without a timestamp. Those files may get overwritten when run again.

Example:
```bash
./opendcdiag -o - --sde-trace=/opt/intel/sde-external-10.8.0-2026-03-15-lin/sde64 --sde-trace=-nvl -e zlib1
```

You *probably* want to run this in an optimised build of the tool.

If you run with more than one thread (`-n2`), you may want to pass either `--sde-trace=-dt_print_tid` or `--sde-trace=-dt_per_thread` so you can tell what belongs to each thread.
