### PR TITLE
Meson: compile with `-z,now` on Unix systems

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,8 +128,9 @@ foreach ccflag : [
 endforeach
 
 foreach lflag : [
-    '-Wl,-z,relro',
     '-Wl,-z,noexecstack',
+    '-Wl,-z,now',
+    '-Wl,-z,relro',
 ]
     if cc.links('int main() { return 0; }', args: [lflag], name: lflag)
         add_project_link_arguments(lflag, language: ['c', 'cpp'])


### PR DESCRIPTION
This is equivalent to running with `LD_BIND_NOW=1` in the environment, forcing the dynamic linker to resolve all symbols at load time, instead of lazily when functions are called through the PLT. This is good for OpenDCDiag-based tools because we fork and continue to execute in the child, so it would cause the page containing the .got.plt section to become Copy-On-Write.

Before this change, the ELF program headers were:
```
 Section to Segment mapping:
  Segment Sections...
   04      [RO: .rodata .eh_frame_hdr .eh_frame .gcc_except_table .note.ABI-tag .note.dlopen]
   05      [RELRO: .tbss .init_array .fini_array .data.rel.ro .dynamic .got] <RELRO: .got.plt> .data tests .bss
```

Now:
```
 Section to Segment mapping:
  Segment Sections...
   04      [RO: .rodata .eh_frame_hdr .eh_frame .gcc_except_table .note.ABI-tag .note.dlopen]
   05      [RELRO: .tbss .init_array .fini_array .data.rel.ro .dynamic .got] .data tests .bss
```

The `<RELRO:.got.plt>` portion disappeared - in fact, there is no more `.got.plt` section, it was merged into the normal `.got`. That marker in angle brackets instead of square ones indicated it was *partially* RELRO: the first 3 entries of the section belonged to the RELRO segment, which are definitely calculated at load time and therefore can be marked read-only; the rest was left in the non-RELRO segment, which must be left read-write.