### PR TITLE
FW/IDXD: implement `thread_id_header_for_device`

### DIFF
--- a/framework/device/idxd/build_topology.cpp
+++ b/framework/device/idxd/build_topology.cpp
@@ -115,6 +115,7 @@ Topology build_topology(const AccfgCtx& ctx)
             it->numa_node = accfg_device_get_numa_node(device_handle);
             it->max_transfer_size = accfg_device_get_max_transfer_size(device_handle);
             it->max_batch_size = accfg_device_get_max_batch_size(device_handle);
+            it->max_groups = accfg_device_get_max_groups(device_handle);
             int op_cap_ret = accfg_device_get_op_cap(device_handle, &it->op_cap);
             assert(op_cap_ret == 0);
         }

--- a/framework/device/idxd/logging_idxd.cpp
+++ b/framework/device/idxd/logging_idxd.cpp
@@ -4,11 +4,77 @@
  */
 
 #include "logging.h"
+#include "idxd_device.h"
+#include "topology_idxd.hpp"
+
+#include <algorithm>
+#include <format>
+#include <string>
 
 #if !SANDSTONE_NO_LOGGING
+static std::string to_string(accfg_device_type device_type)
+{
+    switch (device_type) {
+    case ACCFG_DEVICE_DSA:
+        return "dsa";
+    case ACCFG_DEVICE_IAX:
+        return "iax";
+    default:
+        return {};
+    }
+}
+
+static auto calc_spacing()
+{
+    static const auto spacing = []() {
+        struct {
+            int device;
+            int wq;
+            int cpu;
+            uint32_t group;
+        } result = {};
+        const auto digit_count = [](auto value) {
+            int result = 0;
+            do { value /= 10; result++; } while (value != 0);
+            return result;
+        };
+        const auto max_value = [](auto member) {
+            return std::max_element(
+                device_info, device_info + thread_count(),
+                [member](const auto& first, const auto& second) { return first.*member < second.*member; }
+            )->*member;
+        };
+
+        result.device = digit_count(max_value(&wq_info_t::device_id));
+        result.wq = digit_count(max_value(&wq_info_t::wq_id));
+        result.cpu = digit_count(max_value(&wq_info_t::cpu_number));
+        const auto max_groups = std::max_element(
+            Topology::topology().devices.begin(), Topology::topology().devices.end(),
+            [](const auto& first, const auto& second) { return first.max_groups < second.max_groups; }
+        )->max_groups;
+        result.group = digit_count(max_groups - 1);
+
+        return result;
+    }();
+    return spacing;
+}
+
 std::string AbstractLogger::thread_id_header_for_device(int thread, LogLevelVerbosity verbosity)
 {
+    const wq_info_t* info = device_info + thread;
     std::string line;
+
+    const auto spacing = calc_spacing();
+    line = std::format("{{ device: {}{:{}}, wq: {:{}}, ",
+        to_string(info->dev_type), info->device_id, spacing.device, info->wq_id, spacing.wq);
+    const auto& path = info->path;
+    line += std::format("group: {:{}}, ", Topology::topology().devices[path.device].groups[path.group].id, spacing.group);
+    line += std::format("logical_cpu: {:{}}, ", info->cpu_number, spacing.cpu);
+    line += std::format("pci_address: {:04x}:{:02x}:{:02x}.{:01x}",
+        info->bdf.domain, info->bdf.bus, info->bdf.device, info->bdf.function
+    );
+    line += " }";
+
     return line;
 }
 

--- a/framework/device/idxd/topology_idxd.hpp
+++ b/framework/device/idxd/topology_idxd.hpp
@@ -132,6 +132,7 @@ public:
 
         uint32_t max_batch_size = 0;
         uint64_t max_transfer_size = 0;
+        uint32_t max_groups = 0;
 
         accfg_op_cap op_cap = {};
 


### PR DESCRIPTION
Example:
```
  - thread: 0
    id: { device: iax1, wq: 4, group: 123, logical_cpu: 12, pci_address: 0000:6c:01.0 }
```