### PR TITLE
FW/GPU: use `device_count` in `build_topology`

### DIFF
--- a/framework/device/gpu/build_topology.cpp
+++ b/framework/device/gpu/build_topology.cpp
@@ -25,7 +25,7 @@ Topology build_topology()
 {
     Topology topo;
     gpu_info_t* info = device_info;
-    const gpu_info_t* cend = device_info + thread_count();
+    const gpu_info_t* cend = device_info + device_count();
     auto root_first = info;
     while (info != cend) {
         if (info->subdevice_index == -1) {


### PR DESCRIPTION
`thread_count` is not even set yet at that point. This caused empty output from `--dump-device-info`.