### PR TITLE
FW: add --wrapper-{executable,script} command-line options

### DIFF
--- a/bats/sanity-check/22-wrapping.bats
+++ b/bats/sanity-check/22-wrapping.bats
@@ -153,3 +153,27 @@ EOF
     test_yaml_regexp "/exit" pass
     test_yaml_regexp "/tests/0/stderr messages" ".*WRAP_STDERR_MARKER.*"
 }
+
+@test "failing executable wrapper is reported" {
+    declare -A yamldump
+    wrapper_skip_unless_direct
+    local false_path=`type -P false`
+    if $is_windows && type -p cygpath > /dev/null; then
+        # get actual Windows file path
+        false_path=`cygpath -a -m "$false_path"`
+    fi
+
+    sandstone_selftest -e selftest_pass --wrapper-executable "$false_path" || :
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+}
+
+@test "failing script wrapper is reported" {
+    declare -A yamldump
+    wrapper_skip_unless_direct
+
+    # A wrapper that cannot be exec'd must make the run invalid, not pass.
+    sandstone_selftest -e selftest_pass --wrapper-script "false" || :
+    [[ "$status" -eq 1 ]]
+    test_yaml_regexp "/exit" fail
+}

--- a/bats/sanity-check/22-wrapping.bats
+++ b/bats/sanity-check/22-wrapping.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/bats
+# -*- mode: sh -*-
+# Copyright 2026 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+load ../testenv
+load helpers
+
+function setup_file() {
+    setup_sandstone
+}
+
+# The wrapper mechanism re-execs the child as program_invocation_name, which
+# does not include any qemu/wine launcher prefix. Only run wrappers that must
+# actually launch the tool when we are executing the binary directly.
+function wrapper_skip_unless_direct() {
+    if [[ "$SANDSTONE" != "$SANDSTONE_BIN" ]] &&
+       [[ "$SANDSTONE" != "$SANDSTONE_BIN "* ]]; then
+        skip "Not executing directly (executing '$SANDSTONE')"
+    fi
+}
+
+@test "--wrapper-executable requires an argument" {
+    run $SANDSTONE --wrapper-executable
+    [[ $status -eq 64 ]]
+    [[ "$output" == *"requires an argument"* ]]
+}
+
+@test "--wrapper-script requires an argument" {
+    run $SANDSTONE --wrapper-script
+    [[ $status -eq 64 ]]
+    [[ "$output" == *"requires an argument"* ]]
+}
+
+@test "--wrapper-executable + --wrapper-script are incompatible" {
+    run $SANDSTONE --selftests -e selftest_pass \
+        --wrapper-executable env --wrapper-script 'exec "$0" "$@"'
+    [[ $status -eq 64 ]]
+    [[ "$output" == *"--wrapper-script is incompatible with other executable wrapper options"* ]]
+}
+
+@test "--wrapper-script + --wrapper-executable are incompatible" {
+    run $SANDSTONE --selftests -e selftest_pass \
+        --wrapper-script 'exec "$0" "$@"' --wrapper-executable env
+    [[ $status -eq 64 ]]
+    [[ "$output" == *"is incompatible with other executable wrapper options"* ]]
+}
+
+@test "--wrapper-script no-op wrapper runs the test" {
+    declare -A yamldump
+    wrapper_skip_unless_direct
+
+    # A wrapper that just re-execs the tool must not change the result.
+    sandstone_selftest -e selftest_pass --wrapper-script 'exec "$0" "$@"'
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/result" pass
+}
+
+@test "--wrapper-executable no-op wrapper runs the test" {
+    declare -A yamldump
+    wrapper_skip_unless_direct
+
+    # env(1) execs its remaining arguments, i.e. the tool itself.
+    sandstone_selftest -e selftest_pass --wrapper-executable env
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/result" pass
+}
+
+@test "executable wrapper forces exec fork-mode" {
+    wrapper_skip_unless_direct
+
+    # A wrapper is incompatible with any non-exec fork mode; the tool warns and
+    # switches to -fexec instead of failing.
+    run $SANDSTONE --selftests -e selftest_pass --quick -f no --wrapper-executable env
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"--fork-mode=no is incompatible with executable wrappers; using -fexec"* ]]
+}
+
+@test "--wrapper-executable accumulates multiple arguments" {
+    declare -A yamldump
+    wrapper_skip_unless_direct
+
+    # Each --wrapper-executable appends one argument to the wrapper command
+    # line: `env FOO=bar <tool> ...`.
+    sandstone_selftest -e selftest_pass \
+        --wrapper-executable env --wrapper-executable FOO=bar
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/result" pass
+}
+
+@test "--wrapper-script is actually invoked" {
+    declare -A yamldump
+    wrapper_skip_unless_direct
+
+    local marker=$BATS_TEST_TMPDIR/wrapper-script-marker
+    rm -f "$marker"
+
+    # Use the --opt=value form with single quotes and spaces in the script: the
+    # whole argument must survive as one shell-recoverable token in the header.
+    sandstone_selftest -e selftest_pass \
+        "--wrapper-script=echo invoked > '$marker'; exec \"\$0\" \"\$@\""
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+
+    # The command-line header must quote the whole --wrapper-script argument
+    # (note the opening quote before "--wrapper-script") and escape the embedded
+    # single quotes around the marker path as '\'' so the line is recoverable.
+    test_yaml_regexp "/command-line" ".*'--wrapper-script=echo invoked > '\\\\''.*'\\\\''; exec.*"
+
+    # The wrapper must have run before exec'ing the tool.
+    [[ -f "$marker" ]]
+    [[ "$(cat "$marker")" == invoked ]]
+    rm -f "$marker"
+}
+
+@test "--wrapper-executable is actually invoked" {
+    declare -A yamldump
+    wrapper_skip_unless_direct
+    if $is_windows; then
+        skip "Shell scripts are not directly executable on Windows"
+    fi
+
+    local marker=$BATS_TEST_TMPDIR/wrapper-exec-marker
+    local wrapper=$BATS_TEST_TMPDIR/wrapper-exec.sh
+    rm -f "$marker"
+    cat > "$wrapper" <<EOF
+#!/bin/sh
+echo invoked > "$marker"
+exec "\$@"
+EOF
+    chmod +x "$wrapper"
+
+    sandstone_selftest -e selftest_pass --wrapper-executable "$wrapper"
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+
+    [[ -f "$marker" ]]
+    [[ "$(cat "$marker")" == invoked ]]
+    rm -f "$marker" "$wrapper"
+}
+
+@test "wrapper stderr is captured in stderr messages" {
+    declare -A yamldump
+    wrapper_skip_unless_direct
+
+    # Anything the wrapper writes to stderr before exec'ing the tool must be
+    # collected into the test's "stderr messages" field.
+    sandstone_selftest -e selftest_pass \
+        --wrapper-script 'echo WRAP_STDERR_MARKER >&2; exec "$0" "$@"'
+    [[ "$status" -eq 0 ]]
+    test_yaml_regexp "/exit" pass
+    test_yaml_regexp "/tests/0/stderr messages" ".*WRAP_STDERR_MARKER.*"
+}

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -944,18 +944,43 @@ void logging_print_header(int argc, char **argv, ShortDuration test_duration, Sh
     if (current_output_format() == SandstoneApplication::OutputFormat::no_output)
         return;                 // short-circuit
 
+    // Append one command-line argument, quoting it if necessary so that
+    // argument boundaries (and any embedded whitespace) survive in the printed
+    // command line and it can be pasted back into a shell. We only quote when
+    // needed to keep the common case free of noise.
+    auto append_arg = [](std::string &out, std::string_view arg) {
+        static constexpr std::string_view needs_quoting = " \t\n\r\v\f'";
+        if (!arg.empty() && arg.find_first_of(needs_quoting) == std::string_view::npos) {
+            out += arg;
+            return;
+        }
+
+        // Single-quote the argument, escaping embedded single quotes as '\''.
+        out += '\'';
+        for (char c : arg) {
+            if (c == '\'')
+                out += "'\\''";
+            else
+                out += c;
+        }
+        out += '\'';
+    };
+
     std::string cmdline;
     if (argc > 0) {
-        cmdline = argv[0];
+        std::string_view arg0 = argv[0];
 #ifdef _WIN32
-        size_t pos = cmdline.find_last_of('\\');
+        size_t pos = arg0.find_last_of('\\');
 #else
-        size_t pos = cmdline.find_last_of('/');
+        size_t pos = arg0.find_last_of('/');
 #endif
-        if (pos != std::string::npos)
-            cmdline = cmdline.substr(pos+1);
-        for (int i = 1; i < argc; i++)
-            cmdline += " " + std::string(argv[i]);
+        if (pos != std::string_view::npos)
+            arg0.remove_prefix(pos + 1);
+        append_arg(cmdline, arg0);
+        for (int i = 1; i < argc; i++) {
+            cmdline += ' ';
+            append_arg(cmdline, argv[i]);
+        }
     }
 
     switch (current_output_format()) {
@@ -2312,7 +2337,10 @@ void YamlLogger::maybe_print_virt_state() {
 void YamlLogger::print_header(std::string_view cmdline, Duration test_duration, Duration test_timeout)
 {
     using ::format_duration;
-    logging_printf(LOG_LEVEL_QUIET, "command-line: '%s'\n", cmdline.data());
+    std::string storage;
+    std::string_view escaped_cmdline = escape_for_single_line(cmdline, storage);
+    logging_printf(LOG_LEVEL_QUIET, "command-line: '%.*s'\n",
+                   int(escaped_cmdline.size()), escaped_cmdline.data());
     logging_printf(LOG_LEVEL_QUIET, "version: %s\n", program_version);
     logging_printf(LOG_LEVEL_VERBOSE(1), "os: %s\n", kernel_info().c_str());
     logging_printf(LOG_LEVEL_VERBOSE(1), "runtime: %s\n", libc_info().c_str());

--- a/framework/logging.cpp
+++ b/framework/logging.cpp
@@ -651,7 +651,7 @@ void logging_mark_thread_failed(int thread_num) noexcept
     // get_monotonic_time_now() because we'll compare to
     // sApp->current_test_starttime.
     thr->fail_time = std::chrono::steady_clock::now();
-    thr->failing_cpu = LogicalProcessor(sched_getcpu());
+    thr->failing_cpu_plus_1 = sched_getcpu() + 1;
     if (thread_num >= 0) {
         auto tthr = static_cast<PerThreadData::Test *>(thr);
         tthr->inner_loop_count_at_fail = tthr->inner_loop_count;
@@ -1753,7 +1753,7 @@ inline AbstractLogger::AbstractLogger(const struct test *test, std::span<const C
             bool had_failed = data->has_failed();
             log_message(thread, SANDSTONE_LOG_ERROR "Thread is stuck");
             if (!had_failed)
-                data->failing_cpu = LogicalProcessor(device_info[device].cpu_number);
+                data->failing_cpu_plus_1 = device_info[device].cpu_number + 1;
         }, slices.size());
         return;
 
@@ -1957,8 +1957,9 @@ void YamlLogger::print_thread_header(int fd, PerThreadData::Common *data, int th
                 thread_id_header_for_device(device, verbosity).c_str());
     }
     if (has_failed) {
+        LogicalProcessor lp = LogicalProcessor(thr->failing_cpu_plus_1 - 1);
         dprintf(fd, "%s    %s: %s\n", indent_spaces().data(), failing_cpu_label,
-                format_logical_processor(thr->failing_cpu).c_str());
+                format_logical_processor(lp).c_str());
         if (int(thr->previous_cpu) >= 0)
             dprintf(fd, "%s    previous-cpu: %s\n", indent_spaces().data(),
                     format_logical_processor(thr->previous_cpu).c_str());

--- a/framework/sandstone.cpp
+++ b/framework/sandstone.cpp
@@ -590,7 +590,7 @@ static int exec_mode_run(int argc, char **argv)
         char *end;
         long n = strtol(arg, &end, 10);
         if (__builtin_expect(int(n) != n || n < 0 || *end, false)) {
-#if defined(_WIN32) && !defined(NDEBUG)
+#if defined(_WIN32)
            if (*arg == 'h') {
                // a handle
                n = _open_osfhandle(strtoll(arg + 1, &end, 16), O_RDWR);

--- a/framework/sandstone_opts.cpp
+++ b/framework/sandstone_opts.cpp
@@ -14,6 +14,9 @@
 #include <vector>
 
 #include <getopt.h>
+#if __has_include(<paths.h>)
+#  include <paths.h>
+#endif
 
 #ifdef SANDSTONE_UNITTESTS
 extern FILE* test_stream;
@@ -22,6 +25,10 @@ extern FILE* test_stream;
 #else
 #define OUT_STREAM stdout
 #define ERR_STREAM stderr
+#endif
+
+#ifndef _PATH_BSHELL
+#define _PATH_BSHELL    "sh"
 #endif
 
 using namespace std::chrono;
@@ -102,6 +109,8 @@ enum {
     vary_uncore_frequency,
 #endif
     version_option,
+    wrapper_exec_option,
+    wrapper_script_option,
     weighted_testrun_option,
     thread_ratio_option,
     alpha_option,
@@ -203,6 +212,8 @@ static struct option long_options[]  = {
 #endif
     { "verbose", no_argument, nullptr, 'v' },
     { "version", no_argument, nullptr, version_option },
+    { "wrapper-executable", required_argument, nullptr, wrapper_exec_option },
+    { "wrapper-script", required_argument, nullptr, wrapper_script_option },
     { "weighted-testrun-type", required_argument, nullptr, weighted_testrun_option },
     { "yaml", optional_argument, nullptr, 'Y' },
 
@@ -479,6 +490,7 @@ struct ProgramOptionsParser {
 #if SANDSTONE_ULOG
             case ulog_option:
 #endif
+            case wrapper_exec_option:
                 add_to_map_as_vec(opt, optarg);
                 break;
 
@@ -527,6 +539,7 @@ struct ProgramOptionsParser {
             case max_messages_option:
             case reschedule_option:
             case thread_ratio_option:
+            case wrapper_script_option:
                 opts_map.insert_or_assign(opt, optarg);
                 break;
 
@@ -926,6 +939,24 @@ struct ProgramOptionsParser {
             app_cfg->max_test_loop_count = 1;
         }
 #endif
+        if (auto it = opts_map.find(wrapper_exec_option); it != opts_map.end()) {
+            if (app_cfg->exec_wrapper.size()) {
+                fprintf(ERR_STREAM, "%s: --wrapper-executable is incompatible with other "
+                                    "executable wrapper options\n", argv[0]);
+                return EX_USAGE;
+            }
+            const auto args = std::get<std::vector<const char *>>(it->second);
+            app_cfg->exec_wrapper.reserve(args.size());
+            std::copy(args.begin(), args.end(), std::back_inserter(app_cfg->exec_wrapper));
+        }
+        if (const char *script = string_opt_for(wrapper_script_option)) {
+            if (app_cfg->exec_wrapper.size()) {
+                fprintf(ERR_STREAM, "%s: --wrapper-script is incompatible with other executable "
+                                    "wrapper options\n", argv[0]);
+                return EX_USAGE;
+            }
+            app_cfg->exec_wrapper = { _PATH_BSHELL, "-c", script };
+        }
 
         // assign 1:1
         opts.seed = string_opt_for('s');

--- a/framework/sandstone_run.cpp
+++ b/framework/sandstone_run.cpp
@@ -1333,6 +1333,44 @@ static StartedChild call_forkfd()
     return { .pid = pid, .fd = ffd };
 }
 
+#ifdef _WIN32
+// The MSVCRT/UCRT _spawn* family builds the child's command line by
+// concatenating argv[] separated by single spaces, without any quoting. Any
+// argument that is empty or contains whitespace, a double quote or a backslash
+// would therefore be split or mangled before the child (or a wrapper shell)
+// re-parses it. Apply the canonical Windows command-line quoting so the
+// argument round-trips through both CommandLineToArgvW and Cygwin/MSYS sh.
+static std::string windows_quote_arg(std::string_view arg)
+{
+    if (!arg.empty() && arg.find_first_of(" \t\n\v\"") == std::string_view::npos)
+        return std::string(arg);
+
+    std::string result = "\"";
+    for (auto it = arg.begin(); ; ++it) {
+        unsigned backslashes = 0;
+        while (it != arg.end() && *it == '\\') {
+            ++it;
+            ++backslashes;
+        }
+        if (it == arg.end()) {
+            // escape trailing backslashes so they don't escape the closing quote
+            result.append(backslashes * 2, '\\');
+            break;
+        } else if (*it == '"') {
+            // escape all preceding backslashes and the double quote itself
+            result.append(backslashes * 2 + 1, '\\');
+            result.push_back('"');
+        } else {
+            // backslashes not followed by a quote are literal
+            result.append(backslashes, '\\');
+            result.push_back(*it);
+        }
+    }
+    result.push_back('"');
+    return result;
+}
+#endif // _WIN32
+
 static StartedChild spawn_child(const char *test_id, int child_number,
                                 const std::vector<const char *> &common_args)
 {
@@ -1375,14 +1413,30 @@ static StartedChild spawn_child(const char *test_id, int child_number,
     }
 
 #ifdef _WIN32
+    // Quote each argument for the child command line (see windows_quote_arg).
+    // The cmdname argument passed separately to _spawnv* is used only to locate
+    // the executable and must stay unquoted.
+    std::vector<std::string> quoted;
+    std::vector<const char *> qargv;
+    quoted.reserve(argv.size());
+    qargv.reserve(argv.size());
+    for (const char *arg : argv) {
+        if (!arg) {
+            qargv.push_back(nullptr);
+            continue;
+        }
+        quoted.push_back(windows_quote_arg(arg));
+        qargv.push_back(quoted.back().c_str());
+    }
+
     // save stderr
     static int saved_stderr = _dup(STDERR_FILENO);
     logging_init_child_preexec();
 
     if (sApp->exec_wrapper.size()) {
-        ret.pid = _spawnvp(_P_NOWAIT, argv[0], const_cast<char **>(argv.data()));
+        ret.pid = _spawnvp(_P_NOWAIT, argv[0], const_cast<char **>(qargv.data()));
     } else {
-        ret.pid = _spawnv(_P_NOWAIT, path_to_exe(), const_cast<char **>(argv.data()));
+        ret.pid = _spawnv(_P_NOWAIT, path_to_exe(), const_cast<char **>(qargv.data()));
     }
 
     int saved_errno = errno;

--- a/framework/test_data.h
+++ b/framework/test_data.h
@@ -64,11 +64,11 @@ struct Common
         return flags & unsigned(f2);
     }
 
-    LogicalProcessor failing_cpu;
+    int failing_cpu_plus_1;
     MonotonicTimePoint fail_time;
     bool has_failed() const
     {
-        //assert((fail_time > MonotonicTimePoint{}) == (int(failing_cpu) >= 0));
+        assert((fail_time > MonotonicTimePoint{}) == (failing_cpu_plus_1 > 0));
         return fail_time > MonotonicTimePoint{};
     }
     bool has_skipped() const
@@ -81,7 +81,7 @@ struct Common
         thread_state.store(thread_not_started, std::memory_order_relaxed);
         messages_logged.store(0, std::memory_order_relaxed);
         data_bytes_logged.store(0, std::memory_order_relaxed);
-        failing_cpu = LogicalProcessor::None;
+        failing_cpu_plus_1 = int(LogicalProcessor::None) + 1;   // == 0
         fail_time = MonotonicTimePoint{};
         thread_flags = {};
     }


### PR DESCRIPTION
Add two options that let the user interpose a wrapper program between OpenDCDiag and the child process it exec()s for each test. Both imply -fexec fork mode, and both are mutually exclusive with each other and with the existing wrappers (--gdb-server, --sde-trace, both of which could be replaced with this new option).

```
  --wrapper-executable ARG
        Prepend ARG to the child's argv. Repeat the option to add more
        arguments; the child is then exec'd as:
            ARG1 ARG2 ... <opendcdiag> ...
        No shell is involved, so arguments are passed verbatim.

  --wrapper-script SCRIPT
        Run SCRIPT through the shell as `sh -c SCRIPT <opendcdiag> ...`,
        i.e. inside the script $0 is the OpenDCDiag binary and "$@" are its
        arguments. This is the convenient form when a bit of shell (quoting,
        redirection, chaining) is needed.
```
A useful application is running each test child under Linux's perf tool.

```bash
    opendcdiag -e zlib --max-test-loop-count=0 --wrapper-script 'exec perf stat "$0" "$@"'
```

produces, for the "zlib" test:

```yaml
    stderr messages: |
       Performance counter stats for 'opendcdiag -x 0 3 zlib LCG:1917468910':

                       0      context-switches:u
                  47,137      page-faults:u
                2,499.43 msec task-clock:u              #    6.0 CPUs utilized
              61,514,561      branch-misses:u           #    4.6 % of branches
           1,349,715,159      branches:u
           8,411,360,443      cpu-cycles:u              #    3.4 GHz
          10,728,688,839      instructions:u            #    1.3 insn per cycle

             0.409002077 seconds time elapsed
```

This also includes fixes for quoting command-line arguments in our YAML output and in calling `_spawnp` on Windows, and a fix for the assertion that PR #1197 had to disable.