### PR TITLE
FW/IDXD: implement `dump_device_info`

### DIFF
--- a/framework/device/idxd/idxd_device.cpp
+++ b/framework/device/idxd/idxd_device.cpp
@@ -5,6 +5,13 @@
 
 #include "sandstone_p.h"
 #include "idxd_device.h"
+#include "idxd_features.h"
+#include "topology_idxd.hpp"
+
+#include <cstdint>
+#include <print>
+#include <string>
+#include <vector>
 
 std::string device_features_to_string(device_features_t f)
 {
@@ -14,6 +21,35 @@ std::string device_features_to_string(device_features_t f)
 
 void dump_device_info()
 {
+    std::print("#Dev\t#Ver\t#WQs\t#Engs\tPCI-addr\n");
+    for (const auto& device : Topology::topology().devices) {
+        uint32_t num_wqs = 0;
+        uint32_t num_eng = 0;
+        bdf_t bdf{};
+        const char* version = nullptr;
+        for (const auto& group : device.groups) {
+            auto size = group.wqs.size();
+            num_wqs += size;
+            num_eng += group.engines.size();
+            if (!version && size != 0) {
+                bdf = group.wqs.front().wq->bdf;
+
+                switch (group.wqs.front().wq->dev_version) {
+                case ACCFG_DEVICE_VERSION_1:
+                    version = "v1";
+                    break;
+                case ACCFG_DEVICE_VERSION_2:
+                    version = "v2";
+                    break;
+                }
+            }
+        }
+
+        std::print("{}\t{}\t{}\t{}\t", device.name, version, num_wqs, num_eng);
+        std::print("{:04x}:{:02x}:{:02x}.{:01x}\n",
+            bdf.domain, bdf.bus, (uint8_t)bdf.device, (uint8_t)bdf.function
+        );
+    }
 }
 
 TestResult prepare_test_for_device(struct test *test)


### PR DESCRIPTION
My idea was to dump only the invariants - for that we can present at the DSA/IAX device level, not WQ. 
Example:
```
#Dev    #Ver    #WQs    #Engs   PCI-addr
dsa0    v1      8       4       0000:e7:01.0
dsa1    v1      8       4       0000:e8:01.0
iax0    v2      8       8       0000:98:01.0
```