### PR TITLE
FW/IDXD: include `core_id` in `wq_info_t`

### DIFF
--- a/framework/device/idxd/idxd_device.h
+++ b/framework/device/idxd/idxd_device.h
@@ -34,6 +34,9 @@ struct wq_info_t
     /// Package ID in the system.
     int16_t package_id;
 
+    /// Core ID within the package.
+    int16_t core_id;
+
     /// PCI location.
     struct bdf_t bdf;
 

--- a/framework/device/idxd/topology.cpp
+++ b/framework/device/idxd/topology.cpp
@@ -565,6 +565,29 @@ int16_t detect_package_id_via_os(int cpu)
     return res;
 }
 
+int16_t detect_core_id_via_os(int cpu)
+{
+    int16_t res = -1;
+    if (cpu < 0) { [[unlikely]]
+        return res;
+    }
+    auto file = std::format("/sys/devices/system/cpu/cpu{}/topology/core_id", cpu);
+
+    FILE* fp = fopen(file.c_str(), "r");
+    if (!fp) { [[unlikely]]
+        fprintf(stderr, "%s: internal error: unable to find core_id file: %m\n",
+                program_invocation_name);
+        return res;
+    }
+    int val;
+    if (std::fscanf(fp, "%d", &val) == 1) {
+        res = static_cast<int16_t>(val);
+    }
+    fclose(fp);
+
+    return res;
+}
+
 bdf_t detect_bdf_via_os(accfg_device *device)
 {
     bdf_t bdf = {};
@@ -629,6 +652,7 @@ void setup_devices<WorkQueueSet>(const WorkQueueSet& enabled_devices)
     for (const auto &enabled : enabled_devices.visible_wqs) {
         info->cpu_number = enabled_cpus[cpu_ind++];
         info->package_id = detect_package_id_via_os(info->cpu_number);
+        info->core_id = detect_core_id_via_os(info->cpu_number);
 
         auto it = bdf_cache.find(enabled.device_id);
         if (it == bdf_cache.end()) {


### PR DESCRIPTION
For legacy reasons. May be deleted in future.